### PR TITLE
Fix purchase order pricing to use base cost (fixes #13)

### DIFF
--- a/frontend/src/components/editors/POEditor.tsx
+++ b/frontend/src/components/editors/POEditor.tsx
@@ -314,7 +314,7 @@ export function POEditor({ poId, onUpdate }: POEditorProps) {
                   options={parts.map((part): SearchableSelectOption => ({
                     value: part.id.toString(),
                     label: `${part.part_number} - ${part.description}`,
-                    description: `$${(part.cost * (1 + (part.markup_percent ?? 0) / 100)).toFixed(2)}`,
+                    description: `$${(part.cost ?? 0).toFixed(2)}`,
                   }))}
                   value={selectedPartId}
                   onChange={setSelectedPartId}


### PR DESCRIPTION
## Summary
- Fixed purchase order pricing to correctly use base part cost instead of marked-up selling price
- Purchase orders represent procurement from vendors, so they should reflect what the business pays, not what customers pay

## Changes
- Modified `POEditor.tsx` to remove markup calculation when adding parts to POs
- Changed from: `part.cost * (1 + markup_percent / 100)` to: `part.cost`

## Test Plan
- [ ] Create/open a purchase order
- [ ] Add a part with markup (e.g., cost=$100, markup=20%)
- [ ] Verify PO line shows $100 (not $120)
- [ ] Test with multiple parts with varying markup percentages
- [ ] Verify miscellaneous items still work (manual price entry)

Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected part line item pricing: unit price now uses the part's direct cost (no markup applied), so totals reflect quantity × cost accurately.
* **UI**
  * Updated part selection dropdown text to display the raw part cost (no markup calculation shown).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->