### PR TITLE
Add Backlog Quotes Report with Excel export

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -11,7 +11,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from database import engine, Base, SessionLocal
-from routes import parts, labor, profiles, projects, quotes, purchase_orders, discount_codes, miscellaneous, invoices, company_settings
+from routes import parts, labor, profiles, projects, quotes, purchase_orders, discount_codes, miscellaneous, invoices, company_settings, reports
 from seed import seed_system_items
 
 
@@ -110,6 +110,7 @@ app.include_router(discount_codes.router)
 app.include_router(miscellaneous.router)
 app.include_router(invoices.router)
 app.include_router(company_settings.router)
+app.include_router(reports.router)
 
 
 @app.get("/")

--- a/backend/routes/reports.py
+++ b/backend/routes/reports.py
@@ -1,0 +1,118 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session, joinedload
+from typing import List
+
+from database import get_db
+from models import Quote, QuoteLineItem, Project, Profile
+from schemas import BacklogQuoteItem, BacklogLineItem
+from routes.quotes import compute_quote_status, format_quote_number, get_line_item_description
+
+router = APIRouter(prefix="/reports", tags=["reports"])
+
+
+def _line_item_unit_price(item: QuoteLineItem) -> float:
+    """Resolve effective unit price from the line item or its linked inventory record."""
+    if item.unit_price is not None:
+        return item.unit_price
+    if item.labor:
+        return item.labor.hours * item.labor.rate * (1 + item.labor.markup_percent / 100)
+    if item.part:
+        return item.part.cost * (1 + (item.part.markup_percent or 0) / 100)
+    if item.miscellaneous:
+        return item.miscellaneous.unit_price * (1 + item.miscellaneous.markup_percent / 100)
+    return 0.0
+
+
+def _line_item_total(item: QuoteLineItem) -> float:
+    """Unit price * quantity, after discount."""
+    subtotal = _line_item_unit_price(item) * item.quantity
+    if item.discount_code:
+        return subtotal * (1 - item.discount_code.discount_percent / 100)
+    return subtotal
+
+
+def _line_item_backlog_value(item: QuoteLineItem) -> float:
+    """Backlog = unit price * qty_pending, after discount."""
+    unit = _line_item_unit_price(item)
+    subtotal = unit * item.qty_pending
+    if item.discount_code:
+        return subtotal * (1 - item.discount_code.discount_percent / 100)
+    return subtotal
+
+
+@router.get("/backlog-quotes", response_model=List[BacklogQuoteItem])
+def get_backlog_quotes(db: Session = Depends(get_db)):
+    """Return all quotes with uninvoiced line items (Work Order or Invoiced status)."""
+    quotes = (
+        db.query(Quote)
+        .options(
+            joinedload(Quote.project).joinedload(Project.customer),
+            joinedload(Quote.line_items).joinedload(QuoteLineItem.labor),
+            joinedload(Quote.line_items).joinedload(QuoteLineItem.part),
+            joinedload(Quote.line_items).joinedload(QuoteLineItem.miscellaneous),
+            joinedload(Quote.line_items).joinedload(QuoteLineItem.discount_code),
+        )
+        .all()
+    )
+
+    result: List[BacklogQuoteItem] = []
+
+    for quote in quotes:
+        status = compute_quote_status(quote)
+        if status not in ("Work Order", "Invoiced"):
+            continue
+
+        # Only include line items with remaining qty
+        pending_items = [li for li in quote.line_items if li.qty_pending > 0]
+        if not pending_items:
+            continue
+
+        project = quote.project
+        customer_name = project.customer.name if project.customer else "Unknown"
+
+        # Build backlog line items
+        backlog_lines: List[BacklogLineItem] = []
+        backlog_total = 0.0
+        for li in pending_items:
+            discount_pct = li.discount_code.discount_percent if li.discount_code else 0.0
+            unit = _line_item_unit_price(li)
+            value = _line_item_backlog_value(li)
+            backlog_total += value
+
+            backlog_lines.append(BacklogLineItem(
+                line_item_id=li.id,
+                item_type=li.item_type,
+                description=get_line_item_description(li, db),
+                quantity=li.quantity,
+                qty_fulfilled=li.qty_fulfilled,
+                qty_pending=li.qty_pending,
+                unit_price=round(unit, 2),
+                discount_percent=discount_pct,
+                backlog_value=round(value, 2),
+            ))
+
+        # Calculate full quote total
+        quote_total = sum(_line_item_total(li) for li in quote.line_items)
+
+        quote_number = format_quote_number(
+            project.uca_project_number,
+            quote.quote_sequence,
+            quote.current_version,
+        )
+
+        result.append(BacklogQuoteItem(
+            quote_id=quote.id,
+            quote_number=quote_number,
+            uca_project_number=project.uca_project_number,
+            customer_name=customer_name,
+            project_name=project.name,
+            client_po_number=quote.client_po_number,
+            status=status,
+            quote_total=round(quote_total, 2),
+            backlog_total=round(backlog_total, 2),
+            line_items=backlog_lines,
+        ))
+
+    # Sort by quote number for consistent output
+    result.sort(key=lambda q: q.quote_number)
+    return result

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -49,6 +49,32 @@ class InvoiceSummaryItem(BaseModel):
     grand_total: float
 
 
+# ===== Backlog Quotes Report =====
+class BacklogLineItem(BaseModel):
+    line_item_id: int
+    item_type: str
+    description: str
+    quantity: int
+    qty_fulfilled: int
+    qty_pending: int
+    unit_price: float
+    discount_percent: float = 0.0
+    backlog_value: float
+
+
+class BacklogQuoteItem(BaseModel):
+    quote_id: int
+    quote_number: str
+    uca_project_number: str
+    customer_name: str
+    project_name: str
+    client_po_number: Optional[str] = None
+    status: str
+    quote_total: float
+    backlog_total: float
+    line_items: List[BacklogLineItem] = []
+
+
 class PhoneType(str, Enum):
     work = "work"
     mobile = "mobile"

--- a/backend/tests/test_backlog_report.py
+++ b/backend/tests/test_backlog_report.py
@@ -1,0 +1,34 @@
+"""Tests for the backlog quotes report endpoint."""
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+def test_backlog_report_returns_200():
+    """GET /reports/backlog-quotes should return 200 with a list."""
+    r = client.get("/reports/backlog-quotes")
+    assert r.status_code == 200
+    data = r.json()
+    assert isinstance(data, list)
+
+
+def test_backlog_report_excludes_draft_and_closed():
+    """Every returned quote must be Work Order or Invoiced."""
+    r = client.get("/reports/backlog-quotes")
+    assert r.status_code == 200
+    for item in r.json():
+        assert item["status"] in ("Work Order", "Invoiced"), (
+            f"Unexpected status {item['status']} for quote {item['quote_number']}"
+        )
+
+
+def test_backlog_report_items_have_pending():
+    """Every returned line item must have qty_pending > 0."""
+    r = client.get("/reports/backlog-quotes")
+    assert r.status_code == 200
+    for quote in r.json():
+        for li in quote["line_items"]:
+            assert li["qty_pending"] > 0, (
+                f"Line item {li['line_item_id']} in {quote['quote_number']} has qty_pending=0"
+            )

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,7 +31,8 @@
         "react-dom": "^19.2.0",
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -3799,6 +3800,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -4069,6 +4079,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -4142,6 +4165,15 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4184,6 +4216,18 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4771,6 +4815,15 @@
         "tiny-inflate": "^1.0.3",
         "unicode-properties": "^1.4.0",
         "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fraction.js": {
@@ -6169,6 +6222,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -6836,6 +6901,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -6844,6 +6927,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xml-name-validator": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,8 @@
     "react-dom": "^19.2.0",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -13,7 +13,8 @@ import type {
   Invoice, InvoiceCreate, InvoiceStatusUpdate, QuoteSnapshot, RevertPreview,
   MarkupControlToggleRequest, MarkupControlToggleResponse,
   CommitEditsRequest, CommitEditsResponse,
-  CompanySettings, CompanySettingsUpdate, InvoiceSummaryItem
+  CompanySettings, CompanySettingsUpdate, InvoiceSummaryItem,
+  BacklogQuoteItem
 } from '@/types';
 
 // API base URL - configurable via environment variable for production
@@ -260,5 +261,10 @@ export const api = {
     // Clone
     clone: (poId: number) =>
       request<PurchaseOrder>(`/purchase-orders/${poId}/clone`, { method: 'POST' }),
+  },
+
+  // ===== Reports =====
+  reports: {
+    getBacklogQuotes: () => request<BacklogQuoteItem[]>('/reports/backlog-quotes'),
   },
 };

--- a/frontend/src/lib/excel.ts
+++ b/frontend/src/lib/excel.ts
@@ -1,0 +1,131 @@
+import * as XLSX from 'xlsx'
+import type { BacklogQuoteItem } from '@/types'
+
+/**
+ * Generate and download a Backlog Quotes Excel report.
+ *
+ * Layout:
+ *   - Quote header rows (bold) with summary columns
+ *   - Item detail rows grouped under each quote (outline level 1)
+ *   - Grand total row at the bottom
+ */
+export function generateBacklogExcel(data: BacklogQuoteItem[]): void {
+  const wb = XLSX.utils.book_new()
+
+  // Build row data — each row is an array of cell values
+  const rows: (string | number)[][] = []
+
+  // Header row
+  const headerRow = [
+    'Quote #', 'UCA Project #', 'Customer', 'Project', 'Client PO',
+    'Status', 'Item Type', 'Description', 'Qty Ordered', 'Qty Fulfilled',
+    'Qty Pending', 'Unit Price', 'Discount %', 'Backlog Value',
+  ]
+  rows.push(headerRow)
+
+  // Track which data rows are detail rows (for grouping)
+  // Row index 0 = header, data rows start at index 1
+  const detailRowIndices: number[] = []
+
+  let grandTotal = 0
+
+  for (const quote of data) {
+    // Quote summary row
+    rows.push([
+      quote.quote_number,
+      quote.uca_project_number,
+      quote.customer_name,
+      quote.project_name,
+      quote.client_po_number || '',
+      quote.status,
+      '', // item_type (blank for summary)
+      '', // description
+      '', // qty ordered
+      '', // qty fulfilled
+      '', // qty pending
+      '', // unit price
+      '', // discount
+      quote.backlog_total,
+    ])
+
+    // Item detail rows
+    for (const li of quote.line_items) {
+      const rowIdx = rows.length // 0-based index of the row we're about to push
+      detailRowIndices.push(rowIdx)
+
+      rows.push([
+        '', // quote #
+        '', // uca project
+        '', // customer
+        '', // project
+        '', // client PO
+        '', // status
+        li.item_type,
+        li.description,
+        li.quantity,
+        li.qty_fulfilled,
+        li.qty_pending,
+        li.unit_price,
+        li.discount_percent,
+        li.backlog_value,
+      ])
+    }
+
+    grandTotal += quote.backlog_total
+  }
+
+  // Grand total row
+  rows.push([
+    '', '', '', '', '', '', '', '', '', '', '', '', 'Grand Total',
+    grandTotal,
+  ])
+
+  // Create worksheet from array of arrays
+  const ws = XLSX.utils.aoa_to_sheet(rows)
+
+  // Set column widths
+  ws['!cols'] = [
+    { wch: 18 }, // Quote #
+    { wch: 14 }, // UCA Project #
+    { wch: 22 }, // Customer
+    { wch: 22 }, // Project
+    { wch: 14 }, // Client PO
+    { wch: 12 }, // Status
+    { wch: 10 }, // Item Type
+    { wch: 30 }, // Description
+    { wch: 11 }, // Qty Ordered
+    { wch: 12 }, // Qty Fulfilled
+    { wch: 11 }, // Qty Pending
+    { wch: 12 }, // Unit Price
+    { wch: 11 }, // Discount %
+    { wch: 14 }, // Backlog Value
+  ]
+
+  // Apply row outline/grouping for detail rows
+  if (!ws['!rows']) ws['!rows'] = []
+  for (const idx of detailRowIndices) {
+    // Ensure array is long enough
+    while (ws['!rows'].length <= idx) {
+      ws['!rows'].push({})
+    }
+    ws['!rows'][idx] = { level: 1 }
+  }
+
+  // Format currency columns (Unit Price and Backlog Value) as number with 2 decimals
+  const numFmt = '#,##0.00'
+  const currencyCols = [11, 13] // 0-indexed: Unit Price (K), Backlog Value (N)
+  for (let r = 1; r < rows.length; r++) {
+    for (const c of currencyCols) {
+      const cellRef = XLSX.utils.encode_cell({ r, c })
+      if (ws[cellRef] && typeof ws[cellRef].v === 'number') {
+        ws[cellRef].z = numFmt
+      }
+    }
+  }
+
+  XLSX.utils.book_append_sheet(wb, ws, 'Backlog Quotes')
+
+  // Generate filename with today's date
+  const today = new Date().toISOString().slice(0, 10)
+  XLSX.writeFile(wb, `Backlog_Quotes_Report_${today}.xlsx`)
+}

--- a/frontend/src/pages/ReportsPage.tsx
+++ b/frontend/src/pages/ReportsPage.tsx
@@ -2,13 +2,17 @@ import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
 import { api } from '@/api/client'
 import { pdf } from '@react-pdf/renderer'
 import { InvoiceSummaryPDF } from '@/components/pdf/InvoiceSummaryPDF'
-import type { InvoiceSummaryItem, CompanySettings } from '@/types'
-import { FileText, Download, Loader2 } from 'lucide-react'
+import { generateBacklogExcel } from '@/lib/excel'
+import { formatCurrency } from '@/lib/pricing'
+import type { InvoiceSummaryItem, CompanySettings, BacklogQuoteItem } from '@/types'
+import { FileText, Download, Loader2, ChevronRight, ChevronDown, FileSpreadsheet } from 'lucide-react'
 
 export function ReportsPage() {
+  // Invoice Summary state
   const [startDate, setStartDate] = useState('')
   const [endDate, setEndDate] = useState('')
   const [loading, setLoading] = useState(false)
@@ -16,6 +20,13 @@ export function ReportsPage() {
   const [invoices, setInvoices] = useState<InvoiceSummaryItem[] | null>(null)
   const [companySettings, setCompanySettings] = useState<CompanySettings | null>(null)
 
+  // Backlog Quotes state
+  const [backlogLoading, setBacklogLoading] = useState(false)
+  const [backlogError, setBacklogError] = useState<string | null>(null)
+  const [backlogData, setBacklogData] = useState<BacklogQuoteItem[] | null>(null)
+  const [expandedQuotes, setExpandedQuotes] = useState<Set<number>>(new Set())
+
+  // ===== Invoice Summary handlers =====
   const handleGenerate = async () => {
     if (!startDate || !endDate) {
       setError('Please select both start and end dates.')
@@ -86,6 +97,46 @@ export function ReportsPage() {
     } finally {
       setLoading(false)
     }
+  }
+
+  // ===== Backlog Quotes handlers =====
+  const handleBacklogGenerate = async () => {
+    setBacklogLoading(true)
+    setBacklogError(null)
+    setBacklogData(null)
+    setExpandedQuotes(new Set())
+
+    try {
+      const data = await api.reports.getBacklogQuotes()
+      setBacklogData(data)
+    } catch (err) {
+      setBacklogError(err instanceof Error ? err.message : 'Failed to fetch backlog data')
+    } finally {
+      setBacklogLoading(false)
+    }
+  }
+
+  const handleBacklogDownload = () => {
+    if (!backlogData) return
+    generateBacklogExcel(backlogData)
+  }
+
+  const toggleQuoteExpanded = (quoteId: number) => {
+    setExpandedQuotes(prev => {
+      const next = new Set(prev)
+      if (next.has(quoteId)) {
+        next.delete(quoteId)
+      } else {
+        next.add(quoteId)
+      }
+      return next
+    })
+  }
+
+  const statusVariant = (status: string) => {
+    if (status === 'Work Order') return 'default' as const
+    if (status === 'Invoiced') return 'secondary' as const
+    return 'outline' as const
   }
 
   return (
@@ -212,6 +263,136 @@ export function ReportsPage() {
           )}
         </div>
       </div>
+
+      {/* Backlog Quotes Report */}
+      <div className="bg-card rounded-lg border shadow-sm">
+        <div className="p-4 border-b">
+          <h2 className="text-lg font-semibold flex items-center gap-2">
+            <FileSpreadsheet className="h-5 w-5" />
+            Backlog Quotes Report
+          </h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            Quotes with uninvoiced line items (Work Order and partially Invoiced). Point-in-time snapshot.
+          </p>
+        </div>
+
+        <div className="p-4 space-y-4">
+          <Button onClick={handleBacklogGenerate} disabled={backlogLoading}>
+            {backlogLoading ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
+            Generate
+          </Button>
+
+          {backlogError && (
+            <div className="p-3 bg-destructive/10 border border-destructive/20 rounded-md text-destructive text-sm">
+              {backlogError}
+            </div>
+          )}
+
+          {backlogData !== null && (
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-muted-foreground">
+                  Found <span className="font-medium text-foreground">{backlogData.length}</span> quote{backlogData.length !== 1 ? 's' : ''} with uninvoiced items.
+                </p>
+                <Button size="sm" onClick={handleBacklogDownload} disabled={backlogData.length === 0}>
+                  <Download className="h-4 w-4 mr-2" />
+                  Download Excel
+                </Button>
+              </div>
+
+              {backlogData.length > 0 && (
+                <div className="border rounded-md overflow-hidden">
+                  <table className="w-full text-sm">
+                    <thead className="bg-muted/50">
+                      <tr>
+                        <th className="w-8 px-2 py-2" />
+                        <th className="px-3 py-2 text-left font-medium text-muted-foreground">Quote #</th>
+                        <th className="px-3 py-2 text-left font-medium text-muted-foreground">UCA Project #</th>
+                        <th className="px-3 py-2 text-left font-medium text-muted-foreground">Customer / Project</th>
+                        <th className="px-3 py-2 text-left font-medium text-muted-foreground">Client PO</th>
+                        <th className="px-3 py-2 text-left font-medium text-muted-foreground">Status</th>
+                        <th className="px-3 py-2 text-right font-medium text-muted-foreground">Backlog Value</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y">
+                      {backlogData.map((q) => {
+                        const isExpanded = expandedQuotes.has(q.quote_id)
+                        return (
+                          <BacklogQuoteRow
+                            key={q.quote_id}
+                            quote={q}
+                            isExpanded={isExpanded}
+                            onToggle={() => toggleQuoteExpanded(q.quote_id)}
+                            statusVariant={statusVariant}
+                          />
+                        )
+                      })}
+                    </tbody>
+                    <tfoot className="bg-muted/50 font-medium">
+                      <tr>
+                        <td colSpan={6} className="px-3 py-2">Grand Total</td>
+                        <td className="px-3 py-2 text-right">
+                          {formatCurrency(backlogData.reduce((s, q) => s + q.backlog_total, 0))}
+                        </td>
+                      </tr>
+                    </tfoot>
+                  </table>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
     </div>
+  )
+}
+
+function BacklogQuoteRow({
+  quote,
+  isExpanded,
+  onToggle,
+  statusVariant,
+}: {
+  quote: BacklogQuoteItem
+  isExpanded: boolean
+  onToggle: () => void
+  statusVariant: (s: string) => 'default' | 'secondary' | 'outline'
+}) {
+  return (
+    <>
+      <tr className="hover:bg-muted/50 cursor-pointer" onClick={onToggle}>
+        <td className="px-2 py-2 text-center">
+          {isExpanded
+            ? <ChevronDown className="h-4 w-4 text-muted-foreground" />
+            : <ChevronRight className="h-4 w-4 text-muted-foreground" />}
+        </td>
+        <td className="px-3 py-2 font-medium">{quote.quote_number}</td>
+        <td className="px-3 py-2">{quote.uca_project_number}</td>
+        <td className="px-3 py-2">{quote.customer_name} — {quote.project_name}</td>
+        <td className="px-3 py-2">{quote.client_po_number || '—'}</td>
+        <td className="px-3 py-2">
+          <Badge variant={statusVariant(quote.status)}>{quote.status}</Badge>
+        </td>
+        <td className="px-3 py-2 text-right font-medium">{formatCurrency(quote.backlog_total)}</td>
+      </tr>
+      {isExpanded && quote.line_items.map((li) => (
+        <tr key={li.line_item_id} className="bg-muted/30">
+          <td />
+          <td className="px-3 py-1.5 text-xs text-muted-foreground pl-8" colSpan={2}>
+            <span className="capitalize">{li.item_type}</span> — {li.description}
+          </td>
+          <td className="px-3 py-1.5 text-xs text-muted-foreground">
+            Ord: {li.quantity} / Ful: {li.qty_fulfilled} / Pend: {li.qty_pending}
+          </td>
+          <td className="px-3 py-1.5 text-xs text-muted-foreground">
+            {formatCurrency(li.unit_price)}{li.discount_percent > 0 ? ` (-${li.discount_percent}%)` : ''}
+          </td>
+          <td />
+          <td className="px-3 py-1.5 text-xs text-right text-muted-foreground">
+            {formatCurrency(li.backlog_value)}
+          </td>
+        </tr>
+      ))}
+    </>
   )
 }

--- a/frontend/src/test/backlog-report.test.ts
+++ b/frontend/src/test/backlog-report.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { generateBacklogExcel } from '@/lib/excel'
+
+describe('Backlog Report - Excel generation', () => {
+  it('does not throw with empty data', () => {
+    // generateBacklogExcel calls XLSX.writeFile which tries to trigger a download.
+    // In jsdom there's no real DOM download, but it should not throw.
+    expect(() => generateBacklogExcel([])).not.toThrow()
+  })
+
+  it('does not throw with sample data', () => {
+    expect(() =>
+      generateBacklogExcel([
+        {
+          quote_id: 1,
+          quote_number: 'A1000-0001-0',
+          uca_project_number: 'A1000',
+          customer_name: 'Test Customer',
+          project_name: 'Test Project',
+          client_po_number: 'PO-123',
+          status: 'Work Order',
+          quote_total: 5000,
+          backlog_total: 3000,
+          line_items: [
+            {
+              line_item_id: 10,
+              item_type: 'labor',
+              description: 'Labor: Electrical',
+              quantity: 10,
+              qty_fulfilled: 4,
+              qty_pending: 6,
+              unit_price: 500,
+              discount_percent: 0,
+              backlog_value: 3000,
+            },
+          ],
+        },
+      ])
+    ).not.toThrow()
+  })
+})

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -34,6 +34,32 @@ export interface InvoiceSummaryItem {
   grand_total: number;
 }
 
+// ===== Backlog Quotes Report =====
+export interface BacklogLineItem {
+  line_item_id: number;
+  item_type: string;
+  description: string;
+  quantity: number;
+  qty_fulfilled: number;
+  qty_pending: number;
+  unit_price: number;
+  discount_percent: number;
+  backlog_value: number;
+}
+
+export interface BacklogQuoteItem {
+  quote_id: number;
+  quote_number: string;
+  uca_project_number: string;
+  customer_name: string;
+  project_name: string;
+  client_po_number?: string;
+  status: string;
+  quote_total: number;
+  backlog_total: number;
+  line_items: BacklogLineItem[];
+}
+
 // ===== Labor =====
 export interface Labor {
   id: number;


### PR DESCRIPTION
## Summary
- New **Backlog Quotes Report** on the Reports page showing all quotes not yet fully invoiced (Work Order + Invoiced status)
- Backend `GET /reports/backlog-quotes` endpoint reuses existing `compute_quote_status()` logic to filter quotes and returns denormalized data with line item detail
- Frontend preview table with expandable quote rows (chevron toggle) and client-side Excel download via SheetJS with row grouping

## Changes
| File | Action | Purpose |
|---|---|---|
| `backend/routes/reports.py` | NEW | Report endpoint |
| `backend/schemas.py` | MODIFY | Add `BacklogLineItem` + `BacklogQuoteItem` models |
| `backend/main.py` | MODIFY | Register reports router |
| `frontend/src/types/index.ts` | MODIFY | Add TS interfaces |
| `frontend/src/api/client.ts` | MODIFY | Add `reports.getBacklogQuotes()` |
| `frontend/src/lib/excel.ts` | NEW | Excel generation with row grouping |
| `frontend/src/pages/ReportsPage.tsx` | MODIFY | Add backlog report card with preview + download |
| `frontend/package.json` | MODIFY | Add `xlsx` dependency |
| `backend/tests/test_backlog_report.py` | NEW | Backend endpoint tests |
| `frontend/src/test/backlog-report.test.ts` | NEW | Frontend Excel generation test |

No database migrations needed — reads existing data only.

## Test plan
- [ ] TypeScript: `cd frontend && npx tsc -b` compiles clean
- [ ] Backend: `cd backend && pytest tests/test_backlog_report.py -v` (CI only — needs Postgres)
- [ ] Frontend: `cd frontend && npx vitest run src/test/backlog-report.test.ts`
- [ ] Manual: Run full stack, navigate to Reports, click Generate on Backlog section, verify preview table, click Download Excel, open in Excel and verify row grouping
- [ ] Production build: `cd frontend && npm run build` succeeds

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Backlog Quotes Report feature enabling users to generate and review pending quote line items with status filtering and fulfillment tracking
  * Added Excel export functionality for backlog quotes reports, providing detailed line item breakdowns, formatted pricing columns, and aggregated quote and backlog totals

<!-- end of auto-generated comment: release notes by coderabbit.ai -->