### PR TITLE
Add Cost Codes for POs and Quotes (Issue #20)

### DIFF
--- a/backend/alembic/versions/20260226_1200_008_add_cost_codes.py
+++ b/backend/alembic/versions/20260226_1200_008_add_cost_codes.py
@@ -1,0 +1,134 @@
+"""Add cost_codes table and cost_code_id FK to quotes and purchase_orders
+
+Creates a reference table for cost codes (~50 initial entries) used to classify
+work by type (hardware, doors & frames, field install, etc.). Each quote and
+PO gets exactly one required cost code. Existing records are backfilled to
+"200-000" (Supply of Hardware Series).
+
+Revision ID: 008_add_cost_codes
+Revises: 007_add_hst_rate
+Create Date: 2026-02-26
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '008_add_cost_codes'
+down_revision = '007_add_hst_rate'
+branch_labels = None
+depends_on = None
+
+
+# All cost codes to seed
+COST_CODES = [
+    ("100-000", "Doors & Frames Series", None, None),
+    ("100-100", "Supply of Doors & Frames", None, None),
+    ("100-200", "Install of Doors & Frames", None, None),
+    ("100-300", "Supply & Install of Doors & Frames", None, None),
+    ("200-000", "Supply of Hardware Series", None, None),
+    ("200-100", "Supply of Door Hardware", None, None),
+    ("200-200", "Supply of Bathroom Hardware", None, None),
+    ("200-300", "Supply of Specialty Hardware", None, None),
+    ("200-400", "Supply of Electronic Hardware", None, None),
+    ("200-500", "Supply of Access Control Hardware", None, None),
+    ("200-600", "Supply of Misc Hardware/Materials", None, None),
+    ("300-000", "Field Install Series", None, None),
+    ("300-100", "Field Install of Door Hardware", None, None),
+    ("300-200", "Field Install of Bathroom Hardware", None, None),
+    ("300-300", "Field Install of Specialty Hardware", None, None),
+    ("300-400", "Field Install of Electronic Hardware", None, None),
+    ("300-500", "Field Install of Access Control", None, None),
+    ("300-600", "Field Install of Misc Hardware", None, None),
+    ("400-000", "Supply & Install Hardware Series", None, None),
+    ("400-100", "Supply & Install Door Hardware", None, None),
+    ("400-200", "Supply & Install Bathroom Hardware", None, None),
+    ("400-300", "Supply & Install Specialty Hardware", None, None),
+    ("400-400", "Supply & Install Electronic Hardware", None, None),
+    ("400-500", "Supply & Install Access Control", None, None),
+    ("400-600", "Supply & Install Misc Hardware", None, None),
+    ("500-000", "Service & Maintenance Series", None, None),
+    ("500-100", "Service Call - Door Hardware", None, None),
+    ("500-200", "Service Call - Bathroom Hardware", None, None),
+    ("500-300", "Service Call - Specialty Hardware", None, None),
+    ("500-400", "Service Call - Electronic Hardware", None, None),
+    ("500-500", "Service Call - Access Control", None, None),
+    ("500-600", "Preventive Maintenance", None, None),
+    ("500-700", "Warranty Service", None, None),
+    ("600-000", "Keying & Locking Series", None, None),
+    ("600-100", "Keying - New Construction", None, None),
+    ("600-200", "Keying - Renovation/Rekey", None, None),
+    ("600-300", "Master Key System", None, None),
+    ("600-400", "Key Cutting & Duplication", None, None),
+    ("700-000", "Consulting & Engineering Series", None, None),
+    ("700-100", "Hardware Consulting", None, None),
+    ("700-200", "Specification Writing", None, None),
+    ("700-300", "Security Assessment", None, None),
+    ("700-400", "Project Management", None, None),
+    ("800-000", "Div 10 Specialties Series", None, None),
+    ("800-100", "Washroom Accessories", None, None),
+    ("800-200", "Toilet Partitions", None, None),
+    ("800-300", "Lockers", None, None),
+    ("800-400", "Signage", None, None),
+    ("900-000", "Internal / Admin Series", None, None),
+    ("900-100", "Internal Transfer", None, None),
+    ("900-200", "Stock Replenishment", None, None),
+]
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # 1. Create cost_codes table
+    conn.execute(sa.text("""
+        CREATE TABLE IF NOT EXISTS cost_codes (
+            id SERIAL PRIMARY KEY,
+            code VARCHAR NOT NULL UNIQUE,
+            description VARCHAR NOT NULL,
+            gp_cost_code_properties VARCHAR,
+            uch_dept_properties VARCHAR
+        )
+    """))
+
+    # 2. Seed all cost codes
+    for code, description, gp_props, uch_props in COST_CODES:
+        conn.execute(sa.text(
+            "INSERT INTO cost_codes (code, description, gp_cost_code_properties, uch_dept_properties) "
+            "VALUES (:code, :description, :gp_props, :uch_props) "
+            "ON CONFLICT (code) DO NOTHING"
+        ), {"code": code, "description": description, "gp_props": gp_props, "uch_props": uch_props})
+
+    # 3. Add cost_code_id to quotes (nullable first for backfill)
+    conn.execute(sa.text(
+        "ALTER TABLE quotes ADD COLUMN IF NOT EXISTS cost_code_id INTEGER REFERENCES cost_codes(id)"
+    ))
+
+    # 4. Add cost_code_id to purchase_orders (nullable first for backfill)
+    conn.execute(sa.text(
+        "ALTER TABLE purchase_orders ADD COLUMN IF NOT EXISTS cost_code_id INTEGER REFERENCES cost_codes(id)"
+    ))
+
+    # 5. Backfill existing records to "200-000" (Supply of Hardware Series)
+    conn.execute(sa.text(
+        "UPDATE quotes SET cost_code_id = (SELECT id FROM cost_codes WHERE code = '200-000') "
+        "WHERE cost_code_id IS NULL"
+    ))
+    conn.execute(sa.text(
+        "UPDATE purchase_orders SET cost_code_id = (SELECT id FROM cost_codes WHERE code = '200-000') "
+        "WHERE cost_code_id IS NULL"
+    ))
+
+    # 6. Set NOT NULL constraint
+    conn.execute(sa.text("ALTER TABLE quotes ALTER COLUMN cost_code_id SET NOT NULL"))
+    conn.execute(sa.text("ALTER TABLE purchase_orders ALTER COLUMN cost_code_id SET NOT NULL"))
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    # Drop cost_code_id from quotes and purchase_orders
+    conn.execute(sa.text("ALTER TABLE quotes DROP COLUMN IF EXISTS cost_code_id"))
+    conn.execute(sa.text("ALTER TABLE purchase_orders DROP COLUMN IF EXISTS cost_code_id"))
+
+    # Drop cost_codes table
+    conn.execute(sa.text("DROP TABLE IF EXISTS cost_codes"))

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,7 +11,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from database import engine, Base, SessionLocal
-from routes import parts, labor, profiles, projects, quotes, purchase_orders, discount_codes, miscellaneous, invoices, company_settings, reports
+from routes import parts, labor, profiles, projects, quotes, purchase_orders, discount_codes, miscellaneous, invoices, company_settings, reports, cost_codes
 from seed import seed_system_items
 
 
@@ -111,6 +111,7 @@ app.include_router(miscellaneous.router)
 app.include_router(invoices.router)
 app.include_router(company_settings.router)
 app.include_router(reports.router)
+app.include_router(cost_codes.router)
 
 
 @app.get("/")

--- a/backend/models.py
+++ b/backend/models.py
@@ -130,6 +130,16 @@ class Miscellaneous(Base):
     category = relationship("Category")
 
 
+class CostCode(Base):
+    __tablename__ = "cost_codes"
+
+    id = Column(Integer, primary_key=True, index=True)
+    code = Column(String, unique=True, nullable=False)
+    description = Column(String, nullable=False)
+    gp_cost_code_properties = Column(String, nullable=True)
+    uch_dept_properties = Column(String, nullable=True)
+
+
 class DiscountCode(Base):
     __tablename__ = "discount_codes"
 
@@ -173,12 +183,14 @@ class Quote(Base):
     work_description = Column(String, nullable=True)  # Optional work description
     markup_control_enabled = Column(Boolean, default=False)  # Markup Discount Control toggle
     global_markup_percent = Column(Float, nullable=True)  # Global markup % when control is enabled
+    cost_code_id = Column(Integer, ForeignKey('cost_codes.id'), nullable=False)
 
     # Relationships
     project = relationship("Project", back_populates="quotes")
     line_items = relationship("QuoteLineItem", back_populates="quote", cascade="all, delete-orphan")
     invoices = relationship("Invoice", back_populates="quote", order_by="Invoice.created_at")
     snapshots = relationship("QuoteSnapshot", back_populates="quote", order_by="QuoteSnapshot.version")
+    cost_code = relationship("CostCode")
 
 
 class QuoteLineItem(Base):
@@ -225,6 +237,7 @@ class PurchaseOrder(Base):
     vendor_po_number = Column(String, nullable=True)
     expected_delivery_date = Column(DateTime, nullable=True)
     status = Column(Enum(POStatus), default=POStatus.draft)
+    cost_code_id = Column(Integer, ForeignKey('cost_codes.id'), nullable=False)
 
     # Relationships
     project = relationship("Project", back_populates="purchase_orders")
@@ -232,6 +245,7 @@ class PurchaseOrder(Base):
     line_items = relationship("POLineItem", back_populates="purchase_order", cascade="all, delete-orphan")
     receivings = relationship("POReceiving", back_populates="purchase_order", order_by="POReceiving.created_at")
     snapshots = relationship("POSnapshot", back_populates="purchase_order", order_by="POSnapshot.version")
+    cost_code = relationship("CostCode")
 
 
 class POLineItem(Base):

--- a/backend/routes/cost_codes.py
+++ b/backend/routes/cost_codes.py
@@ -1,0 +1,99 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+
+from database import get_db
+from models import CostCode, Quote, PurchaseOrder
+from schemas import (
+    CostCodeCreate, CostCodeUpdate, CostCode as CostCodeSchema
+)
+
+router = APIRouter(prefix="/cost-codes", tags=["cost-codes"])
+
+
+@router.get("/", response_model=List[CostCodeSchema])
+def get_all_cost_codes(db: Session = Depends(get_db)):
+    """Get all cost codes, ordered by code."""
+    return db.query(CostCode).order_by(CostCode.code).all()
+
+
+@router.get("/{cost_code_id}", response_model=CostCodeSchema)
+def get_cost_code(cost_code_id: int, db: Session = Depends(get_db)):
+    """Get a single cost code."""
+    cc = db.query(CostCode).filter(CostCode.id == cost_code_id).first()
+    if not cc:
+        raise HTTPException(status_code=404, detail="Cost code not found")
+    return cc
+
+
+@router.post("/", response_model=CostCodeSchema)
+def create_cost_code(data: CostCodeCreate, db: Session = Depends(get_db)):
+    """Create a new cost code."""
+    existing = db.query(CostCode).filter(CostCode.code == data.code).first()
+    if existing:
+        raise HTTPException(status_code=400, detail=f"Cost code '{data.code}' already exists")
+
+    cc = CostCode(
+        code=data.code,
+        description=data.description,
+        gp_cost_code_properties=data.gp_cost_code_properties,
+        uch_dept_properties=data.uch_dept_properties,
+    )
+    db.add(cc)
+    db.commit()
+    db.refresh(cc)
+    return cc
+
+
+@router.put("/{cost_code_id}", response_model=CostCodeSchema)
+def update_cost_code(cost_code_id: int, data: CostCodeUpdate, db: Session = Depends(get_db)):
+    """Update an existing cost code."""
+    cc = db.query(CostCode).filter(CostCode.id == cost_code_id).first()
+    if not cc:
+        raise HTTPException(status_code=404, detail="Cost code not found")
+
+    # Check unique code if being changed
+    if data.code is not None and data.code != cc.code:
+        existing = db.query(CostCode).filter(CostCode.code == data.code).first()
+        if existing:
+            raise HTTPException(status_code=400, detail=f"Cost code '{data.code}' already exists")
+        cc.code = data.code
+
+    if data.description is not None:
+        cc.description = data.description
+    if data.gp_cost_code_properties is not None:
+        cc.gp_cost_code_properties = data.gp_cost_code_properties
+    if data.uch_dept_properties is not None:
+        cc.uch_dept_properties = data.uch_dept_properties
+
+    db.commit()
+    db.refresh(cc)
+    return cc
+
+
+@router.delete("/{cost_code_id}")
+def delete_cost_code(cost_code_id: int, db: Session = Depends(get_db)):
+    """Delete a cost code. Blocked if referenced by any Quote or PO."""
+    cc = db.query(CostCode).filter(CostCode.id == cost_code_id).first()
+    if not cc:
+        raise HTTPException(status_code=404, detail="Cost code not found")
+
+    # Check if referenced by any quotes
+    quote_count = db.query(Quote).filter(Quote.cost_code_id == cost_code_id).count()
+    if quote_count > 0:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot delete cost code '{cc.code}' — it is used by {quote_count} quote(s). Reassign them first."
+        )
+
+    # Check if referenced by any purchase orders
+    po_count = db.query(PurchaseOrder).filter(PurchaseOrder.cost_code_id == cost_code_id).count()
+    if po_count > 0:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot delete cost code '{cc.code}' — it is used by {po_count} purchase order(s). Reassign them first."
+        )
+
+    db.delete(cc)
+    db.commit()
+    return {"message": f"Cost code '{cc.code}' deleted successfully"}

--- a/backend/routes/purchase_orders.py
+++ b/backend/routes/purchase_orders.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from database import get_db
 from models import (
     PurchaseOrder, POLineItem, Project, Profile, ProfileType, Part,
-    POReceiving, POReceivingLineItem, POSnapshot, POLineItemSnapshot, POStatus
+    POReceiving, POReceivingLineItem, POSnapshot, POLineItemSnapshot, POStatus, CostCode
 )
 from schemas import (
     PurchaseOrderCreate, PurchaseOrderUpdate, PurchaseOrder as PurchaseOrderSchema,
@@ -278,7 +278,8 @@ def get_all_purchase_orders(skip: int = 0, limit: int = 100, db: Session = Depen
         .options(
             joinedload(PurchaseOrder.vendor),
             joinedload(PurchaseOrder.line_items),
-            joinedload(PurchaseOrder.project)
+            joinedload(PurchaseOrder.project),
+            joinedload(PurchaseOrder.cost_code)
         )
         .offset(skip)
         .limit(limit)
@@ -295,7 +296,8 @@ def get_purchase_order(po_id: int, db: Session = Depends(get_db)):
         .options(
             joinedload(PurchaseOrder.vendor),
             joinedload(PurchaseOrder.line_items).joinedload(POLineItem.part),
-            joinedload(PurchaseOrder.project)
+            joinedload(PurchaseOrder.project),
+            joinedload(PurchaseOrder.cost_code)
         )
         .filter(PurchaseOrder.id == po_id)
         .first()
@@ -323,6 +325,13 @@ def create_purchase_order(po_data: PurchaseOrderCreate, db: Session = Depends(ge
     # Get next sequence number
     next_sequence = get_next_po_sequence(db, po_data.project_id)
 
+    # Resolve cost_code_id: use provided or default to "200-000"
+    cost_code_id = po_data.cost_code_id
+    if cost_code_id is None:
+        default_cc = db.query(CostCode).filter(CostCode.code == "200-000").first()
+        if default_cc:
+            cost_code_id = default_cc.id
+
     db_po = PurchaseOrder(
         project_id=po_data.project_id,
         vendor_id=po_data.vendor_id,
@@ -330,7 +339,8 @@ def create_purchase_order(po_data: PurchaseOrderCreate, db: Session = Depends(ge
         status=po_data.status,
         work_description=po_data.work_description,
         vendor_po_number=po_data.vendor_po_number,
-        expected_delivery_date=po_data.expected_delivery_date
+        expected_delivery_date=po_data.expected_delivery_date,
+        cost_code_id=cost_code_id
     )
     db.add(db_po)
     db.flush()  # Get the PO ID without committing
@@ -342,12 +352,13 @@ def create_purchase_order(po_data: PurchaseOrderCreate, db: Session = Depends(ge
     db.commit()
     db.refresh(db_po)
 
-    # Reload with vendor and project relationship
+    # Reload with vendor, project, and cost_code relationships
     db_po = (
         db.query(PurchaseOrder)
         .options(
             joinedload(PurchaseOrder.vendor),
-            joinedload(PurchaseOrder.project)
+            joinedload(PurchaseOrder.project),
+            joinedload(PurchaseOrder.cost_code)
         )
         .filter(PurchaseOrder.id == db_po.id)
         .first()
@@ -384,6 +395,9 @@ def update_purchase_order(
     if po_data.expected_delivery_date is not None:
         db_po.expected_delivery_date = po_data.expected_delivery_date
 
+    if po_data.cost_code_id is not None:
+        db_po.cost_code_id = po_data.cost_code_id
+
     # Create snapshot if status changed
     if status_changed:
         create_po_snapshot(db, db_po, "status_change", f"Status changed from {old_status.value} to {po_data.status.value}")
@@ -391,12 +405,13 @@ def update_purchase_order(
     db.commit()
     db.refresh(db_po)
 
-    # Reload with vendor and project relationship
+    # Reload with vendor, project, and cost_code relationships
     db_po = (
         db.query(PurchaseOrder)
         .options(
             joinedload(PurchaseOrder.vendor),
-            joinedload(PurchaseOrder.project)
+            joinedload(PurchaseOrder.project),
+            joinedload(PurchaseOrder.cost_code)
         )
         .filter(PurchaseOrder.id == db_po.id)
         .first()
@@ -614,7 +629,8 @@ def commit_po_edits(po_id: int, request: POCommitEditsRequest, db: Session = Dep
             .options(
                 joinedload(PurchaseOrder.vendor),
                 joinedload(PurchaseOrder.line_items).joinedload(POLineItem.part),
-                joinedload(PurchaseOrder.project)
+                joinedload(PurchaseOrder.project),
+                joinedload(PurchaseOrder.cost_code)
             )
             .filter(PurchaseOrder.id == po_id)
             .first()
@@ -764,7 +780,8 @@ def commit_po_edits(po_id: int, request: POCommitEditsRequest, db: Session = Dep
         .options(
             joinedload(PurchaseOrder.vendor),
             joinedload(PurchaseOrder.line_items).joinedload(POLineItem.part),
-            joinedload(PurchaseOrder.project)
+            joinedload(PurchaseOrder.project),
+            joinedload(PurchaseOrder.cost_code)
         )
         .filter(PurchaseOrder.id == po_id)
         .first()
@@ -1266,7 +1283,8 @@ def revert_po_to_version(po_id: int, version: int, db: Session = Depends(get_db)
         .options(
             joinedload(PurchaseOrder.vendor),
             joinedload(PurchaseOrder.line_items).joinedload(POLineItem.part),
-            joinedload(PurchaseOrder.project)
+            joinedload(PurchaseOrder.project),
+            joinedload(PurchaseOrder.cost_code)
         )
         .filter(PurchaseOrder.id == po_id)
         .first()
@@ -1326,7 +1344,8 @@ def clone_purchase_order(po_id: int, db: Session = Depends(get_db)):
         status=POStatus.draft,
         work_description=source_po.work_description,
         vendor_po_number=source_po.vendor_po_number,
-        expected_delivery_date=source_po.expected_delivery_date
+        expected_delivery_date=source_po.expected_delivery_date,
+        cost_code_id=source_po.cost_code_id
     )
     db.add(new_po)
     db.flush()  # Get new PO ID
@@ -1358,7 +1377,8 @@ def clone_purchase_order(po_id: int, db: Session = Depends(get_db)):
         .options(
             joinedload(PurchaseOrder.vendor),
             joinedload(PurchaseOrder.line_items).joinedload(POLineItem.part),
-            joinedload(PurchaseOrder.project)
+            joinedload(PurchaseOrder.project),
+            joinedload(PurchaseOrder.cost_code)
         )
         .filter(PurchaseOrder.id == new_po.id)
         .first()

--- a/backend/routes/quotes.py
+++ b/backend/routes/quotes.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 from database import get_db
 from models import (
     Quote, QuoteLineItem, Project, Labor, Part, Miscellaneous, DiscountCode,
-    QuoteSnapshot, QuoteLineItemSnapshot, Invoice, InvoiceLineItem
+    QuoteSnapshot, QuoteLineItemSnapshot, Invoice, InvoiceLineItem, CostCode
 )
 from datetime import datetime
 
@@ -283,7 +283,8 @@ def get_all_quotes(skip: int = 0, limit: int = 100, db: Session = Depends(get_db
         db.query(Quote)
         .options(
             joinedload(Quote.project),  # Need project for uca_project_number
-            joinedload(Quote.line_items)
+            joinedload(Quote.line_items),
+            joinedload(Quote.cost_code)
         )
         .offset(skip)
         .limit(limit)
@@ -303,7 +304,8 @@ def get_quote(quote_id: int, db: Session = Depends(get_db)):
             joinedload(Quote.line_items).joinedload(QuoteLineItem.labor),
             joinedload(Quote.line_items).joinedload(QuoteLineItem.part),
             joinedload(Quote.line_items).joinedload(QuoteLineItem.miscellaneous),
-            joinedload(Quote.line_items).joinedload(QuoteLineItem.discount_code)
+            joinedload(Quote.line_items).joinedload(QuoteLineItem.discount_code),
+            joinedload(Quote.cost_code)
         )
         .filter(Quote.id == quote_id)
         .first()
@@ -328,11 +330,19 @@ def create_quote(quote_data: QuoteCreate, db: Session = Depends(get_db)):
     # Get next sequence number for this project
     next_sequence = get_next_quote_sequence(db, quote_data.project_id)
 
+    # Resolve cost_code_id: use provided or default to "200-000"
+    cost_code_id = quote_data.cost_code_id
+    if cost_code_id is None:
+        default_cc = db.query(CostCode).filter(CostCode.code == "200-000").first()
+        if default_cc:
+            cost_code_id = default_cc.id
+
     db_quote = Quote(
         project_id=quote_data.project_id,
         quote_sequence=next_sequence,
         client_po_number=quote_data.client_po_number,
-        work_description=quote_data.work_description
+        work_description=quote_data.work_description,
+        cost_code_id=cost_code_id
     )
     db.add(db_quote)
     db.commit()
@@ -359,6 +369,9 @@ def update_quote(quote_id: int, quote_data: QuoteUpdate, db: Session = Depends(g
 
     if quote_data.work_description is not None:
         db_quote.work_description = quote_data.work_description.strip() or None
+
+    if quote_data.cost_code_id is not None:
+        db_quote.cost_code_id = quote_data.cost_code_id
 
     db.commit()
     db.refresh(db_quote)
@@ -416,6 +429,7 @@ def clone_quote(quote_id: int, db: Session = Depends(get_db)):
         work_description=source_quote.work_description,
         markup_control_enabled=False,  # Reset to disabled
         global_markup_percent=None,  # Reset to None
+        cost_code_id=source_quote.cost_code_id,
     )
     db.add(new_quote)
     db.flush()  # Get new quote ID
@@ -451,7 +465,8 @@ def clone_quote(quote_id: int, db: Session = Depends(get_db)):
             joinedload(Quote.line_items).joinedload(QuoteLineItem.labor),
             joinedload(Quote.line_items).joinedload(QuoteLineItem.part),
             joinedload(Quote.line_items).joinedload(QuoteLineItem.miscellaneous),
-            joinedload(Quote.line_items).joinedload(QuoteLineItem.discount_code)
+            joinedload(Quote.line_items).joinedload(QuoteLineItem.discount_code),
+            joinedload(Quote.cost_code)
         )
         .filter(Quote.id == new_quote.id)
         .first()
@@ -1175,7 +1190,8 @@ def commit_edits(
             joinedload(Quote.line_items).joinedload(QuoteLineItem.labor),
             joinedload(Quote.line_items).joinedload(QuoteLineItem.part),
             joinedload(Quote.line_items).joinedload(QuoteLineItem.miscellaneous),
-            joinedload(Quote.line_items).joinedload(QuoteLineItem.discount_code)
+            joinedload(Quote.line_items).joinedload(QuoteLineItem.discount_code),
+            joinedload(Quote.cost_code)
         )
         .filter(Quote.id == quote_id)
         .first()
@@ -1524,7 +1540,8 @@ def revert_to_snapshot(quote_id: int, version: int, db: Session = Depends(get_db
             joinedload(Quote.line_items).joinedload(QuoteLineItem.labor),
             joinedload(Quote.line_items).joinedload(QuoteLineItem.part),
             joinedload(Quote.line_items).joinedload(QuoteLineItem.miscellaneous),
-            joinedload(Quote.line_items).joinedload(QuoteLineItem.discount_code)
+            joinedload(Quote.line_items).joinedload(QuoteLineItem.discount_code),
+            joinedload(Quote.cost_code)
         )
         .filter(Quote.id == quote_id)
         .first()

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -87,6 +87,32 @@ class POStatus(str, Enum):
     closed = "Closed"
 
 
+# ===== Cost Code Schemas =====
+class CostCodeBase(BaseModel):
+    code: str
+    description: str
+    gp_cost_code_properties: Optional[str] = None
+    uch_dept_properties: Optional[str] = None
+
+
+class CostCodeCreate(CostCodeBase):
+    pass
+
+
+class CostCodeUpdate(BaseModel):
+    code: Optional[str] = None
+    description: Optional[str] = None
+    gp_cost_code_properties: Optional[str] = None
+    uch_dept_properties: Optional[str] = None
+
+
+class CostCode(CostCodeBase):
+    id: int
+
+    class Config:
+        from_attributes = True
+
+
 # ===== Category Schemas =====
 class CategoryBase(BaseModel):
     name: str
@@ -431,11 +457,13 @@ class QuoteCreate(BaseModel):
     project_id: int
     client_po_number: Optional[str] = None
     work_description: Optional[str] = None
+    cost_code_id: Optional[int] = None
 
 
 class QuoteUpdate(BaseModel):
     client_po_number: Optional[str] = None
     work_description: Optional[str] = None
+    cost_code_id: Optional[int] = None
 
 
 class Quote(QuoteBase):
@@ -444,6 +472,8 @@ class Quote(QuoteBase):
     quote_number: Optional[str] = None  # Computed: "{UCA Project Number}-{Sequence:04d}-{Version}"
     created_at: datetime
     current_version: int = 0
+    cost_code_id: Optional[int] = None
+    cost_code: Optional[CostCode] = None
     line_items: List[QuoteLineItem] = []
 
     class Config:
@@ -496,7 +526,7 @@ class PurchaseOrderBase(BaseModel):
 
 
 class PurchaseOrderCreate(PurchaseOrderBase):
-    pass
+    cost_code_id: Optional[int] = None
 
 
 class PurchaseOrderUpdate(BaseModel):
@@ -504,6 +534,7 @@ class PurchaseOrderUpdate(BaseModel):
     work_description: Optional[str] = None
     vendor_po_number: Optional[str] = None
     expected_delivery_date: Optional[datetime] = None
+    cost_code_id: Optional[int] = None
 
 
 class PurchaseOrder(PurchaseOrderBase):
@@ -512,6 +543,8 @@ class PurchaseOrder(PurchaseOrderBase):
     po_sequence: int
     current_version: int = 0
     po_number: Optional[str] = None
+    cost_code_id: Optional[int] = None
+    cost_code: Optional[CostCode] = None
     vendor: Profile
     line_items: List[POLineItem] = []
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3,6 +3,7 @@ import type {
   Labor, LaborCreate,
   Miscellaneous, MiscellaneousCreate,
   DiscountCode, DiscountCodeCreate,
+  CostCode, CostCodeCreate, CostCodeUpdate,
   Profile, ProfileCreate, ProfileUpdate, ProfileType,
   Contact, ContactCreate, ContactUpdate,
   Project, ProjectCreate, ProjectFull,
@@ -261,6 +262,18 @@ export const api = {
     // Clone
     clone: (poId: number) =>
       request<PurchaseOrder>(`/purchase-orders/${poId}/clone`, { method: 'POST' }),
+  },
+
+  // ===== Cost Codes =====
+  costCodes: {
+    getAll: () => request<CostCode[]>('/cost-codes/'),
+    get: (id: number) => request<CostCode>(`/cost-codes/${id}`),
+    create: (data: CostCodeCreate) =>
+      request<CostCode>('/cost-codes/', { method: 'POST', body: JSON.stringify(data) }),
+    update: (id: number, data: CostCodeUpdate) =>
+      request<CostCode>(`/cost-codes/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+    delete: (id: number) =>
+      request<{ message: string }>(`/cost-codes/${id}`, { method: 'DELETE' }),
   },
 
   // ===== Reports =====

--- a/frontend/src/components/editors/POEditor.tsx
+++ b/frontend/src/components/editors/POEditor.tsx
@@ -49,14 +49,14 @@ import {
 import type { SearchableSelectOption } from "@/components/ui/searchable-select"
 import { api } from "@/api/client"
 import type {
-  PurchaseOrder, POLineItem, POLineItemCreate, POLineItemType, POStatus, Part,
+  PurchaseOrder, POLineItem, POLineItemCreate, POLineItemType, POStatus, Part, CostCode,
   POEditorMode, StagedPOEdit, StagedPOAdd,
   StagedPOLineItemChange, POCommitEditsRequest, POReceivingCreate, POReceivingLineItemCreate,
   CompanySettings
 } from "@/types"
 import {
   Plus, Minus, Trash2, Package, FileText, Building, Pencil, Copy,
-  X, GitCommit, Eye, AlertTriangle, Check, Calendar, Loader2
+  X, GitCommit, Eye, AlertTriangle, Check, Calendar, Loader2, Hash
 } from "lucide-react"
 import { PartForm } from "@/components/forms/PartForm"
 import { POAuditTrail } from "./POAuditTrail"
@@ -131,6 +131,10 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
   const [isCloning, setIsCloning] = useState(false)
   const [cloneConfirmOpen, setCloneConfirmOpen] = useState(false)
 
+  // ===== Cost Codes =====
+  const [costCodes, setCostCodes] = useState<CostCode[]>([])
+  const [savingCostCode, setSavingCostCode] = useState(false)
+
   // ===== Receiving Mode State =====
   const [stagedReceivings, setStagedReceivings] = useState<Map<number, {
     qty_received: number;
@@ -189,6 +193,7 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
     fetchPO()
     fetchParts()
     api.companySettings.get().then(setCompanySettings).catch(() => {})
+    api.costCodes.getAll().then(setCostCodes).catch(() => {})
   }, [poId])
 
   // ===== Navigation Guard =====
@@ -557,6 +562,21 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
       alert(err instanceof Error ? err.message : "Failed to update expected delivery date")
     } finally {
       setSavingDeliveryDate(false)
+    }
+  }
+
+  const handleCostCodeChange = async (value: string) => {
+    const costCodeId = parseInt(value)
+    if (isNaN(costCodeId)) return
+    setSavingCostCode(true)
+    try {
+      await api.purchaseOrders.update(poId, { cost_code_id: costCodeId })
+      fetchPO()
+      onUpdate?.()
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to update cost code")
+    } finally {
+      setSavingCostCode(false)
     }
   }
 
@@ -1209,7 +1229,7 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
           <CardTitle className="text-base">Order Details</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
             {/* Work Description */}
             <div className="space-y-1">
               <Label className="text-sm text-muted-foreground">Work Description</Label>
@@ -1358,6 +1378,25 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
                     <Pencil className="h-3 w-3" />
                   </Button>
                 </div>
+              )}
+            </div>
+
+            {/* Cost Code */}
+            <div className="space-y-1">
+              <Label className="text-sm text-muted-foreground flex items-center gap-1">
+                <Hash className="h-3 w-3" />
+                Cost Code
+              </Label>
+              <SearchableSelect
+                options={costCodes.map(cc => ({ value: cc.id.toString(), label: `${cc.code} - ${cc.description}` }))}
+                value={po.cost_code_id?.toString()}
+                onChange={handleCostCodeChange}
+                placeholder="Select cost code..."
+                searchPlaceholder="Search cost codes..."
+                disabled={savingCostCode}
+              />
+              {savingCostCode && (
+                <p className="text-xs text-muted-foreground">Saving...</p>
               )}
             </div>
           </div>

--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -51,11 +51,11 @@ import type { SearchableSelectOption } from "@/components/ui/searchable-select"
 import { api } from "@/api/client"
 import type {
   Quote, QuoteLineItem, QuoteLineItemCreate, QuoteLineItemUpdate,
-  LineItemType, Part, Labor, Miscellaneous, DiscountCode,
+  LineItemType, Part, Labor, Miscellaneous, DiscountCode, CostCode,
   StagedFulfillment, InvoiceCreate, QuoteEditorMode, StagedEdit, StagedAdd,
   StagedLineItemChange, CommitEditsRequest
 } from "@/types"
-import { Plus, Minus, Trash2, Wrench, Package, FileText, Pencil, Tag, ClipboardCheck, Receipt, Percent, Info, Copy, Car, MapPin, X, Lock, GitCommit, Eye, AlertTriangle, Check, CheckCircle2, Printer, Loader2 } from "lucide-react"
+import { Plus, Minus, Trash2, Wrench, Package, FileText, Pencil, Tag, ClipboardCheck, Receipt, Percent, Info, Copy, Car, MapPin, X, Lock, GitCommit, Eye, AlertTriangle, Check, CheckCircle2, Printer, Loader2, Hash } from "lucide-react"
 import { pdf } from '@react-pdf/renderer'
 import { QuotePDF } from '@/components/pdf/QuotePDF'
 import type { CompanySettings, Project } from '@/types'
@@ -168,6 +168,10 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
   // Clone quote state
   const [isCloning, setIsCloning] = useState(false)
 
+  // Cost codes
+  const [costCodes, setCostCodes] = useState<CostCode[]>([])
+  const [savingCostCode, setSavingCostCode] = useState(false)
+
   // Print PDF state
   const [isPrinting, setIsPrinting] = useState(false)
 
@@ -263,6 +267,7 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
     fetchQuote()
     fetchResources()
     api.companySettings.get().then(setCompanySettings).catch(() => {})
+    api.costCodes.getAll().then(setCostCodes).catch(() => {})
   }, [quoteId])
 
   // Computed: Are there staged invoicing changes?
@@ -808,6 +813,21 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
       alert(err instanceof Error ? err.message : "Failed to update Work Description")
     } finally {
       setSavingWorkDescription(false)
+    }
+  }
+
+  const handleCostCodeChange = async (value: string) => {
+    const costCodeId = parseInt(value)
+    if (isNaN(costCodeId)) return
+    setSavingCostCode(true)
+    try {
+      await api.quotes.update(quoteId, { cost_code_id: costCodeId })
+      fetchQuote()
+      onUpdate?.()
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to update cost code")
+    } finally {
+      setSavingCostCode(false)
     }
   }
 
@@ -2626,6 +2646,31 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
               A Client PO Number is required before you can create an invoice.
             </p>
           )}
+        </CardContent>
+      </Card>
+
+      {/* Cost Code */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2">
+            <Hash className="h-4 w-4" />
+            Cost Code
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="max-w-md">
+            <SearchableSelect
+              options={costCodes.map(cc => ({ value: cc.id.toString(), label: `${cc.code} - ${cc.description}` }))}
+              value={quote.cost_code_id?.toString()}
+              onChange={handleCostCodeChange}
+              placeholder="Select cost code..."
+              searchPlaceholder="Search cost codes..."
+              disabled={editorMode !== "edit" || savingCostCode}
+            />
+            {savingCostCode && (
+              <p className="text-xs text-muted-foreground mt-1">Saving...</p>
+            )}
+          </div>
         </CardContent>
       </Card>
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -4,9 +4,35 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { api } from '@/api/client'
-import type { CompanySettings, CompanySettingsUpdate } from '@/types'
-import { Loader2, Save } from 'lucide-react'
+import type { CompanySettings, CompanySettingsUpdate, CostCode, CostCodeCreate } from '@/types'
+import { Loader2, Save, Pencil, Trash2, Plus, X, Check } from 'lucide-react'
+
+// Inline editing row state
+interface CostCodeEditState {
+  code: string
+  description: string
+  gp_cost_code_properties: string
+  uch_dept_properties: string
+}
 
 export function SettingsPage() {
   const [settings, setSettings] = useState<CompanySettings | null>(null)
@@ -23,8 +49,20 @@ export function SettingsPage() {
   const [gstNumber, setGstNumber] = useState('')
   const [hstRate, setHstRate] = useState('')
 
+  // Cost codes state
+  const [costCodes, setCostCodes] = useState<CostCode[]>([])
+  const [costCodesLoading, setCostCodesLoading] = useState(true)
+  const [editingCostCodeId, setEditingCostCodeId] = useState<number | null>(null)
+  const [editingCostCode, setEditingCostCode] = useState<CostCodeEditState | null>(null)
+  const [addingCostCode, setAddingCostCode] = useState(false)
+  const [newCostCode, setNewCostCode] = useState<CostCodeEditState>({ code: '', description: '', gp_cost_code_properties: '', uch_dept_properties: '' })
+  const [costCodeSaving, setCostCodeSaving] = useState(false)
+  const [costCodeError, setCostCodeError] = useState<string | null>(null)
+  const [deleteConfirm, setDeleteConfirm] = useState<CostCode | null>(null)
+
   useEffect(() => {
     fetchSettings()
+    fetchCostCodes()
   }, [])
 
   const fetchSettings = async () => {
@@ -43,6 +81,18 @@ export function SettingsPage() {
       setError(err instanceof Error ? err.message : 'Failed to load settings')
     } finally {
       setLoading(false)
+    }
+  }
+
+  const fetchCostCodes = async () => {
+    setCostCodesLoading(true)
+    try {
+      const data = await api.costCodes.getAll()
+      setCostCodes(data)
+    } catch (err) {
+      setCostCodeError(err instanceof Error ? err.message : 'Failed to load cost codes')
+    } finally {
+      setCostCodesLoading(false)
     }
   }
 
@@ -74,6 +124,98 @@ export function SettingsPage() {
       setError(err instanceof Error ? err.message : 'Failed to save settings')
     } finally {
       setSaving(false)
+    }
+  }
+
+  // Cost code CRUD handlers
+  const startEditCostCode = (cc: CostCode) => {
+    setEditingCostCodeId(cc.id)
+    setEditingCostCode({
+      code: cc.code,
+      description: cc.description,
+      gp_cost_code_properties: cc.gp_cost_code_properties || '',
+      uch_dept_properties: cc.uch_dept_properties || '',
+    })
+    setCostCodeError(null)
+  }
+
+  const cancelEditCostCode = () => {
+    setEditingCostCodeId(null)
+    setEditingCostCode(null)
+  }
+
+  const saveEditCostCode = async () => {
+    if (!editingCostCode || editingCostCodeId === null) return
+    if (!editingCostCode.code.trim() || !editingCostCode.description.trim()) {
+      setCostCodeError('Code and Description are required.')
+      return
+    }
+
+    setCostCodeSaving(true)
+    setCostCodeError(null)
+    try {
+      await api.costCodes.update(editingCostCodeId, {
+        code: editingCostCode.code.trim(),
+        description: editingCostCode.description.trim(),
+        gp_cost_code_properties: editingCostCode.gp_cost_code_properties.trim() || undefined,
+        uch_dept_properties: editingCostCode.uch_dept_properties.trim() || undefined,
+      })
+      setEditingCostCodeId(null)
+      setEditingCostCode(null)
+      fetchCostCodes()
+    } catch (err) {
+      setCostCodeError(err instanceof Error ? err.message : 'Failed to update cost code')
+    } finally {
+      setCostCodeSaving(false)
+    }
+  }
+
+  const startAddCostCode = () => {
+    setAddingCostCode(true)
+    setNewCostCode({ code: '', description: '', gp_cost_code_properties: '', uch_dept_properties: '' })
+    setCostCodeError(null)
+  }
+
+  const cancelAddCostCode = () => {
+    setAddingCostCode(false)
+    setNewCostCode({ code: '', description: '', gp_cost_code_properties: '', uch_dept_properties: '' })
+  }
+
+  const saveNewCostCode = async () => {
+    if (!newCostCode.code.trim() || !newCostCode.description.trim()) {
+      setCostCodeError('Code and Description are required.')
+      return
+    }
+
+    setCostCodeSaving(true)
+    setCostCodeError(null)
+    try {
+      const data: CostCodeCreate = {
+        code: newCostCode.code.trim(),
+        description: newCostCode.description.trim(),
+        gp_cost_code_properties: newCostCode.gp_cost_code_properties.trim() || undefined,
+        uch_dept_properties: newCostCode.uch_dept_properties.trim() || undefined,
+      }
+      await api.costCodes.create(data)
+      setAddingCostCode(false)
+      setNewCostCode({ code: '', description: '', gp_cost_code_properties: '', uch_dept_properties: '' })
+      fetchCostCodes()
+    } catch (err) {
+      setCostCodeError(err instanceof Error ? err.message : 'Failed to create cost code')
+    } finally {
+      setCostCodeSaving(false)
+    }
+  }
+
+  const deleteCostCode = async (cc: CostCode) => {
+    setCostCodeError(null)
+    try {
+      await api.costCodes.delete(cc.id)
+      setDeleteConfirm(null)
+      fetchCostCodes()
+    } catch (err) {
+      setDeleteConfirm(null)
+      setCostCodeError(err instanceof Error ? err.message : 'Failed to delete cost code')
     }
   }
 
@@ -194,6 +336,208 @@ export function SettingsPage() {
           Save Settings
         </Button>
       </div>
+
+      {/* Cost Codes */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Cost Codes</CardTitle>
+          <Button
+            size="sm"
+            onClick={startAddCostCode}
+            disabled={addingCostCode || editingCostCodeId !== null}
+            className="gap-1"
+          >
+            <Plus className="h-4 w-4" />
+            Add New
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {costCodeError && (
+            <div className="p-3 mb-4 bg-destructive/10 border border-destructive/20 rounded-md text-destructive text-sm">
+              {costCodeError}
+            </div>
+          )}
+
+          {costCodesLoading ? (
+            <div className="p-4 text-center text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin mx-auto mb-2" />
+              Loading cost codes...
+            </div>
+          ) : (
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-[120px]">Code</TableHead>
+                    <TableHead>Description</TableHead>
+                    <TableHead className="w-[180px]">GP Properties</TableHead>
+                    <TableHead className="w-[180px]">UCH Dept Properties</TableHead>
+                    <TableHead className="w-[100px] text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {costCodes.map((cc) => (
+                    <TableRow key={cc.id}>
+                      {editingCostCodeId === cc.id && editingCostCode ? (
+                        <>
+                          <TableCell>
+                            <Input
+                              value={editingCostCode.code}
+                              onChange={(e) => setEditingCostCode({ ...editingCostCode, code: e.target.value })}
+                              className="h-8"
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <Input
+                              value={editingCostCode.description}
+                              onChange={(e) => setEditingCostCode({ ...editingCostCode, description: e.target.value })}
+                              className="h-8"
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <Input
+                              value={editingCostCode.gp_cost_code_properties}
+                              onChange={(e) => setEditingCostCode({ ...editingCostCode, gp_cost_code_properties: e.target.value })}
+                              className="h-8"
+                              placeholder="Optional"
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <Input
+                              value={editingCostCode.uch_dept_properties}
+                              onChange={(e) => setEditingCostCode({ ...editingCostCode, uch_dept_properties: e.target.value })}
+                              className="h-8"
+                              placeholder="Optional"
+                            />
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <div className="flex justify-end gap-1">
+                              <Button size="icon" variant="ghost" className="h-7 w-7" onClick={saveEditCostCode} disabled={costCodeSaving}>
+                                {costCodeSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4 text-green-600" />}
+                              </Button>
+                              <Button size="icon" variant="ghost" className="h-7 w-7" onClick={cancelEditCostCode}>
+                                <X className="h-4 w-4 text-muted-foreground" />
+                              </Button>
+                            </div>
+                          </TableCell>
+                        </>
+                      ) : (
+                        <>
+                          <TableCell className="font-mono text-sm">{cc.code}</TableCell>
+                          <TableCell>{cc.description}</TableCell>
+                          <TableCell className="text-sm text-muted-foreground">{cc.gp_cost_code_properties || '—'}</TableCell>
+                          <TableCell className="text-sm text-muted-foreground">{cc.uch_dept_properties || '—'}</TableCell>
+                          <TableCell className="text-right">
+                            <div className="flex justify-end gap-1">
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                className="h-7 w-7"
+                                onClick={() => startEditCostCode(cc)}
+                                disabled={addingCostCode || editingCostCodeId !== null}
+                              >
+                                <Pencil className="h-3.5 w-3.5" />
+                              </Button>
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                className="h-7 w-7 text-destructive hover:text-destructive"
+                                onClick={() => setDeleteConfirm(cc)}
+                                disabled={addingCostCode || editingCostCodeId !== null}
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </Button>
+                            </div>
+                          </TableCell>
+                        </>
+                      )}
+                    </TableRow>
+                  ))}
+
+                  {/* Add new row */}
+                  {addingCostCode && (
+                    <TableRow>
+                      <TableCell>
+                        <Input
+                          value={newCostCode.code}
+                          onChange={(e) => setNewCostCode({ ...newCostCode, code: e.target.value })}
+                          className="h-8"
+                          placeholder="e.g. 999-100"
+                          autoFocus
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Input
+                          value={newCostCode.description}
+                          onChange={(e) => setNewCostCode({ ...newCostCode, description: e.target.value })}
+                          className="h-8"
+                          placeholder="Description"
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Input
+                          value={newCostCode.gp_cost_code_properties}
+                          onChange={(e) => setNewCostCode({ ...newCostCode, gp_cost_code_properties: e.target.value })}
+                          className="h-8"
+                          placeholder="Optional"
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Input
+                          value={newCostCode.uch_dept_properties}
+                          onChange={(e) => setNewCostCode({ ...newCostCode, uch_dept_properties: e.target.value })}
+                          className="h-8"
+                          placeholder="Optional"
+                        />
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex justify-end gap-1">
+                          <Button size="icon" variant="ghost" className="h-7 w-7" onClick={saveNewCostCode} disabled={costCodeSaving}>
+                            {costCodeSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4 text-green-600" />}
+                          </Button>
+                          <Button size="icon" variant="ghost" className="h-7 w-7" onClick={cancelAddCostCode}>
+                            <X className="h-4 w-4 text-muted-foreground" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  )}
+
+                  {costCodes.length === 0 && !addingCostCode && (
+                    <TableRow>
+                      <TableCell colSpan={5} className="text-center text-muted-foreground py-8">
+                        No cost codes found. Click "Add New" to create one.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Delete confirmation dialog */}
+      <AlertDialog open={!!deleteConfirm} onOpenChange={(open) => !open && setDeleteConfirm(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Cost Code</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete cost code <strong>{deleteConfirm?.code}</strong> ({deleteConfirm?.description})?
+              This cannot be undone. If this cost code is used by any quotes or purchase orders, deletion will be blocked.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={() => deleteConfirm && deleteCostCode(deleteConfirm)}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -60,6 +60,29 @@ export interface BacklogQuoteItem {
   line_items: BacklogLineItem[];
 }
 
+// ===== Cost Codes =====
+export interface CostCode {
+  id: number;
+  code: string;
+  description: string;
+  gp_cost_code_properties?: string | null;
+  uch_dept_properties?: string | null;
+}
+
+export interface CostCodeCreate {
+  code: string;
+  description: string;
+  gp_cost_code_properties?: string | null;
+  uch_dept_properties?: string | null;
+}
+
+export interface CostCodeUpdate {
+  code?: string;
+  description?: string;
+  gp_cost_code_properties?: string | null;
+  uch_dept_properties?: string | null;
+}
+
 // ===== Labor =====
 export interface Labor {
   id: number;
@@ -297,6 +320,8 @@ export interface Quote {
   work_description?: string | null;
   markup_control_enabled: boolean;  // Markup Discount Control toggle
   global_markup_percent?: number | null;  // Global markup % when control is enabled
+  cost_code_id?: number | null;
+  cost_code?: CostCode | null;
   line_items: QuoteLineItem[];
 }
 
@@ -304,11 +329,13 @@ export interface QuoteCreate {
   project_id: number;
   client_po_number?: string;
   work_description?: string;
+  cost_code_id?: number;
 }
 
 export interface QuoteUpdate {
   client_po_number?: string | null;
   work_description?: string | null;
+  cost_code_id?: number | null;
 }
 
 // ===== PO Line Items =====
@@ -349,6 +376,8 @@ export interface PurchaseOrder {
   work_description?: string | null;
   vendor_po_number?: string | null;
   expected_delivery_date?: string | null;
+  cost_code_id?: number | null;
+  cost_code?: CostCode | null;
   vendor: Profile;
   line_items: POLineItem[];
 }
@@ -360,6 +389,7 @@ export interface PurchaseOrderCreate {
   work_description?: string;
   vendor_po_number?: string;
   expected_delivery_date?: string;
+  cost_code_id?: number;
 }
 
 export interface PurchaseOrderUpdate {
@@ -367,6 +397,7 @@ export interface PurchaseOrderUpdate {
   work_description?: string | null;
   vendor_po_number?: string | null;
   expected_delivery_date?: string | null;
+  cost_code_id?: number | null;
 }
 
 // ===== PO Receiving =====


### PR DESCRIPTION
## Summary
- Adds a `cost_codes` reference table (~50 seeded entries) with full CRUD management in the Settings page
- Quotes and Purchase Orders now require a cost code assignment (FK, NOT NULL, backfilled to "200-000 - Supply of Hardware Series")
- SearchableSelect dropdown integrated into QuoteEditor (edit-mode gated) and POEditor (always editable)

## Changes
| Area | Files |
|------|-------|
| Migration | `008_add_cost_codes` — creates table, seeds data, adds FK columns with backfill |
| Backend models | `CostCode` model, FK + relationship on `Quote` and `PurchaseOrder` |
| Backend schemas | `CostCode` CRUD schemas, `cost_code_id`/`cost_code` on Quote/PO schemas |
| Backend routes | New `/cost-codes/` CRUD router with referential integrity on delete |
| Backend routes | `joinedload(cost_code)` across all Quote and PO query/reload points |
| Frontend types | `CostCode`, `CostCodeCreate`, `CostCodeUpdate` interfaces |
| Frontend API | `api.costCodes` namespace (getAll, get, create, update, delete) |
| Settings page | Inline-editable Cost Codes table with add/edit/delete |
| QuoteEditor | Cost code dropdown (disabled outside edit mode) |
| POEditor | Cost code in Order Details grid (always editable) |

## Test plan
- [ ] CI passes (migration integrity, backend tests, TypeScript check, frontend build)
- [ ] Settings page: verify ~50 cost codes load, inline edit works, delete blocked if referenced
- [ ] QuoteEditor: cost code dropdown appears, defaults to 200-000, saves on change (edit mode only)
- [ ] POEditor: cost code appears in Order Details, saves on change (always interactive)
- [ ] New Quote/PO creation defaults to 200-000 cost code
- [ ] Clone preserves cost_code_id from source

Closes #20