### PR TITLE
Fix PO receiving 422 error

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -18,6 +18,7 @@ import type {
 // API base URL - configurable via environment variable for production
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
 
+/** Fetch wrapper that handles JSON serialization and extracts error details from FastAPI responses. */
 async function request<T>(
   endpoint: string,
   options: RequestInit = {}

--- a/frontend/src/components/editors/POEditor.tsx
+++ b/frontend/src/components/editors/POEditor.tsx
@@ -631,6 +631,7 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
     setStagedReceivings(newMap)
   }
 
+  /** Submit staged receiving quantities and actual prices to the backend. */
   const handleSubmitReceiving = async () => {
     if (!po) return
 


### PR DESCRIPTION
## Summary
- **Fix 422 on receiving submit**: The frontend sent a date-only string (`"2026-02-08"`) for `received_date`, which Pydantic v2 rejects for `datetime` fields. Now appends `T00:00:00` so the backend accepts it.
- **Fix `[object Object]` error display**: The API client assumed `error.detail` is always a string, but FastAPI 422 validation errors return an array of objects. Now extracts `.msg` from each entry for a readable message.

## Test plan
- [ ] Open a PO with "Sent" status, click "Receive Items", set quantities, and confirm receipt succeeds
- [ ] Verify receiving history appears in the audit trail after submission
- [ ] Trigger a validation error (e.g. receive more than pending qty) and confirm the error message is human-readable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error handling to surface clearer, consolidated messages when requests fail, making error feedback more actionable for users.
  * Fixed purchase order receiving submissions to include a full timestamp (date plus time) so submitted receipts carry complete datetime information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->