### PR TITLE
Allow decimal labor hours (Issue #25)

### DIFF
--- a/backend/alembic/versions/20260226_1400_009_labor_hours_decimal.py
+++ b/backend/alembic/versions/20260226_1400_009_labor_hours_decimal.py
@@ -1,0 +1,39 @@
+"""Convert labor.hours from Integer to Float for decimal hours
+
+Labor hours genuinely need fractional values (1.5 hrs, 0.25 hrs, etc.)
+while the original migration 003 converted all quantities to integers.
+This restores float support specifically for labor hours.
+
+Revision ID: 009_labor_hours_decimal
+Revises: 008_add_cost_codes
+Create Date: 2026-02-26
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '009_labor_hours_decimal'
+down_revision = '008_add_cost_codes'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    # Convert hours column from Integer to Float (Double Precision)
+    # Existing integer values are losslessly promoted (1 -> 1.0)
+    conn.execute(sa.text(
+        "ALTER TABLE labor ALTER COLUMN hours TYPE DOUBLE PRECISION USING hours::DOUBLE PRECISION"
+    ))
+
+
+def downgrade():
+    conn = op.get_bind()
+    # Round any fractional values before converting back to Integer
+    conn.execute(sa.text(
+        "UPDATE labor SET hours = ROUND(hours) WHERE hours != ROUND(hours)"
+    ))
+    conn.execute(sa.text(
+        "ALTER TABLE labor ALTER COLUMN hours TYPE INTEGER USING hours::INTEGER"
+    ))

--- a/backend/models.py
+++ b/backend/models.py
@@ -106,7 +106,7 @@ class Labor(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     description = Column(String, nullable=False)
-    hours = Column(Integer, nullable=False, default=1)  # Must be whole number
+    hours = Column(Float, nullable=False, default=1)
     rate = Column(Float, nullable=False)
     markup_percent = Column(Float, default=0.0)
     category_id = Column(Integer, ForeignKey('categories.id'))

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -162,20 +162,20 @@ class Part(PartBase):
 # ===== Labor Schemas =====
 class LaborBase(BaseModel):
     description: str
-    hours: int = 1  # Must be a positive whole number
+    hours: float = 1
     rate: float
     markup_percent: float = 0.0
     category_id: Optional[int] = None
 
     @validator('hours', pre=True)
-    def hours_must_be_positive_integer(cls, v) -> int:
-        # Check if value is a whole number before coercion
-        if isinstance(v, float) and not v.is_integer():
-            raise ValueError('Hours must be a positive whole number')
-        v_int = int(v)
-        if v_int <= 0:
-            raise ValueError('Hours must be a positive whole number')
-        return v_int
+    def hours_must_be_positive(cls, v) -> float:
+        v_float = float(v)
+        if v_float <= 0:
+            raise ValueError('Hours must be a positive number')
+        # Enforce max 2 decimal places
+        if round(v_float, 2) != v_float:
+            raise ValueError('Hours cannot have more than 2 decimal places')
+        return round(v_float, 2)
 
 
 class LaborCreate(LaborBase):
@@ -184,22 +184,22 @@ class LaborCreate(LaborBase):
 
 class LaborUpdate(BaseModel):
     description: Optional[str] = None
-    hours: Optional[int] = None  # Must be a positive whole number
+    hours: Optional[float] = None
     rate: Optional[float] = None
     markup_percent: Optional[float] = None
     category_id: Optional[int] = None
 
     @validator('hours', pre=True)
-    def hours_must_be_positive_integer(cls, v) -> Optional[int]:
+    def hours_must_be_positive(cls, v) -> Optional[float]:
         if v is None:
             return None
-        # Check if value is a whole number before coercion
-        if isinstance(v, float) and not v.is_integer():
-            raise ValueError('Hours must be a positive whole number')
-        v_int = int(v)
-        if v_int <= 0:
-            raise ValueError('Hours must be a positive whole number')
-        return v_int
+        v_float = float(v)
+        if v_float <= 0:
+            raise ValueError('Hours must be a positive number')
+        # Enforce max 2 decimal places
+        if round(v_float, 2) != v_float:
+            raise ValueError('Hours cannot have more than 2 decimal places')
+        return round(v_float, 2)
 
 
 class Labor(LaborBase):

--- a/frontend/src/components/forms/LaborForm.tsx
+++ b/frontend/src/components/forms/LaborForm.tsx
@@ -34,7 +34,7 @@ export function LaborForm({ labor, onSuccess, onCancel }: LaborFormProps) {
   }, [labor])
 
   // Calculate labor cost (use parsed values or 0 for display)
-  const hoursNum = parseInt(hours, 10) || 0
+  const hoursNum = parseFloat(hours) || 0
   const rateNum = parseFloat(rate) || 0
   const markupNum = parseFloat(markupPercent) || 0
   const laborCost = hoursNum * rateNum * (1 + markupNum / 100)
@@ -44,10 +44,16 @@ export function LaborForm({ labor, onSuccess, onCancel }: LaborFormProps) {
     setLoading(true)
     setError(null)
 
-    // Validate hours is a positive integer
-    const hoursValue = parseInt(hours, 10)
-    if (!Number.isInteger(hoursValue) || hoursValue <= 0) {
-      setError("Hours must be a positive whole number (e.g., 1, 2, 3...)")
+    // Validate hours is a positive number with max 2 decimal places
+    const hoursValue = parseFloat(hours)
+    if (isNaN(hoursValue) || hoursValue <= 0) {
+      setError("Hours must be a positive number")
+      setLoading(false)
+      return
+    }
+    const decimalPart = hours.split('.')[1]
+    if (decimalPart && decimalPart.length > 2) {
+      setError("Hours cannot have more than 2 decimal places")
       setLoading(false)
       return
     }
@@ -98,8 +104,8 @@ export function LaborForm({ labor, onSuccess, onCancel }: LaborFormProps) {
           <Input
             id="hours"
             type="number"
-            step="1"
-            min="1"
+            step="0.25"
+            min="0.01"
             value={hours}
             onChange={(e) => setHours(e.target.value)}
             placeholder="1"


### PR DESCRIPTION
## Summary
- Convert `labor.hours` from integer to float with a 2-decimal-place limit
- Parts keep integer quantities; labor hours now support fractional values (1.5, 0.25, 8.75)
- New Alembic migration 009 with safe downgrade (rounds before casting back)

## Test plan
- [ ] CI passes (Backend, Frontend, Migration Integrity)
- [ ] Create a labor item with hours = 1.5, verify it saves correctly
- [ ] Edit existing labor item to fractional hours, verify quote totals update
- [ ] Verify form rejects > 2 decimal places (e.g. 1.333)

Closes #25