### PR TITLE
Modified price flow with vendor pricebook and section markup (Issue #26)

### DIFF
--- a/backend/alembic/versions/20260227_010_price_flow_changes.py
+++ b/backend/alembic/versions/20260227_010_price_flow_changes.py
@@ -1,0 +1,121 @@
+"""Add vendor pricebook fields, section-level markup, and per-line-item markup
+
+- parts: add vendor_id, list_price, discount_percent
+- profiles: add default_discount_percent
+- quote_line_items: add markup_percent
+- quotes: add parts_markup_percent, labor_markup_percent, misc_markup_percent
+  (replace global_markup_percent — data migrated before drop)
+- quote_line_item_snapshots: add markup_percent
+
+Revision ID: 010_price_flow_changes
+Revises: 009_labor_hours_decimal
+Create Date: 2026-02-27
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '010_price_flow_changes'
+down_revision = '009_labor_hours_decimal'
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table, column):
+    """Check if a column already exists (idempotent guard)."""
+    conn = op.get_bind()
+    result = conn.execute(sa.text(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_name = :table AND column_name = :column"
+    ), {"table": table, "column": column})
+    return result.fetchone() is not None
+
+
+def upgrade():
+    # 1. Part model: add vendor linkage + pricebook fields
+    if not _column_exists('parts', 'vendor_id'):
+        op.add_column('parts', sa.Column('vendor_id', sa.Integer(), nullable=True))
+        op.create_foreign_key('fk_parts_vendor_id', 'parts', 'profiles', ['vendor_id'], ['id'])
+
+    if not _column_exists('parts', 'list_price'):
+        op.add_column('parts', sa.Column('list_price', sa.Float(), nullable=True))
+
+    if not _column_exists('parts', 'discount_percent'):
+        op.add_column('parts', sa.Column('discount_percent', sa.Float(), nullable=True))
+
+    # 2. Profile (vendor): add default discount
+    if not _column_exists('profiles', 'default_discount_percent'):
+        op.add_column('profiles', sa.Column('default_discount_percent', sa.Float(), nullable=True))
+
+    # 3. QuoteLineItem: add per-line-item markup
+    if not _column_exists('quote_line_items', 'markup_percent'):
+        op.add_column('quote_line_items', sa.Column('markup_percent', sa.Float(), nullable=True))
+
+    # 4. Quote: add section-level markup columns, migrate data, drop old column
+    if not _column_exists('quotes', 'parts_markup_percent'):
+        op.add_column('quotes', sa.Column('parts_markup_percent', sa.Float(), nullable=True))
+
+    if not _column_exists('quotes', 'labor_markup_percent'):
+        op.add_column('quotes', sa.Column('labor_markup_percent', sa.Float(), nullable=True))
+
+    if not _column_exists('quotes', 'misc_markup_percent'):
+        op.add_column('quotes', sa.Column('misc_markup_percent', sa.Float(), nullable=True))
+
+    # Migrate existing data: copy global → all three sections
+    if _column_exists('quotes', 'global_markup_percent'):
+        conn = op.get_bind()
+        conn.execute(sa.text("""
+            UPDATE quotes
+            SET parts_markup_percent = global_markup_percent,
+                labor_markup_percent = global_markup_percent,
+                misc_markup_percent = global_markup_percent
+            WHERE markup_control_enabled = true AND global_markup_percent IS NOT NULL
+        """))
+        op.drop_column('quotes', 'global_markup_percent')
+
+    # 5. QuoteLineItemSnapshot: add markup_percent
+    if not _column_exists('quote_line_item_snapshots', 'markup_percent'):
+        op.add_column('quote_line_item_snapshots', sa.Column('markup_percent', sa.Float(), nullable=True))
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    # 5. Drop markup_percent from snapshots
+    if _column_exists('quote_line_item_snapshots', 'markup_percent'):
+        op.drop_column('quote_line_item_snapshots', 'markup_percent')
+
+    # 4. Restore global_markup_percent on quotes, migrate data back, drop section columns
+    if not _column_exists('quotes', 'global_markup_percent'):
+        op.add_column('quotes', sa.Column('global_markup_percent', sa.Float(), nullable=True))
+
+    # Copy parts_markup_percent back to global (best approximation)
+    if _column_exists('quotes', 'parts_markup_percent'):
+        conn.execute(sa.text("""
+            UPDATE quotes
+            SET global_markup_percent = parts_markup_percent
+            WHERE markup_control_enabled = true AND parts_markup_percent IS NOT NULL
+        """))
+        op.drop_column('quotes', 'misc_markup_percent')
+        op.drop_column('quotes', 'labor_markup_percent')
+        op.drop_column('quotes', 'parts_markup_percent')
+
+    # 3. Drop markup_percent from quote_line_items
+    if _column_exists('quote_line_items', 'markup_percent'):
+        op.drop_column('quote_line_items', 'markup_percent')
+
+    # 2. Drop default_discount_percent from profiles
+    if _column_exists('profiles', 'default_discount_percent'):
+        op.drop_column('profiles', 'default_discount_percent')
+
+    # 1. Drop pricebook fields from parts
+    if _column_exists('parts', 'discount_percent'):
+        op.drop_column('parts', 'discount_percent')
+
+    if _column_exists('parts', 'list_price'):
+        op.drop_column('parts', 'list_price')
+
+    if _column_exists('parts', 'vendor_id'):
+        op.drop_constraint('fk_parts_vendor_id', 'parts', type_='foreignkey')
+        op.drop_column('parts', 'vendor_id')

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,7 +11,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from database import engine, Base, SessionLocal
-from routes import parts, labor, profiles, projects, quotes, purchase_orders, discount_codes, miscellaneous, invoices, company_settings, reports, cost_codes
+from routes import parts, labor, profiles, projects, quotes, purchase_orders, discount_codes, miscellaneous, invoices, company_settings, reports, cost_codes, vendor_pricebook
 from seed import seed_system_items
 
 
@@ -112,6 +112,7 @@ app.include_router(invoices.router)
 app.include_router(company_settings.router)
 app.include_router(reports.router)
 app.include_router(cost_codes.router)
+app.include_router(vendor_pricebook.router)
 
 
 @app.get("/")

--- a/backend/models.py
+++ b/backend/models.py
@@ -53,6 +53,7 @@ class Profile(Base):
     address = Column(String, nullable=False)
     postal_code = Column(String, nullable=False)
     website = Column(String, nullable=True)  # Optional URL to official website
+    default_discount_percent = Column(Float, nullable=True)  # Default vendor discount %
 
     # Relationships
     contacts = relationship("Contact", back_populates="profile", cascade="all, delete-orphan")
@@ -95,10 +96,14 @@ class Part(Base):
     cost = Column(Float, nullable=False)
     markup_percent = Column(Float, default=0.0)
     category_id = Column(Integer, ForeignKey('categories.id'))
+    vendor_id = Column(Integer, ForeignKey('profiles.id'), nullable=True)
+    list_price = Column(Float, nullable=True)
+    discount_percent = Column(Float, nullable=True)  # Per-part discount override (nullable)
 
     # Relationships
     category = relationship("Category", back_populates="parts")
     labor_items = relationship("Labor", secondary=part_labor_link, back_populates="parts")
+    vendor = relationship("Profile")
 
 
 class Labor(Base):
@@ -182,7 +187,9 @@ class Quote(Base):
     client_po_number = Column(String, nullable=True)  # Client's PO number (required for invoicing)
     work_description = Column(String, nullable=True)  # Optional work description
     markup_control_enabled = Column(Boolean, default=False)  # Markup Discount Control toggle
-    global_markup_percent = Column(Float, nullable=True)  # Global markup % when control is enabled
+    parts_markup_percent = Column(Float, nullable=True)  # Section-level markup for parts
+    labor_markup_percent = Column(Float, nullable=True)  # Section-level markup for labor
+    misc_markup_percent = Column(Float, nullable=True)  # Section-level markup for misc
     cost_code_id = Column(Integer, ForeignKey('cost_codes.id'), nullable=False)
 
     # Relationships
@@ -212,6 +219,7 @@ class QuoteLineItem(Base):
     pms_percent = Column(Float, nullable=True)  # Percentage value for PMS % items (null for PMS $ or non-PMS)
     original_markup_percent = Column(Float, nullable=True)  # Individual markup before global override
     base_cost = Column(Float, nullable=True)  # Base cost used for recalculation
+    markup_percent = Column(Float, nullable=True)  # Per-line-item markup (when global OFF)
 
     # Relationships
     quote = relationship("Quote", back_populates="line_items")
@@ -438,6 +446,7 @@ class QuoteLineItemSnapshot(Base):
     pms_percent = Column(Float, nullable=True)  # Percentage value for PMS % items
     original_markup_percent = Column(Float, nullable=True)  # Individual markup before global override
     base_cost = Column(Float, nullable=True)  # Base cost used for recalculation
+    markup_percent = Column(Float, nullable=True)  # Per-line-item markup
 
     # Relationships
     snapshot = relationship("QuoteSnapshot", back_populates="line_item_states")

--- a/backend/routes/parts.py
+++ b/backend/routes/parts.py
@@ -3,10 +3,23 @@ from sqlalchemy.orm import Session, joinedload
 from typing import List
 
 from database import get_db
-from models import Part, Labor
+from models import Part, Labor, Profile
 from schemas import PartCreate, PartUpdate, Part as PartSchema, PartWithLabor
 
 router = APIRouter(prefix="/parts", tags=["parts"])
+
+
+def auto_calculate_cost(part: Part, db: Session) -> None:
+    """Auto-calculate cost from list_price and vendor discount when applicable."""
+    if part.list_price is not None and part.vendor_id:
+        vendor = db.query(Profile).filter(Profile.id == part.vendor_id).first()
+        if vendor:
+            effective_discount = (
+                part.discount_percent
+                if part.discount_percent is not None
+                else (vendor.default_discount_percent or 0)
+            )
+            part.cost = part.list_price * (1 - effective_discount / 100)
 
 
 @router.get("/", response_model=List[PartWithLabor])
@@ -14,7 +27,7 @@ def get_all_parts(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)
     """Get all parts with their linked labor items."""
     parts = (
         db.query(Part)
-        .options(joinedload(Part.labor_items))
+        .options(joinedload(Part.labor_items), joinedload(Part.vendor))
         .offset(skip)
         .limit(limit)
         .all()
@@ -27,7 +40,7 @@ def get_part(part_id: int, db: Session = Depends(get_db)):
     """Get a single part by ID with linked labor items."""
     part = (
         db.query(Part)
-        .options(joinedload(Part.labor_items))
+        .options(joinedload(Part.labor_items), joinedload(Part.vendor))
         .filter(Part.id == part_id)
         .first()
     )
@@ -63,13 +76,25 @@ def create_part(part_data: PartCreate, db: Session = Depends(get_db)):
     # Round markup_percent to 2 decimal places
     formatted_markup = round(part_data.markup_percent, 2) if part_data.markup_percent else 0.0
 
+    # Validate vendor if provided
+    if part_data.vendor_id:
+        vendor = db.query(Profile).filter(Profile.id == part_data.vendor_id).first()
+        if not vendor:
+            raise HTTPException(status_code=400, detail="Vendor not found")
+
     db_part = Part(
         part_number=part_data.part_number,
         description=part_data.description,
         cost=part_data.cost,
         markup_percent=formatted_markup,
-        category_id=part_data.category_id
+        category_id=part_data.category_id,
+        vendor_id=part_data.vendor_id,
+        list_price=part_data.list_price,
+        discount_percent=part_data.discount_percent,
     )
+
+    # Auto-calculate cost from list_price + vendor discount
+    auto_calculate_cost(db_part, db)
 
     # Link the labor items
     db_part.labor_items = labor_to_link
@@ -106,6 +131,18 @@ def update_part(part_id: int, part_data: PartUpdate, db: Session = Depends(get_d
         db_part.markup_percent = round(part_data.markup_percent, 2)
     if part_data.category_id is not None:
         db_part.category_id = part_data.category_id
+    if part_data.vendor_id is not None:
+        vendor = db.query(Profile).filter(Profile.id == part_data.vendor_id).first()
+        if not vendor:
+            raise HTTPException(status_code=400, detail="Vendor not found")
+        db_part.vendor_id = part_data.vendor_id
+    if part_data.list_price is not None:
+        db_part.list_price = part_data.list_price
+    if part_data.discount_percent is not None:
+        db_part.discount_percent = part_data.discount_percent
+
+    # Auto-calculate cost from list_price + vendor discount
+    auto_calculate_cost(db_part, db)
 
     # Update labor links if provided
     if part_data.linked_labor_ids is not None:

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -50,7 +50,8 @@ def create_profile(profile_data: ProfileCreate, db: Session = Depends(get_db)):
         pst=profile_data.pst,
         address=profile_data.address,
         postal_code=profile_data.postal_code,
-        website=profile_data.website
+        website=profile_data.website,
+        default_discount_percent=getattr(profile_data, 'default_discount_percent', None)
     )
     db.add(db_profile)
     db.flush()  # Get the profile ID
@@ -100,6 +101,8 @@ def update_profile(profile_id: int, profile_data: ProfileUpdate, db: Session = D
         db_profile.postal_code = profile_data.postal_code
     if profile_data.website is not None:
         db_profile.website = profile_data.website
+    if profile_data.default_discount_percent is not None:
+        db_profile.default_discount_percent = profile_data.default_discount_percent
 
     db.commit()
     db.refresh(db_profile)

--- a/backend/routes/quotes.py
+++ b/backend/routes/quotes.py
@@ -80,7 +80,8 @@ def create_snapshot(
             is_pms=item.is_pms,
             pms_percent=item.pms_percent,
             original_markup_percent=item.original_markup_percent,
-            base_cost=item.base_cost
+            base_cost=item.base_cost,
+            markup_percent=item.markup_percent
         )
         db.add(item_snapshot)
 
@@ -428,7 +429,9 @@ def clone_quote(quote_id: int, db: Session = Depends(get_db)):
         client_po_number=source_quote.client_po_number,
         work_description=source_quote.work_description,
         markup_control_enabled=False,  # Reset to disabled
-        global_markup_percent=None,  # Reset to None
+        parts_markup_percent=None,
+        labor_markup_percent=None,
+        misc_markup_percent=None,
         cost_code_id=source_quote.cost_code_id,
     )
     db.add(new_quote)
@@ -478,6 +481,28 @@ def clone_quote(quote_id: int, db: Session = Depends(get_db)):
 
 # ==================== Markup Discount Control ====================
 
+def _get_section_markup(item_type: str, request: MarkupControlToggleRequest) -> float:
+    """Get the appropriate section-level markup % for a line item type."""
+    if item_type == "part":
+        return request.parts_markup_percent or 0
+    elif item_type == "labor":
+        return request.labor_markup_percent or 0
+    elif item_type == "misc":
+        return request.misc_markup_percent or 0
+    return 0
+
+
+def _get_section_markup_from_quote(item_type: str, quote: Quote) -> float:
+    """Get the appropriate section-level markup % from a quote's stored values."""
+    if item_type == "part":
+        return quote.parts_markup_percent or 0
+    elif item_type == "labor":
+        return quote.labor_markup_percent or 0
+    elif item_type == "misc":
+        return quote.misc_markup_percent or 0
+    return 0
+
+
 @router.post("/{quote_id}/markup-control", response_model=MarkupControlToggleResponse)
 def toggle_markup_control(
     quote_id: int,
@@ -489,9 +514,10 @@ def toggle_markup_control(
 
     When enabling (request.enabled=True):
     - Validates no discount codes are applied to any line items
-    - Requires global_markup_percent to be provided
+    - Requires section-level markup percentages (parts/labor/misc)
     - Stores original markups and base costs for each line item
-    - Recalculates all unit_prices using the global markup
+    - Recalculates all unit_prices using the section-appropriate markup
+    - Stores markup_percent on each line item
     - PMS items are EXEMPT and not recalculated
 
     When disabling (request.enabled=False):
@@ -511,33 +537,48 @@ def toggle_markup_control(
     check_quote_not_frozen(quote_id, db)
 
     if request.enabled:
-        if request.global_markup_percent is None:
+        if request.parts_markup_percent is None and request.labor_markup_percent is None and request.misc_markup_percent is None:
             raise HTTPException(
                 status_code=400,
-                detail="global_markup_percent is required when enabling or updating markup control"
+                detail="At least one section markup percentage is required when enabling markup control"
             )
 
         if quote.markup_control_enabled:
-            # UPDATE MODE: Already enabled, just update the percent
-            old_percent = quote.global_markup_percent
-            quote.global_markup_percent = request.global_markup_percent
+            # UPDATE MODE: Already enabled, just update the percents
+            old_parts = quote.parts_markup_percent
+            old_labor = quote.labor_markup_percent
+            old_misc = quote.misc_markup_percent
+
+            quote.parts_markup_percent = request.parts_markup_percent if request.parts_markup_percent is not None else quote.parts_markup_percent
+            quote.labor_markup_percent = request.labor_markup_percent if request.labor_markup_percent is not None else quote.labor_markup_percent
+            quote.misc_markup_percent = request.misc_markup_percent if request.misc_markup_percent is not None else quote.misc_markup_percent
 
             # Recalculate using EXISTING base_cost (don't recalculate base_cost)
             for item in quote.line_items:
                 if item.is_pms:
                     continue  # Skip PMS items - they are EXEMPT
+                section_markup = _get_section_markup_from_quote(item.item_type, quote)
+                item.markup_percent = section_markup
                 if item.base_cost is not None:
-                    item.unit_price = item.base_cost * (1 + request.global_markup_percent / 100)
+                    item.unit_price = item.base_cost * (1 + section_markup / 100)
 
             # Create snapshot
+            desc_parts = []
+            if request.parts_markup_percent is not None and request.parts_markup_percent != old_parts:
+                desc_parts.append(f"Parts: {old_parts}% -> {request.parts_markup_percent}%")
+            if request.labor_markup_percent is not None and request.labor_markup_percent != old_labor:
+                desc_parts.append(f"Labour: {old_labor}% -> {request.labor_markup_percent}%")
+            if request.misc_markup_percent is not None and request.misc_markup_percent != old_misc:
+                desc_parts.append(f"Misc: {old_misc}% -> {request.misc_markup_percent}%")
+
             create_snapshot(
                 db=db,
                 quote=quote,
                 action_type="edit",
-                action_description=f"Updated global markup from {old_percent}% to {request.global_markup_percent}%"
+                action_description=f"Updated section markup ({', '.join(desc_parts) if desc_parts else 'no change'})"
             )
 
-            message = f"Global markup updated to {request.global_markup_percent}%"
+            message = f"Section markup updated (Parts: {quote.parts_markup_percent}%, Labour: {quote.labor_markup_percent}%, Misc: {quote.misc_markup_percent}%)"
 
         else:
             # ENABLE MODE: First time enabling
@@ -552,9 +593,11 @@ def toggle_markup_control(
                     detail="Remove discount codes first to enable this feature"
                 )
 
-            # Enable markup control
+            # Enable markup control with section-level percents
             quote.markup_control_enabled = True
-            quote.global_markup_percent = request.global_markup_percent
+            quote.parts_markup_percent = request.parts_markup_percent or 0
+            quote.labor_markup_percent = request.labor_markup_percent or 0
+            quote.misc_markup_percent = request.misc_markup_percent or 0
 
             # Recalculate all line items
             for item in quote.line_items:
@@ -565,24 +608,30 @@ def toggle_markup_control(
                 item.original_markup_percent = get_original_markup(item, db)
                 item.base_cost = calculate_base_cost(item, db)
 
-                # Recalculate unit_price with global markup
+                # Apply section-appropriate markup
+                section_markup = _get_section_markup_from_quote(item.item_type, quote)
+                item.markup_percent = section_markup
+
+                # Recalculate unit_price with section markup
                 if item.base_cost:
-                    item.unit_price = item.base_cost * (1 + request.global_markup_percent / 100)
+                    item.unit_price = item.base_cost * (1 + section_markup / 100)
 
             # Create snapshot
             create_snapshot(
                 db=db,
                 quote=quote,
                 action_type="edit",
-                action_description=f"Enabled Markup Discount Control ({request.global_markup_percent}%)"
+                action_description=f"Enabled Markup Control (Parts: {quote.parts_markup_percent}%, Labour: {quote.labor_markup_percent}%, Misc: {quote.misc_markup_percent}%)"
             )
 
-            message = f"Markup Discount Control enabled with {request.global_markup_percent}% markup"
+            message = f"Markup Control enabled (Parts: {quote.parts_markup_percent}%, Labour: {quote.labor_markup_percent}%, Misc: {quote.misc_markup_percent}%)"
 
     else:
         # Disable markup control
         quote.markup_control_enabled = False
-        quote.global_markup_percent = None
+        quote.parts_markup_percent = None
+        quote.labor_markup_percent = None
+        quote.misc_markup_percent = None
 
         # Restore original markups
         for item in quote.line_items:
@@ -592,16 +641,17 @@ def toggle_markup_control(
             # Restore unit_price using original markup
             if item.base_cost is not None and item.original_markup_percent is not None:
                 item.unit_price = item.base_cost * (1 + item.original_markup_percent / 100)
+            item.markup_percent = None
 
         # Create snapshot
         create_snapshot(
             db=db,
             quote=quote,
             action_type="edit",
-            action_description="Disabled Markup Discount Control (restored individual markups)"
+            action_description="Disabled Markup Control (restored individual markups)"
         )
 
-        message = "Markup Discount Control disabled, original markups restored"
+        message = "Markup Control disabled, original markups restored"
 
     db.commit()
 
@@ -732,12 +782,14 @@ def add_quote_line(quote_id: int, line_data: QuoteLineItemCreate, db: Session = 
     db.add(db_line)
     db.flush()  # Need ID for calculate_base_cost
 
-    # If markup control is enabled, apply global markup to new items
+    # If markup control is enabled, apply section markup to new items
     if quote.markup_control_enabled and not line_data.is_pms:
         db_line.original_markup_percent = get_original_markup(db_line, db)
         db_line.base_cost = calculate_base_cost(db_line, db)
-        if db_line.base_cost and quote.global_markup_percent is not None:
-            db_line.unit_price = db_line.base_cost * (1 + quote.global_markup_percent / 100)
+        section_markup = _get_section_markup_from_quote(db_line.item_type, quote)
+        db_line.markup_percent = section_markup
+        if db_line.base_cost:
+            db_line.unit_price = db_line.base_cost * (1 + section_markup / 100)
 
     # Create snapshot after adding line item
     item_desc = get_line_item_description(db_line, db)
@@ -923,7 +975,8 @@ def delete_quote_line(quote_id: int, line_id: int, db: Session = Depends(get_db)
             is_pms=item.is_pms,
             pms_percent=item.pms_percent,
             original_markup_percent=item.original_markup_percent,
-            base_cost=item.base_cost
+            base_cost=item.base_cost,
+            markup_percent=item.markup_percent
         )
         db.add(item_snapshot)
 
@@ -1049,12 +1102,20 @@ def commit_edits(
             db.add(new_item)
             db.flush()
 
-            # Apply markup control if enabled
-            if quote.markup_control_enabled and not change.is_pms:
-                new_item.original_markup_percent = get_original_markup(new_item, db)
+            # Compute and store base_cost and markup_percent
+            if not change.is_pms:
                 new_item.base_cost = calculate_base_cost(new_item, db)
-                if new_item.base_cost and quote.global_markup_percent is not None:
-                    new_item.unit_price = new_item.base_cost * (1 + quote.global_markup_percent / 100)
+                new_item.original_markup_percent = get_original_markup(new_item, db)
+
+                if quote.markup_control_enabled:
+                    # Use section-level markup
+                    section_markup = _get_section_markup_from_quote(new_item.item_type, quote)
+                    new_item.markup_percent = section_markup
+                    if new_item.base_cost:
+                        new_item.unit_price = new_item.base_cost * (1 + section_markup / 100)
+                else:
+                    # Use the inventory item's markup_percent
+                    new_item.markup_percent = new_item.original_markup_percent
 
             item_desc = get_line_item_description(new_item, db)
             change_descriptions.append(f"Added {item_desc} (qty: {quantity})")
@@ -1124,6 +1185,21 @@ def commit_edits(
             if change.description is not None and change.description != line_item.description:
                 item_changes.append("updated description")
                 line_item.description = change.description
+
+            # Update markup_percent if provided (only when global toggle is OFF)
+            if change.markup_percent is not None and change.markup_percent != line_item.markup_percent:
+                if quote.markup_control_enabled:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Cannot change per-item markup while Markup Control is enabled"
+                    )
+                item_changes.append(f"markup: {line_item.markup_percent or 0:.1f}% -> {change.markup_percent:.1f}%")
+                line_item.markup_percent = change.markup_percent
+                # Recalculate unit_price from base_cost
+                if line_item.base_cost is None:
+                    line_item.base_cost = calculate_base_cost(line_item, db)
+                if line_item.base_cost:
+                    line_item.unit_price = line_item.base_cost * (1 + change.markup_percent / 100)
 
             if item_changes:
                 change_descriptions.append(f"{item_desc}: {', '.join(item_changes)}")
@@ -1526,7 +1602,8 @@ def revert_to_snapshot(quote_id: int, version: int, db: Session = Depends(get_db
             is_pms=item.is_pms,
             pms_percent=item.pms_percent,
             original_markup_percent=item.original_markup_percent,
-            base_cost=item.base_cost
+            base_cost=item.base_cost,
+            markup_percent=item.markup_percent
         )
         db.add(item_snapshot)
 

--- a/backend/routes/vendor_pricebook.py
+++ b/backend/routes/vendor_pricebook.py
@@ -1,0 +1,139 @@
+import csv
+import io
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import Profile, Part
+from schemas import PricebookImportResult
+
+router = APIRouter(prefix="/vendors", tags=["vendor_pricebook"])
+
+
+@router.post("/{vendor_id}/pricebook/import", response_model=PricebookImportResult)
+async def import_pricebook(
+    vendor_id: int,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db)
+):
+    """
+    Import a CSV pricebook for a vendor.
+
+    Required columns: part_number, list_price
+    Optional columns: description, discount_percent
+
+    For each row:
+    - If a Part with that part_number exists: update list_price, discount_percent, vendor_id, recalculate cost
+    - If not found: create new Part with the data
+    """
+    vendor = db.query(Profile).filter(Profile.id == vendor_id).first()
+    if not vendor:
+        raise HTTPException(status_code=404, detail="Vendor not found")
+
+    if vendor.type.value != "vendor":
+        raise HTTPException(status_code=400, detail="Profile is not a vendor")
+
+    # Read and parse CSV
+    try:
+        content = await file.read()
+        text = content.decode("utf-8-sig")  # Handle BOM
+        reader = csv.DictReader(io.StringIO(text))
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Failed to parse CSV: {str(e)}")
+
+    # Validate required columns
+    if not reader.fieldnames:
+        raise HTTPException(status_code=400, detail="CSV file is empty or has no headers")
+
+    fieldnames_lower = [f.strip().lower() for f in reader.fieldnames]
+    if "part_number" not in fieldnames_lower or "list_price" not in fieldnames_lower:
+        raise HTTPException(
+            status_code=400,
+            detail="CSV must have 'part_number' and 'list_price' columns"
+        )
+
+    # Build column index mapping (case-insensitive)
+    col_map = {}
+    for original in reader.fieldnames:
+        col_map[original.strip().lower()] = original
+
+    created = 0
+    updated = 0
+    errors = []
+
+    for row_num, row in enumerate(reader, start=2):  # Start at 2 (header is row 1)
+        part_number = row.get(col_map.get("part_number", ""), "").strip()
+        list_price_str = row.get(col_map.get("list_price", ""), "").strip()
+
+        if not part_number:
+            errors.append(f"Row {row_num}: missing part_number")
+            continue
+
+        if not list_price_str:
+            errors.append(f"Row {row_num}: missing list_price for {part_number}")
+            continue
+
+        try:
+            list_price = float(list_price_str)
+        except ValueError:
+            errors.append(f"Row {row_num}: invalid list_price '{list_price_str}' for {part_number}")
+            continue
+
+        # Optional fields
+        description = row.get(col_map.get("description", ""), "").strip() or None
+        discount_str = row.get(col_map.get("discount_percent", ""), "").strip()
+        discount_percent = None
+        if discount_str:
+            try:
+                discount_percent = float(discount_str)
+            except ValueError:
+                errors.append(f"Row {row_num}: invalid discount_percent '{discount_str}' for {part_number}")
+                continue
+
+        # Find or create part
+        existing = db.query(Part).filter(Part.part_number == part_number).first()
+
+        if existing:
+            existing.list_price = list_price
+            existing.vendor_id = vendor_id
+            if discount_percent is not None:
+                existing.discount_percent = discount_percent
+            if description:
+                existing.description = description
+
+            # Auto-calculate cost
+            effective_discount = (
+                existing.discount_percent
+                if existing.discount_percent is not None
+                else (vendor.default_discount_percent or 0)
+            )
+            existing.cost = list_price * (1 - effective_discount / 100)
+            updated += 1
+        else:
+            effective_discount = (
+                discount_percent
+                if discount_percent is not None
+                else (vendor.default_discount_percent or 0)
+            )
+            cost = list_price * (1 - effective_discount / 100)
+
+            new_part = Part(
+                part_number=part_number,
+                description=description or part_number,
+                list_price=list_price,
+                cost=cost,
+                vendor_id=vendor_id,
+                discount_percent=discount_percent,
+                markup_percent=0.0,
+            )
+            db.add(new_part)
+            created += 1
+
+    db.commit()
+
+    return PricebookImportResult(
+        created=created,
+        updated=updated,
+        errors=errors,
+    )

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -137,6 +137,9 @@ class PartBase(BaseModel):
     cost: float
     markup_percent: float = 0.0
     category_id: Optional[int] = None
+    vendor_id: Optional[int] = None
+    list_price: Optional[float] = None
+    discount_percent: Optional[float] = None  # Per-part discount override
 
 
 class PartCreate(PartBase):
@@ -150,6 +153,9 @@ class PartUpdate(BaseModel):
     markup_percent: Optional[float] = None
     category_id: Optional[int] = None
     linked_labor_ids: Optional[List[int]] = None
+    vendor_id: Optional[int] = None
+    list_price: Optional[float] = None
+    discount_percent: Optional[float] = None
 
 
 class Part(PartBase):
@@ -321,6 +327,7 @@ class ProfileBase(BaseModel):
     address: str
     postal_code: str
     website: Optional[str] = None
+    default_discount_percent: Optional[float] = None
 
 
 class ProfileCreate(ProfileBase):
@@ -340,6 +347,7 @@ class ProfileUpdate(BaseModel):
     address: Optional[str] = None
     postal_code: Optional[str] = None
     website: Optional[str] = None
+    default_discount_percent: Optional[float] = None
 
 
 class Profile(ProfileBase):
@@ -395,6 +403,7 @@ class QuoteLineItemBase(BaseModel):
     pms_percent: Optional[float] = None  # Percentage value for PMS % items
     original_markup_percent: Optional[float] = None  # Individual markup before global override
     base_cost: Optional[float] = None  # Base cost used for recalculation
+    markup_percent: Optional[float] = None  # Per-line-item markup (when global OFF)
 
     @validator('quantity', pre=True)
     def quantity_must_be_positive_integer(cls, v) -> int:
@@ -450,7 +459,9 @@ class QuoteBase(BaseModel):
     client_po_number: Optional[str] = None
     work_description: Optional[str] = None
     markup_control_enabled: bool = False  # Markup Discount Control toggle
-    global_markup_percent: Optional[float] = None  # Global markup % when control is enabled
+    parts_markup_percent: Optional[float] = None  # Section-level markup for parts
+    labor_markup_percent: Optional[float] = None  # Section-level markup for labor
+    misc_markup_percent: Optional[float] = None  # Section-level markup for misc
 
 
 class QuoteCreate(BaseModel):
@@ -811,6 +822,7 @@ class QuoteLineItemSnapshotBase(BaseModel):
     pms_percent: Optional[float] = None  # Percentage value for PMS % items
     original_markup_percent: Optional[float] = None  # Individual markup before global override
     base_cost: Optional[float] = None  # Base cost used for recalculation
+    markup_percent: Optional[float] = None  # Per-line-item markup
 
     @validator('quantity', 'qty_pending', 'qty_fulfilled', pre=True)
     def quantities_must_be_whole_numbers(cls, v) -> int:
@@ -856,7 +868,9 @@ class RevertPreview(BaseModel):
 # ===== Markup Control Toggle Schemas =====
 class MarkupControlToggleRequest(BaseModel):
     enabled: bool
-    global_markup_percent: Optional[float] = None  # Required when enabled=True
+    parts_markup_percent: Optional[float] = None  # Required when enabled=True
+    labor_markup_percent: Optional[float] = None
+    misc_markup_percent: Optional[float] = None
 
 
 class MarkupControlToggleResponse(BaseModel):
@@ -881,6 +895,7 @@ class StagedLineItemChange(BaseModel):
     unit_price: Optional[float] = None
     is_pms: bool = False
     pms_percent: Optional[float] = None
+    markup_percent: Optional[float] = None  # Per-line-item markup
 
     @validator('quantity', pre=True)
     def quantity_must_be_positive_integer(cls, v) -> Optional[int]:
@@ -907,3 +922,10 @@ class CommitEditsResponse(BaseModel):
     message: str
     quote: Quote
     snapshot_version: int
+
+
+# ===== Vendor Pricebook Import Schemas =====
+class PricebookImportResult(BaseModel):
+    created: int
+    updated: int
+    errors: List[str] = []

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -15,7 +15,7 @@ import type {
   MarkupControlToggleRequest, MarkupControlToggleResponse,
   CommitEditsRequest, CommitEditsResponse,
   CompanySettings, CompanySettingsUpdate, InvoiceSummaryItem,
-  BacklogQuoteItem
+  BacklogQuoteItem, PricebookImportResult
 } from '@/types';
 
 // API base URL - configurable via environment variable for production
@@ -279,5 +279,29 @@ export const api = {
   // ===== Reports =====
   reports: {
     getBacklogQuotes: () => request<BacklogQuoteItem[]>('/reports/backlog-quotes'),
+  },
+
+  // ===== Vendor Pricebook =====
+  vendorPricebook: {
+    import: async (vendorId: number, file: File): Promise<PricebookImportResult> => {
+      const formData = new FormData();
+      formData.append('file', file);
+      const response = await fetch(`${API_BASE}/vendors/${vendorId}/pricebook/import`, {
+        method: 'POST',
+        body: formData,
+        // Note: do NOT set Content-Type header — browser sets multipart boundary automatically
+      });
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({}));
+        let message = `API error: ${response.status}`;
+        if (typeof error.detail === 'string') {
+          message = error.detail;
+        } else if (Array.isArray(error.detail)) {
+          message = error.detail.map((e: any) => e.msg).join('; ');
+        }
+        throw new Error(message);
+      }
+      return response.json();
+    },
   },
 };

--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -149,14 +149,18 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
   const [pmsType, setPmsType] = useState<"percent" | "dollar">("dollar")
   const [pmsValue, setPmsValue] = useState("")
 
-  // Markup Discount Control states
+  // Markup Discount Control states (section-level)
   const [markupControlDialogOpen, setMarkupControlDialogOpen] = useState(false)
-  const [pendingMarkupPercent, setPendingMarkupPercent] = useState("")
+  const [pendingPartsMarkup, setPendingPartsMarkup] = useState("")
+  const [pendingLaborMarkup, setPendingLaborMarkup] = useState("")
+  const [pendingMiscMarkup, setPendingMiscMarkup] = useState("")
   const [togglingMarkupControl, setTogglingMarkupControl] = useState(false)
 
   // Edit Markup states (for modifying markup while enabled)
   const [editMarkupDialogOpen, setEditMarkupDialogOpen] = useState(false)
-  const [editingMarkupPercent, setEditingMarkupPercent] = useState("")
+  const [editingPartsMarkup, setEditingPartsMarkup] = useState("")
+  const [editingLaborMarkup, setEditingLaborMarkup] = useState("")
+  const [editingMiscMarkup, setEditingMiscMarkup] = useState("")
   const [updatingMarkupPercent, setUpdatingMarkupPercent] = useState(false)
 
   // Discount All dialog state
@@ -656,7 +660,8 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
       (staged.quantity === undefined || staged.quantity === item.quantity) &&
       (staged.unit_price === undefined || staged.unit_price === item.unit_price) &&
       (staged.discount_code_id === undefined || staged.discount_code_id === item.discount_code_id) &&
-      (staged.description === undefined || staged.description === item.description)
+      (staged.description === undefined || staged.description === item.description) &&
+      (staged.markup_percent === undefined || staged.markup_percent === item.markup_percent)
 
     if (isUnchanged) {
       newStagedEdits.delete(item.id)
@@ -744,6 +749,7 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
           unit_price: edit.unit_price,
           discount_code_id: edit.discount_code_id === null ? 0 : edit.discount_code_id,
           description: edit.description,
+          markup_percent: edit.markup_percent,
         })
       }
 
@@ -842,12 +848,14 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
         alert("Remove discount codes first to enable this feature")
         return
       }
-      // Open dialog to get global markup percent
-      setPendingMarkupPercent("")
+      // Open dialog to get section markup percents
+      setPendingPartsMarkup("")
+      setPendingLaborMarkup("")
+      setPendingMiscMarkup("")
       setMarkupControlDialogOpen(true)
     } else {
       // Disabling - confirm and call API
-      if (!confirm("Disable Markup Discount Control? This will restore individual markups.")) {
+      if (!confirm("Disable Markup Control? This will restore individual markups.")) {
         return
       }
       handleDisableMarkupControl()
@@ -868,9 +876,12 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
   }
 
   const handleConfirmEnableMarkupControl = async () => {
-    const percent = parseFloat(pendingMarkupPercent)
-    if (isNaN(percent) || percent < 0) {
-      alert("Please enter a valid markup percentage (0 or greater)")
+    const partsP = parseFloat(pendingPartsMarkup) || 0
+    const laborP = parseFloat(pendingLaborMarkup) || 0
+    const miscP = parseFloat(pendingMiscMarkup) || 0
+
+    if (partsP < 0 || laborP < 0 || miscP < 0) {
+      alert("Markup percentages must be 0 or greater")
       return
     }
 
@@ -878,10 +889,14 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
     try {
       await api.quotes.toggleMarkupControl(quoteId, {
         enabled: true,
-        global_markup_percent: percent
+        parts_markup_percent: partsP,
+        labor_markup_percent: laborP,
+        misc_markup_percent: miscP,
       })
       setMarkupControlDialogOpen(false)
-      setPendingMarkupPercent("")
+      setPendingPartsMarkup("")
+      setPendingLaborMarkup("")
+      setPendingMiscMarkup("")
       fetchQuote()
       onUpdate?.()
     } catch (err) {
@@ -894,24 +909,34 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
   // Edit Markup handlers (for modifying markup while enabled)
   const handleOpenEditMarkup = () => {
     if (!quote || !quote.markup_control_enabled) return
-    setEditingMarkupPercent(quote.global_markup_percent?.toString() || "")
+    setEditingPartsMarkup(quote.parts_markup_percent?.toString() || "0")
+    setEditingLaborMarkup(quote.labor_markup_percent?.toString() || "0")
+    setEditingMiscMarkup(quote.misc_markup_percent?.toString() || "0")
     setEditMarkupDialogOpen(true)
   }
 
   const handleConfirmUpdateMarkup = async () => {
-    const percent = parseFloat(editingMarkupPercent)
-    if (isNaN(percent) || percent < 0) {
-      alert("Please enter a valid markup percentage (0 or greater)")
+    const partsP = parseFloat(editingPartsMarkup) || 0
+    const laborP = parseFloat(editingLaborMarkup) || 0
+    const miscP = parseFloat(editingMiscMarkup) || 0
+
+    if (partsP < 0 || laborP < 0 || miscP < 0) {
+      alert("Markup percentages must be 0 or greater")
       return
     }
+
     setUpdatingMarkupPercent(true)
     try {
       await api.quotes.toggleMarkupControl(quoteId, {
         enabled: true,
-        global_markup_percent: percent
+        parts_markup_percent: partsP,
+        labor_markup_percent: laborP,
+        misc_markup_percent: miscP,
       })
       setEditMarkupDialogOpen(false)
-      setEditingMarkupPercent("")
+      setEditingPartsMarkup("")
+      setEditingLaborMarkup("")
+      setEditingMiscMarkup("")
       fetchQuote()
       onUpdate?.()
     } catch (err) {
@@ -1027,6 +1052,9 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
         baseCost = item.miscellaneous.unit_price
         markupPercent = item.miscellaneous.markup_percent
       }
+
+      // Per-line-item markup overrides inventory markup
+      if (item.markup_percent != null) markupPercent = item.markup_percent
 
       // PMS items have 0 markup by definition
       if (item.is_pms) {
@@ -1177,6 +1205,10 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
         baseCost = item.miscellaneous.unit_price
         markupPercent = item.miscellaneous.markup_percent
       }
+
+      // Per-line-item markup overrides inventory markup; staged edit overrides both
+      if (item.markup_percent != null) markupPercent = item.markup_percent
+      if (editedItem?.markup_percent != null) markupPercent = editedItem.markup_percent
 
       if (item.is_pms) markupPercent = 0
 
@@ -2040,6 +2072,10 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
                     <TableHead className="text-right">Fulfilled Price</TableHead>
                   </>
                 )}
+                {/* Markup % column - edit mode only, when global toggle is OFF */}
+                {editorMode === "edit" && !quote?.markup_control_enabled && (
+                  <TableHead className="text-right">Markup %</TableHead>
+                )}
                 <TableHead className="text-right">Unit Price</TableHead>
                 <TableHead className="text-center">Discount</TableHead>
                 {/* Non-edit mode: Qty Fulfilled and Fulfilled Price come after Unit Price/Discount */}
@@ -2183,6 +2219,32 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
                           )}
                         </TableCell>
                       </>
+                    )}
+
+                    {/* Markup % Column — inline editable when global toggle is OFF */}
+                    {editorMode === "edit" && !quote?.markup_control_enabled && (
+                      <TableCell className="text-right">
+                        {item.is_pms ? (
+                          <span className="text-muted-foreground">-</span>
+                        ) : (
+                          <Input
+                            type="number"
+                            step="0.01"
+                            min="0"
+                            className="w-20 h-7 text-right text-sm inline-block"
+                            value={editedItem?.markup_percent ?? item.markup_percent ?? (
+                              item.part ? (item.part.markup_percent ?? 0) :
+                              item.labor ? item.labor.markup_percent :
+                              item.miscellaneous ? item.miscellaneous.markup_percent : 0
+                            )}
+                            onChange={(e) => {
+                              const val = e.target.value === "" ? 0 : parseFloat(e.target.value)
+                              if (!isNaN(val)) stageEdit(item, { markup_percent: val })
+                            }}
+                            disabled={isDeleted || hasBeenInvoiced}
+                          />
+                        )}
+                      </TableCell>
                     )}
 
                     {/* Unit Price Column */}
@@ -2395,6 +2457,10 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
                         <TableCell className="text-right text-muted-foreground">-</TableCell>
                       </>
                     )}
+                    {/* Markup % — placeholder for staged adds */}
+                    {editorMode === "edit" && !quote?.markup_control_enabled && (
+                      <TableCell className="text-right text-muted-foreground">-</TableCell>
+                    )}
                     {/* Unit Price */}
                     <TableCell className="text-right text-green-700 dark:text-green-300 font-medium">${unitPrice.toFixed(2)}</TableCell>
                     {/* Discount */}
@@ -2461,6 +2527,10 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
                         )}
                       </TableCell>
                     </>
+                  )}
+                  {/* Markup % — empty in footer */}
+                  {editorMode === "edit" && !quote?.markup_control_enabled && (
+                    <TableCell></TableCell>
                   )}
                   {/* Unit Price */}
                   <TableCell></TableCell>
@@ -2738,20 +2808,20 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
               Markup Discount Control
             </CardTitle>
             <div className="flex items-center gap-3">
-              {/* Display current state */}
-              {quote.markup_control_enabled && quote.global_markup_percent !== null && (
+              {/* Display current section markup badges */}
+              {quote.markup_control_enabled && (quote.parts_markup_percent != null || quote.labor_markup_percent != null || quote.misc_markup_percent != null) && (
                 editorMode === "edit" ? (
                   <button
                     onClick={handleOpenEditMarkup}
                     className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-semibold bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-300 border border-blue-300 dark:border-blue-700 hover:bg-blue-100 dark:hover:bg-blue-900 transition-colors cursor-pointer"
-                    title="Click to edit global markup"
+                    title="Click to edit section markups"
                   >
-                    Global Markup: {quote.global_markup_percent}%
+                    Parts: {quote.parts_markup_percent ?? 0}% | Labour: {quote.labor_markup_percent ?? 0}% | Misc: {quote.misc_markup_percent ?? 0}%
                     <Pencil className="h-3 w-3" />
                   </button>
                 ) : (
                   <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-300 border border-blue-300 dark:border-blue-700">
-                    Global Markup: {quote.global_markup_percent}%
+                    Parts: {quote.parts_markup_percent ?? 0}% | Labour: {quote.labor_markup_percent ?? 0}% | Misc: {quote.misc_markup_percent ?? 0}%
                   </span>
                 )
               )}
@@ -2778,8 +2848,8 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
         <CardContent>
           <p className="text-sm text-muted-foreground">
             {quote.markup_control_enabled
-              ? "Global markup is applied to all items. Discount codes are disabled."
-              : "Enable to apply a global markup percentage to all line items (excluding PMS items)."}
+              ? "Section markups are applied to all items. Discount codes are disabled."
+              : "Enable to apply markup percentages per section (Parts, Labour, Misc) to all line items (excluding PMS items)."}
           </p>
         </CardContent>
       </Card>
@@ -3365,20 +3435,41 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
               Enable Markup Discount Control
             </DialogTitle>
             <DialogDescription>
-              Enter the global markup percentage to apply to all line items (excluding PMS items).
-              This will replace individual item markups.
+              Set markup percentages per section. These will replace individual item markups (excluding PMS items).
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 pt-4">
             <div className="space-y-2">
-              <Label>Global Markup Percentage (%)</Label>
+              <Label>Parts Markup (%)</Label>
               <Input
                 type="number"
                 step="0.01"
                 min="0"
-                value={pendingMarkupPercent}
-                onChange={(e) => setPendingMarkupPercent(e.target.value)}
+                value={pendingPartsMarkup}
+                onChange={(e) => setPendingPartsMarkup(e.target.value)}
                 placeholder="e.g., 15.00"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Labour Markup (%)</Label>
+              <Input
+                type="number"
+                step="0.01"
+                min="0"
+                value={pendingLaborMarkup}
+                onChange={(e) => setPendingLaborMarkup(e.target.value)}
+                placeholder="e.g., 20.00"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Miscellaneous Markup (%)</Label>
+              <Input
+                type="number"
+                step="0.01"
+                min="0"
+                value={pendingMiscMarkup}
+                onChange={(e) => setPendingMiscMarkup(e.target.value)}
+                placeholder="e.g., 10.00"
               />
             </div>
             <DialogFooter>
@@ -3387,7 +3478,7 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
               </Button>
               <Button
                 onClick={handleConfirmEnableMarkupControl}
-                disabled={togglingMarkupControl || !pendingMarkupPercent}
+                disabled={togglingMarkupControl || (!pendingPartsMarkup && !pendingLaborMarkup && !pendingMiscMarkup)}
               >
                 {togglingMarkupControl ? "Applying..." : "Enable Markup Control"}
               </Button>
@@ -3396,28 +3487,50 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
         </DialogContent>
       </Dialog>
 
-      {/* Edit Markup Percent Dialog */}
+      {/* Edit Section Markup Dialog */}
       <Dialog open={editMarkupDialogOpen} onOpenChange={setEditMarkupDialogOpen}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <Pencil className="h-4 w-4" />
-              Edit Global Markup
+              Edit Section Markups
             </DialogTitle>
             <DialogDescription>
-              Update the global markup percentage. All line items (excluding PMS) will be recalculated.
+              Update markup percentages per section. All line items (excluding PMS) will be recalculated.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 pt-4">
             <div className="space-y-2">
-              <Label>Global Markup Percentage (%)</Label>
+              <Label>Parts Markup (%)</Label>
               <Input
                 type="number"
                 step="0.01"
                 min="0"
-                value={editingMarkupPercent}
-                onChange={(e) => setEditingMarkupPercent(e.target.value)}
+                value={editingPartsMarkup}
+                onChange={(e) => setEditingPartsMarkup(e.target.value)}
                 placeholder="e.g., 15.00"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Labour Markup (%)</Label>
+              <Input
+                type="number"
+                step="0.01"
+                min="0"
+                value={editingLaborMarkup}
+                onChange={(e) => setEditingLaborMarkup(e.target.value)}
+                placeholder="e.g., 20.00"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Miscellaneous Markup (%)</Label>
+              <Input
+                type="number"
+                step="0.01"
+                min="0"
+                value={editingMiscMarkup}
+                onChange={(e) => setEditingMiscMarkup(e.target.value)}
+                placeholder="e.g., 10.00"
               />
             </div>
             <DialogFooter>
@@ -3426,9 +3539,9 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
               </Button>
               <Button
                 onClick={handleConfirmUpdateMarkup}
-                disabled={updatingMarkupPercent || !editingMarkupPercent}
+                disabled={updatingMarkupPercent || (!editingPartsMarkup && !editingLaborMarkup && !editingMiscMarkup)}
               >
-                {updatingMarkupPercent ? "Updating..." : "Update Markup"}
+                {updatingMarkupPercent ? "Updating..." : "Update Markups"}
               </Button>
             </DialogFooter>
           </div>

--- a/frontend/src/components/forms/PartForm.tsx
+++ b/frontend/src/components/forms/PartForm.tsx
@@ -4,8 +4,15 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { SearchableMultiSelect } from "@/components/ui/searchable-multi-select"
 import type { SearchableMultiSelectOption } from "@/components/ui/searchable-multi-select"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { api } from "@/api/client"
-import type { Part, PartCreate, Labor } from "@/types"
+import type { Part, PartCreate, Labor, Profile } from "@/types"
 import { LaborForm } from "./LaborForm"
 
 interface PartFormProps {
@@ -16,6 +23,7 @@ interface PartFormProps {
 
 export function PartForm({ part, onSuccess, onCancel }: PartFormProps) {
   const [laborItems, setLaborItems] = useState<Labor[]>([])
+  const [vendors, setVendors] = useState<Profile[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -28,17 +36,26 @@ export function PartForm({ part, onSuccess, onCancel }: PartFormProps) {
   const [markupPercent, setMarkupPercent] = useState("")
   const [selectedLaborIds, setSelectedLaborIds] = useState<string[]>([])
 
-  // Fetch available labor items on mount
+  // New pricing flow fields
+  const [vendorId, setVendorId] = useState<string>("")
+  const [listPrice, setListPrice] = useState("")
+  const [discountPercent, setDiscountPercent] = useState("")
+
+  // Fetch available labor items and vendors on mount
   useEffect(() => {
-    const fetchLabor = async () => {
+    const fetchData = async () => {
       try {
-        const data = await api.labor.getAll()
-        setLaborItems(data)
+        const [laborData, vendorData] = await Promise.all([
+          api.labor.getAll(),
+          api.profiles.getAll("vendor"),
+        ])
+        setLaborItems(laborData)
+        setVendors(vendorData)
       } catch {
-        setError("Failed to load labor items")
+        setError("Failed to load form data")
       }
     }
-    fetchLabor()
+    fetchData()
   }, [])
 
   // Populate form when editing
@@ -48,12 +65,35 @@ export function PartForm({ part, onSuccess, onCancel }: PartFormProps) {
       setDescription(part.description)
       setCost(part.cost.toString())
       setMarkupPercent(part.markup_percent?.toString() || "0")
-      // Set linked labor IDs if available
       if (part.labor_items) {
         setSelectedLaborIds(part.labor_items.map(l => l.id.toString()))
       }
+      // New fields
+      setVendorId(part.vendor_id?.toString() || "")
+      setListPrice(part.list_price?.toString() || "")
+      setDiscountPercent(part.discount_percent?.toString() || "")
     }
   }, [part])
+
+  // Get selected vendor's default discount for display
+  const selectedVendor = vendors.find(v => v.id.toString() === vendorId)
+  const vendorDefaultDiscount = selectedVendor?.default_discount_percent ?? 0
+
+  // Determine if cost should be auto-calculated
+  const hasListPrice = listPrice !== "" && parseFloat(listPrice) > 0
+  const hasVendor = vendorId !== ""
+  const costIsAutoCalculated = hasListPrice && hasVendor
+
+  // Auto-calculate cost when list_price + vendor are set
+  useEffect(() => {
+    if (costIsAutoCalculated) {
+      const lp = parseFloat(listPrice) || 0
+      const dp = discountPercent !== "" ? parseFloat(discountPercent) : vendorDefaultDiscount
+      const effectiveDiscount = dp || 0
+      const calculatedCost = lp * (1 - effectiveDiscount / 100)
+      setCost(calculatedCost.toFixed(2))
+    }
+  }, [listPrice, discountPercent, vendorId, vendorDefaultDiscount, costIsAutoCalculated])
 
   // Convert labor items to multi-select options
   const laborOptions: SearchableMultiSelectOption[] = laborItems.map((labor) => ({
@@ -82,6 +122,9 @@ export function PartForm({ part, onSuccess, onCancel }: PartFormProps) {
       cost: parseFloat(cost) || 0,
       markup_percent: parseFloat(markupPercent) || 0,
       linked_labor_ids: selectedLaborIds.map((id) => parseInt(id, 10)),
+      vendor_id: vendorId ? parseInt(vendorId, 10) : undefined,
+      list_price: listPrice ? parseFloat(listPrice) : undefined,
+      discount_percent: discountPercent ? parseFloat(discountPercent) : undefined,
     }
 
     try {
@@ -132,8 +175,73 @@ export function PartForm({ part, onSuccess, onCancel }: PartFormProps) {
         />
       </div>
 
+      {/* Vendor Selection */}
       <div className="space-y-2">
-        <Label htmlFor="cost">Manufacturer Cost ($)</Label>
+        <Label htmlFor="vendor">Vendor</Label>
+        <Select value={vendorId} onValueChange={(v) => setVendorId(v === "none" ? "" : v)}>
+          <SelectTrigger>
+            <SelectValue placeholder="Select vendor (optional)" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">No vendor</SelectItem>
+            {vendors.map(v => (
+              <SelectItem key={v.id} value={v.id.toString()}>
+                {v.name}
+                {v.default_discount_percent ? ` (${v.default_discount_percent}% disc.)` : ''}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Vendor List Price (visible when vendor selected) */}
+      {hasVendor && (
+        <div className="space-y-2">
+          <Label htmlFor="listPrice">Vendor List Price ($)</Label>
+          <Input
+            id="listPrice"
+            type="number"
+            step="0.01"
+            min="0"
+            value={listPrice}
+            onChange={(e) => setListPrice(e.target.value)}
+            placeholder="0.00"
+          />
+        </div>
+      )}
+
+      {/* Discount % (visible when vendor selected) */}
+      {hasVendor && (
+        <div className="space-y-2">
+          <Label htmlFor="discountPercent">
+            Discount (%)
+            {vendorDefaultDiscount > 0 && discountPercent === "" && (
+              <span className="text-muted-foreground font-normal ml-1">
+                — using vendor default: {vendorDefaultDiscount}%
+              </span>
+            )}
+          </Label>
+          <Input
+            id="discountPercent"
+            type="number"
+            step="0.01"
+            min="0"
+            max="100"
+            value={discountPercent}
+            onChange={(e) => setDiscountPercent(e.target.value)}
+            placeholder={vendorDefaultDiscount > 0 ? `${vendorDefaultDiscount} (vendor default)` : "0"}
+          />
+          <p className="text-xs text-muted-foreground">
+            Per-part override. Leave blank to use vendor default.
+          </p>
+        </div>
+      )}
+
+      {/* Cost field — read-only when auto-calculated */}
+      <div className="space-y-2">
+        <Label htmlFor="cost">
+          {costIsAutoCalculated ? "Calculated Cost ($)" : "Manufacturer Cost ($)"}
+        </Label>
         <Input
           id="cost"
           type="number"
@@ -143,7 +251,14 @@ export function PartForm({ part, onSuccess, onCancel }: PartFormProps) {
           onChange={(e) => setCost(e.target.value)}
           placeholder="0.00"
           required
+          readOnly={costIsAutoCalculated}
+          className={costIsAutoCalculated ? "bg-muted" : ""}
         />
+        {costIsAutoCalculated && (
+          <p className="text-xs text-muted-foreground">
+            Auto-calculated: List Price x (1 - Discount%)
+          </p>
+        )}
       </div>
 
       <div className="space-y-2">
@@ -184,15 +299,31 @@ export function PartForm({ part, onSuccess, onCancel }: PartFormProps) {
 
       {/* Cost Summary */}
       <div className="bg-muted/50 p-4 rounded-md space-y-2">
-        <h4 className="font-medium text-sm">Cost Summary</h4>
+        <h4 className="font-medium text-sm">Pricing Summary</h4>
         <div className="text-sm space-y-1">
+          {costIsAutoCalculated && (
+            <>
+              <div className="flex justify-between">
+                <span>Vendor List Price:</span>
+                <span>${(parseFloat(listPrice) || 0).toFixed(2)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>
+                  Discount ({discountPercent !== "" ? discountPercent : vendorDefaultDiscount}%):
+                </span>
+                <span>
+                  -${((parseFloat(listPrice) || 0) * ((discountPercent !== "" ? parseFloat(discountPercent) : vendorDefaultDiscount) || 0) / 100).toFixed(2)}
+                </span>
+              </div>
+            </>
+          )}
           <div className="flex justify-between">
-            <span>Part Cost:</span>
+            <span>Cost:</span>
             <span>${partCost.toFixed(2)}</span>
           </div>
           {markupNum > 0 && (
-            <div className="flex justify-between">
-              <span>With Markup ({markupNum}%):</span>
+            <div className="flex justify-between font-medium border-t pt-1">
+              <span>Sell Price ({markupNum}% markup):</span>
               <span>${partPriceWithMarkup.toFixed(2)}</span>
             </div>
           )}

--- a/frontend/src/components/forms/ProfileForm.tsx
+++ b/frontend/src/components/forms/ProfileForm.tsx
@@ -53,6 +53,7 @@ export function ProfileForm({ profile, defaultType = "customer", onSuccess, onCa
   const [address, setAddress] = useState("")
   const [postalCode, setPostalCode] = useState("")
   const [website, setWebsite] = useState("")
+  const [defaultDiscountPercent, setDefaultDiscountPercent] = useState("")
 
   // Contacts state
   const [contacts, setContacts] = useState<ContactFormData[]>([])
@@ -80,6 +81,7 @@ export function ProfileForm({ profile, defaultType = "customer", onSuccess, onCa
       setAddress(profile.address)
       setPostalCode(profile.postal_code)
       setWebsite(profile.website || "")
+      setDefaultDiscountPercent(profile.default_discount_percent?.toString() || "")
       setContacts(profile.contacts.map(c => ({
         id: c.id,
         tempId: `existing-${c.id}`,
@@ -181,7 +183,8 @@ export function ProfileForm({ profile, defaultType = "customer", onSuccess, onCa
           pst: pst.trim(),
           address: address.trim(),
           postal_code: postalCode.trim(),
-          website: website.trim() || undefined
+          website: website.trim() || undefined,
+          default_discount_percent: defaultDiscountPercent ? parseFloat(defaultDiscountPercent) : undefined,
         })
 
         // Sync contacts: delete removed, update existing, add new
@@ -222,6 +225,7 @@ export function ProfileForm({ profile, defaultType = "customer", onSuccess, onCa
           address: address.trim(),
           postal_code: postalCode.trim(),
           website: website.trim() || undefined,
+          default_discount_percent: defaultDiscountPercent ? parseFloat(defaultDiscountPercent) : undefined,
           contacts: contacts.map(buildContactCreate)
         }
         await api.profiles.create(profileData)
@@ -316,6 +320,26 @@ export function ProfileForm({ profile, defaultType = "customer", onSuccess, onCa
             placeholder="e.g., https://www.example.com"
           />
         </div>
+
+        {/* Default Discount — only for vendors */}
+        {type === "vendor" && (
+          <div className="space-y-2">
+            <Label htmlFor="defaultDiscount">Default Discount (%)</Label>
+            <Input
+              id="defaultDiscount"
+              type="number"
+              step="0.01"
+              min="0"
+              max="100"
+              value={defaultDiscountPercent}
+              onChange={(e) => setDefaultDiscountPercent(e.target.value)}
+              placeholder="0"
+            />
+            <p className="text-xs text-muted-foreground">
+              Applied to all parts from this vendor unless overridden per-part.
+            </p>
+          </div>
+        )}
       </div>
 
       <Separator />

--- a/frontend/src/lib/pricing.ts
+++ b/frontend/src/lib/pricing.ts
@@ -3,9 +3,24 @@ import type { QuoteLineItem } from '@/types'
 /**
  * Get the unit price for a quote line item, resolving from the linked
  * inventory item (with markup) if no explicit override is set.
+ *
+ * Priority:
+ * 1. Explicit unit_price override (set by markup control calculation)
+ * 2. Line-item markup_percent with base cost (per-item markup)
+ * 3. Inventory item's markup (legacy / no line-item markup set)
  */
 export function getLineItemUnitPrice(item: QuoteLineItem): number {
+  // If explicit unit_price override exists (from markup calculation), use it
   if (item.unit_price) return item.unit_price
+
+  // If line-item markup_percent is set, use it with base cost
+  if (item.markup_percent != null) {
+    if (item.part) return item.part.cost * (1 + item.markup_percent / 100)
+    if (item.labor) return item.labor.hours * item.labor.rate * (1 + item.markup_percent / 100)
+    if (item.miscellaneous) return item.miscellaneous.unit_price * (1 + item.markup_percent / 100)
+  }
+
+  // Fall back to inventory item's markup (legacy / no line-item markup set)
   if (item.labor) {
     return item.labor.hours * item.labor.rate * (1 + item.labor.markup_percent / 100)
   }

--- a/frontend/src/pages/ProfilesPage.tsx
+++ b/frontend/src/pages/ProfilesPage.tsx
@@ -19,9 +19,10 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import { ProfileForm } from "@/components/forms/ProfileForm"
+import { Input } from "@/components/ui/input"
 import { api } from "@/api/client"
-import type { Profile } from "@/types"
-import { Plus, Trash2, Pencil, Users, Building, ExternalLink, Phone, Mail, MapPin } from "lucide-react"
+import type { Profile, Part, PricebookImportResult } from "@/types"
+import { Plus, Trash2, Pencil, Users, Building, ExternalLink, Phone, Mail, MapPin, Upload } from "lucide-react"
 
 export function ProfilesPage() {
   const [profiles, setProfiles] = useState<Profile[]>([])
@@ -30,6 +31,12 @@ export function ProfilesPage() {
   const [editDialogOpen, setEditDialogOpen] = useState(false)
   const [editingProfile, setEditingProfile] = useState<Profile | null>(null)
   const [viewingProfile, setViewingProfile] = useState<Profile | null>(null)
+
+  // Pricebook state
+  const [vendorParts, setVendorParts] = useState<Part[]>([])
+  const [loadingParts, setLoadingParts] = useState(false)
+  const [importingPricebook, setImportingPricebook] = useState(false)
+  const [importResult, setImportResult] = useState<PricebookImportResult | null>(null)
 
   const fetchData = async () => {
     setLoading(true)
@@ -47,6 +54,37 @@ export function ProfilesPage() {
   useEffect(() => {
     fetchData()
   }, [])
+
+  // Fetch parts linked to this vendor when viewing a vendor
+  useEffect(() => {
+    if (viewingProfile?.type === "vendor") {
+      setLoadingParts(true)
+      setImportResult(null)
+      api.parts.getAll()
+        .then(allParts => setVendorParts(allParts.filter(p => p.vendor_id === viewingProfile.id)))
+        .catch(() => setVendorParts([]))
+        .finally(() => setLoadingParts(false))
+    } else {
+      setVendorParts([])
+    }
+  }, [viewingProfile])
+
+  const handlePricebookImport = async (file: File) => {
+    if (!viewingProfile) return
+    setImportingPricebook(true)
+    setImportResult(null)
+    try {
+      const result = await api.vendorPricebook.import(viewingProfile.id, file)
+      setImportResult(result)
+      // Refresh vendor parts list
+      const allParts = await api.parts.getAll()
+      setVendorParts(allParts.filter(p => p.vendor_id === viewingProfile.id))
+    } catch (err) {
+      setImportResult({ created: 0, updated: 0, errors: [err instanceof Error ? err.message : "Import failed"] })
+    } finally {
+      setImportingPricebook(false)
+    }
+  }
 
   const handleDelete = async (e: React.MouseEvent, id: number) => {
     e.stopPropagation() // Prevent row click
@@ -333,6 +371,104 @@ export function ProfilesPage() {
                   ))}
                 </div>
               </div>
+
+              {/* Vendor Pricebook (vendors only) */}
+              {viewingProfile.type === "vendor" && (
+                <>
+                  <Separator />
+                  <div className="space-y-3">
+                    <div className="flex justify-between items-center">
+                      <h3 className="font-semibold text-sm text-muted-foreground uppercase tracking-wide">
+                        Pricebook ({vendorParts.length} parts)
+                      </h3>
+                      <div className="relative">
+                        <Input
+                          type="file"
+                          accept=".csv"
+                          className="absolute inset-0 opacity-0 cursor-pointer"
+                          onChange={(e) => {
+                            const file = e.target.files?.[0]
+                            if (file) handlePricebookImport(file)
+                            e.target.value = "" // Reset so same file can be re-imported
+                          }}
+                          disabled={importingPricebook}
+                        />
+                        <Button variant="outline" size="sm" disabled={importingPricebook}>
+                          <Upload className="h-4 w-4 mr-1" />
+                          {importingPricebook ? "Importing..." : "Import CSV"}
+                        </Button>
+                      </div>
+                    </div>
+
+                    {/* Import results */}
+                    {importResult && (
+                      <div className={`text-sm p-3 rounded-md border ${importResult.errors.length > 0 ? "bg-amber-50 dark:bg-amber-950 border-amber-200 dark:border-amber-800" : "bg-green-50 dark:bg-green-950 border-green-200 dark:border-green-800"}`}>
+                        <p>
+                          Created: <strong>{importResult.created}</strong> | Updated: <strong>{importResult.updated}</strong>
+                        </p>
+                        {importResult.errors.length > 0 && (
+                          <div className="mt-1 text-amber-700 dark:text-amber-300">
+                            {importResult.errors.map((err, i) => (
+                              <p key={i} className="text-xs">{err}</p>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    )}
+
+                    {/* Parts table */}
+                    {loadingParts ? (
+                      <p className="text-sm text-muted-foreground">Loading parts...</p>
+                    ) : vendorParts.length === 0 ? (
+                      <p className="text-sm text-muted-foreground">
+                        No parts linked to this vendor. Import a CSV pricebook to get started.
+                      </p>
+                    ) : (
+                      <div className="bg-card rounded-lg border">
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead>Part Number</TableHead>
+                              <TableHead>Description</TableHead>
+                              <TableHead className="text-right">List Price</TableHead>
+                              <TableHead className="text-right">Discount %</TableHead>
+                              <TableHead className="text-right">Cost</TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {vendorParts.map(part => (
+                              <TableRow key={part.id}>
+                                <TableCell className="font-medium">{part.part_number}</TableCell>
+                                <TableCell className="text-muted-foreground">{part.description}</TableCell>
+                                <TableCell className="text-right">
+                                  {part.list_price != null ? `$${part.list_price.toFixed(2)}` : "—"}
+                                </TableCell>
+                                <TableCell className="text-right">
+                                  {part.discount_percent != null
+                                    ? `${part.discount_percent}%`
+                                    : viewingProfile.default_discount_percent
+                                      ? <span className="text-muted-foreground">{viewingProfile.default_discount_percent}% (default)</span>
+                                      : "—"}
+                                </TableCell>
+                                <TableCell className="text-right font-medium">
+                                  ${part.cost.toFixed(2)}
+                                </TableCell>
+                              </TableRow>
+                            ))}
+                          </TableBody>
+                        </Table>
+                      </div>
+                    )}
+                  </div>
+                </>
+              )}
+
+              {/* Default Discount display for vendors */}
+              {viewingProfile.type === "vendor" && viewingProfile.default_discount_percent != null && (
+                <div className="text-sm text-muted-foreground">
+                  Default Vendor Discount: <strong>{viewingProfile.default_discount_percent}%</strong>
+                </div>
+              )}
 
               {/* Close button */}
               <div className="flex justify-end pt-4">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -110,6 +110,9 @@ export interface Part {
   markup_percent: number;
   category_id?: number;
   labor_items?: Labor[];  // Linked labor items
+  vendor_id?: number;
+  list_price?: number;
+  discount_percent?: number;  // Per-part discount override
 }
 
 export interface PartCreate {
@@ -119,6 +122,9 @@ export interface PartCreate {
   markup_percent?: number;
   category_id?: number;
   linked_labor_ids?: number[];
+  vendor_id?: number;
+  list_price?: number;
+  discount_percent?: number;
 }
 
 // ===== Miscellaneous =====
@@ -201,6 +207,7 @@ export interface Profile {
   address: string;
   postal_code: string;
   website?: string;
+  default_discount_percent?: number;
   contacts: Contact[];
 }
 
@@ -211,6 +218,7 @@ export interface ProfileCreate {
   address: string;
   postal_code: string;
   website?: string;
+  default_discount_percent?: number;
   contacts: ContactCreate[];
 }
 
@@ -221,6 +229,7 @@ export interface ProfileUpdate {
   address?: string;
   postal_code?: string;
   website?: string;
+  default_discount_percent?: number;
 }
 
 // ===== Projects =====
@@ -277,6 +286,7 @@ export interface QuoteLineItem {
   pms_percent?: number;  // Percentage value for PMS % items
   original_markup_percent?: number;  // Individual markup before global override
   base_cost?: number;  // Base cost used for recalculation
+  markup_percent?: number;  // Per-line-item markup
   labor?: Labor;
   part?: Part;
   miscellaneous?: Miscellaneous;
@@ -319,7 +329,9 @@ export interface Quote {
   client_po_number?: string | null;
   work_description?: string | null;
   markup_control_enabled: boolean;  // Markup Discount Control toggle
-  global_markup_percent?: number | null;  // Global markup % when control is enabled
+  parts_markup_percent?: number | null;  // Section-level markup for parts
+  labor_markup_percent?: number | null;  // Section-level markup for labor
+  misc_markup_percent?: number | null;  // Section-level markup for misc
   cost_code_id?: number | null;
   cost_code?: CostCode | null;
   line_items: QuoteLineItem[];
@@ -592,6 +604,14 @@ export interface QuoteLineItemSnapshot {
   pms_percent?: number;  // Percentage value for PMS % items
   original_markup_percent?: number;  // Individual markup before global override
   base_cost?: number;  // Base cost used for recalculation
+  markup_percent?: number;  // Per-line-item markup
+}
+
+// ===== Pricebook Import =====
+export interface PricebookImportResult {
+  created: number;
+  updated: number;
+  errors: string[];
 }
 
 // ===== Quote Snapshots =====
@@ -624,7 +644,9 @@ export interface StagedFulfillment {
 // ===== Markup Control Toggle =====
 export interface MarkupControlToggleRequest {
   enabled: boolean;
-  global_markup_percent?: number;
+  parts_markup_percent?: number;
+  labor_markup_percent?: number;
+  misc_markup_percent?: number;
 }
 
 export interface MarkupControlToggleResponse {
@@ -650,6 +672,7 @@ export interface StagedLineItemChange {
   unit_price?: number;
   is_pms?: boolean;
   pms_percent?: number;
+  markup_percent?: number;  // Per-line-item markup
 }
 
 export interface CommitEditsRequest {
@@ -677,6 +700,7 @@ export interface StagedEdit {
   unit_price?: number;
   discount_code_id?: number | null;  // null means "remove discount"
   description?: string;
+  markup_percent?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implements the full modified pricing pipeline: **Vendor List Price → Discount → Cost → Markup → Sell Price**
- Replaces single global markup with **section-level markup** (Parts %, Labour %, Misc %) for finer control
- Adds **per-line-item markup editing** when global toggle is OFF
- Adds **vendor pricebook CSV import** for bulk part pricing updates
- Adds **vendor default discount %** that flows down to linked parts

## Changes

### Backend (7 files)
- **Migration 010**: New columns on parts, profiles, quotes, quote_line_items, quote_line_item_snapshots; data migration from global_markup_percent to 3 section columns
- **models.py / schemas.py**: Part vendor linkage, Profile discount, Quote section markups, LineItem markup_percent
- **routes/parts.py**: Auto-cost calculation from list_price + vendor discount, vendor eager loading
- **routes/quotes.py**: Section-level markup toggle, per-item markup in commit_edits, snapshot capture
- **routes/vendor_pricebook.py** (new): CSV import endpoint with create/update/error reporting
- **routes/profiles.py**: Accept default_discount_percent
- **main.py**: Register vendor_pricebook router

### Frontend (7 files)
- **types + API client**: All new fields, PricebookImportResult type, vendorPricebook.import()
- **pricing.ts**: 3-tier unit price resolution (explicit override > line-item markup > inventory markup)
- **PartForm**: Vendor selector, list price, discount %, auto-calculated cost (read-only when auto)
- **ProfileForm**: Default Discount % field for vendors
- **QuoteEditor**: 3-input markup control dialogs, section badges, inline Markup % column
- **ProfilesPage**: Vendor pricebook section with parts table and CSV import UI

## Test plan
- [ ] CI: Backend tests, Frontend tsc + build, Migration integrity (upgrade → downgrade → upgrade)
- [ ] Create vendor with default_discount_percent → verify field saves
- [ ] Create part with vendor + list_price → verify cost auto-calculates
- [ ] Enable section markup control with different Parts/Labour/Misc values → verify recalculation
- [ ] Edit per-line-item markup (global OFF) → verify sell price updates on commit
- [ ] Import CSV pricebook for vendor → verify parts created/updated
- [ ] Clone quote → verify section markup fields reset properly