### PR TITLE
Legacy data migration: UC Vision CSV import

### DIFF
--- a/backend/alembic/versions/20260305_011_nullable_cost_code.py
+++ b/backend/alembic/versions/20260305_011_nullable_cost_code.py
@@ -1,0 +1,43 @@
+"""Make cost_code_id nullable on quotes and purchase_orders
+
+Legacy data from UC Vision has no cost codes, so imported quotes and POs
+need cost_code_id = NULL.
+
+Revision ID: 011_nullable_cost_code
+Revises: 010_price_flow_changes
+Create Date: 2026-03-05
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '011_nullable_cost_code'
+down_revision = '010_price_flow_changes'
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table, column):
+    """Check if a column already exists (idempotent guard)."""
+    conn = op.get_bind()
+    result = conn.execute(sa.text(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_name = :table AND column_name = :column"
+    ), {"table": table, "column": column})
+    return result.fetchone() is not None
+
+
+def upgrade() -> None:
+    if _column_exists('quotes', 'cost_code_id'):
+        op.alter_column('quotes', 'cost_code_id', existing_type=sa.Integer(), nullable=True)
+    if _column_exists('purchase_orders', 'cost_code_id'):
+        op.alter_column('purchase_orders', 'cost_code_id', existing_type=sa.Integer(), nullable=True)
+
+
+def downgrade() -> None:
+    # Set any NULLs to a default before re-adding NOT NULL
+    op.execute("UPDATE quotes SET cost_code_id = 1 WHERE cost_code_id IS NULL")
+    op.alter_column('quotes', 'cost_code_id', existing_type=sa.Integer(), nullable=False)
+    op.execute("UPDATE purchase_orders SET cost_code_id = 1 WHERE cost_code_id IS NULL")
+    op.alter_column('purchase_orders', 'cost_code_id', existing_type=sa.Integer(), nullable=False)

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,7 +11,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from database import engine, Base, SessionLocal
-from routes import parts, labor, profiles, projects, quotes, purchase_orders, discount_codes, miscellaneous, invoices, company_settings, reports, cost_codes, vendor_pricebook
+from routes import parts, labor, profiles, projects, quotes, purchase_orders, discount_codes, miscellaneous, invoices, company_settings, reports, cost_codes, vendor_pricebook, migration
 from seed import seed_system_items
 
 
@@ -113,6 +113,7 @@ app.include_router(company_settings.router)
 app.include_router(reports.router)
 app.include_router(cost_codes.router)
 app.include_router(vendor_pricebook.router)
+app.include_router(migration.router)
 
 
 @app.get("/")

--- a/backend/models.py
+++ b/backend/models.py
@@ -190,7 +190,7 @@ class Quote(Base):
     parts_markup_percent = Column(Float, nullable=True)  # Section-level markup for parts
     labor_markup_percent = Column(Float, nullable=True)  # Section-level markup for labor
     misc_markup_percent = Column(Float, nullable=True)  # Section-level markup for misc
-    cost_code_id = Column(Integer, ForeignKey('cost_codes.id'), nullable=False)
+    cost_code_id = Column(Integer, ForeignKey('cost_codes.id'), nullable=True)
 
     # Relationships
     project = relationship("Project", back_populates="quotes")
@@ -245,7 +245,7 @@ class PurchaseOrder(Base):
     vendor_po_number = Column(String, nullable=True)
     expected_delivery_date = Column(DateTime, nullable=True)
     status = Column(Enum(POStatus), default=POStatus.draft)
-    cost_code_id = Column(Integer, ForeignKey('cost_codes.id'), nullable=False)
+    cost_code_id = Column(Integer, ForeignKey('cost_codes.id'), nullable=True)
 
     # Relationships
     project = relationship("Project", back_populates="purchase_orders")

--- a/backend/routes/migration.py
+++ b/backend/routes/migration.py
@@ -1,0 +1,755 @@
+"""
+Legacy data migration endpoint.
+
+Imports CSV exports from UC Vision (Access database) into UC Velocity.
+Processing order respects FK dependencies. The entire import runs in a
+single transaction — if anything fails, everything rolls back.
+"""
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+from typing import List
+from datetime import datetime
+import csv
+import io
+import re
+
+from database import get_db
+from models import (
+    Category, Profile, ProfileType, Contact, ContactPhone, PhoneType,
+    Part, Labor, Miscellaneous, Project, Quote, QuoteLineItem,
+    PurchaseOrder, POLineItem, POStatus,
+)
+
+router = APIRouter(prefix="/migration", tags=["migration"])
+
+
+# The 13 CSV files we recognize, in processing order
+EXPECTED_FILES = [
+    "tblPartsCategories.csv",
+    "tblClients.csv",
+    "tblVendors.csv",
+    "tblMaterial.csv",
+    "tblApplication.csv",
+    "tblZones.csv",
+    "tblProjects.csv",
+    "tblServiceRecords.csv",
+    "tblWorkorderApplication.csv",
+    "tblWorkorderMaterial.csv",
+    "tblWorkorderZones.csv",
+    "tblPurchaseOrders.csv",
+    "tblPurchaseOrdersMaterial.csv",
+]
+
+
+def parse_csv(content: bytes) -> list[dict]:
+    """Parse CSV bytes into list of dicts, handling BOM."""
+    text = content.decode("utf-8-sig")
+    reader = csv.DictReader(io.StringIO(text))
+    return list(reader)
+
+
+def clean_currency(val: str) -> float:
+    """Strip '$', ',', and whitespace from a currency string, return float."""
+    if not val:
+        return 0.0
+    cleaned = val.replace("$", "").replace(",", "").strip()
+    if not cleaned:
+        return 0.0
+    return float(cleaned)
+
+
+def safe_int(val: str, default: int = 0) -> int:
+    """Parse a value to int, rounding floats."""
+    if not val or not val.strip():
+        return default
+    try:
+        return round(float(val.strip()))
+    except (ValueError, TypeError):
+        return default
+
+
+def safe_float(val: str, default: float = 0.0) -> float:
+    """Parse a value to float."""
+    if not val or not val.strip():
+        return default
+    try:
+        return float(val.strip())
+    except (ValueError, TypeError):
+        return default
+
+
+def parse_date(val: str) -> datetime | None:
+    """Parse Access date formats like '11/12/2004 0:00:00'."""
+    if not val or not val.strip():
+        return None
+    val = val.strip()
+    for fmt in ("%m/%d/%Y %H:%M:%S", "%m/%d/%Y", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(val, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def safe_str(val: str | None, default: str = "") -> str:
+    """Return stripped string or default."""
+    if val is None:
+        return default
+    return val.strip() or default
+
+
+@router.post("/import")
+async def import_legacy_data(
+    files: List[UploadFile] = File(...),
+    db: Session = Depends(get_db),
+):
+    """
+    Import legacy UC Vision CSV data.
+
+    Accepts multiple CSV files via multipart form upload.
+    Wipes all existing data (except cost_codes, discount_codes, company_settings)
+    and imports from the CSV files in FK-dependency order.
+    """
+    # Read all uploaded files into a dict keyed by filename
+    file_contents: dict[str, bytes] = {}
+    skipped_files: list[str] = []
+
+    for f in files:
+        fname = f.filename or ""
+        content = await f.read()
+        if fname in [ef for ef in EXPECTED_FILES]:
+            file_contents[fname] = content
+        else:
+            skipped_files.append(fname)
+
+    warnings: list[str] = []
+    errors: list[str] = []
+    counts: dict[str, int] = {}
+
+    try:
+        # === WIPE existing data ===
+        db.execute(text(
+            "TRUNCATE categories, profiles, parts, labor, miscellaneous, projects CASCADE"
+        ))
+
+        # Reset sequences
+        sequences = [
+            "categories_id_seq",
+            "profiles_id_seq",
+            "contacts_id_seq",
+            "contact_phones_id_seq",
+            "parts_id_seq",
+            "labor_id_seq",
+            "miscellaneous_id_seq",
+            "projects_id_seq",
+            "quotes_id_seq",
+            "quote_line_items_id_seq",
+            "purchase_orders_id_seq",
+            "po_line_items_id_seq",
+        ]
+        for seq in sequences:
+            try:
+                db.execute(text(f"ALTER SEQUENCE {seq} RESTART WITH 1"))
+            except Exception:
+                pass  # Sequence may not exist
+
+        # ID maps: legacy_id -> new_id
+        cat_map_part: dict[int, int] = {}
+        cat_map_labor: dict[int, int] = {}
+        customer_map: dict[int, int] = {}
+        vendor_map: dict[int, int] = {}
+        part_map: dict[int, int] = {}
+        labor_map: dict[int, int] = {}
+        misc_map: dict[int, int] = {}
+        project_map: dict[int, int] = {}
+        quote_map: dict[int, int] = {}
+        po_map: dict[int, int] = {}
+
+        # === 1. Categories ===
+        if "tblPartsCategories.csv" in file_contents:
+            rows = parse_csv(file_contents["tblPartsCategories.csv"])
+            count = 0
+            for row in rows:
+                legacy_id = safe_int(row.get("CategoryID", ""))
+                name = safe_str(row.get("chrCategoryName", ""))
+                cat_type = safe_str(row.get("chrCategoryType", ""))
+
+                if not legacy_id or not name:
+                    warnings.append(f"Categories: skipped row with empty ID or name")
+                    continue
+
+                if cat_type == "Application":
+                    cat = Category(name=name, type="labor")
+                    db.add(cat)
+                    db.flush()
+                    cat_map_labor[legacy_id] = cat.id
+                    count += 1
+                elif cat_type == "Material":
+                    cat = Category(name=name, type="part")
+                    db.add(cat)
+                    db.flush()
+                    cat_map_part[legacy_id] = cat.id
+                    count += 1
+                elif cat_type == "Application & Material":
+                    # Create two rows: one part, one labor
+                    cat_p = Category(name=name, type="part")
+                    db.add(cat_p)
+                    db.flush()
+                    cat_map_part[legacy_id] = cat_p.id
+
+                    cat_l = Category(name=name, type="labor")
+                    db.add(cat_l)
+                    db.flush()
+                    cat_map_labor[legacy_id] = cat_l.id
+                    count += 2
+                else:
+                    warnings.append(f"Categories: unknown type '{cat_type}' for ID {legacy_id}")
+                    continue
+
+            counts["categories"] = count
+
+        # === 2. Customers (tblClients) ===
+        if "tblClients.csv" in file_contents:
+            rows = parse_csv(file_contents["tblClients.csv"])
+            count = 0
+            for row in rows:
+                legacy_id = safe_int(row.get("Client ID", ""))
+                name = safe_str(row.get("chrCompanyName", ""))
+
+                if not legacy_id or not name:
+                    warnings.append(f"Customers: skipped row with empty ID or name")
+                    continue
+
+                # Build address
+                addr_parts = [
+                    safe_str(row.get("chrAddress", "")),
+                    safe_str(row.get("chrCity", "")),
+                    safe_str(row.get("chrProvince", "")),
+                ]
+                address = ", ".join(p for p in addr_parts if p)
+
+                profile = Profile(
+                    name=name,
+                    type=ProfileType.customer,
+                    pst=safe_str(row.get("chrProvincialTax", "")),
+                    address=address,
+                    postal_code=safe_str(row.get("chrPostalCode", "")),
+                )
+                db.add(profile)
+                db.flush()
+                customer_map[legacy_id] = profile.id
+                count += 1
+
+                # Contact 1
+                first1 = safe_str(row.get("chrFirstName", ""))
+                last1 = safe_str(row.get("chrLastName", ""))
+                contact_name1 = f"{first1} {last1}".strip()
+                if contact_name1:
+                    contact1 = Contact(
+                        profile_id=profile.id,
+                        name=contact_name1,
+                        job_title=safe_str(row.get("chrTitle", "")) or None,
+                        email=safe_str(row.get("chrEmailAddress", "")) or None,
+                    )
+                    db.add(contact1)
+                    db.flush()
+
+                    phone1 = safe_str(row.get("chrPhoneNumber", ""))
+                    if phone1:
+                        db.add(ContactPhone(contact_id=contact1.id, type=PhoneType.work, number=phone1))
+                    cell1 = safe_str(row.get("chrCell", ""))
+                    if cell1:
+                        db.add(ContactPhone(contact_id=contact1.id, type=PhoneType.mobile, number=cell1))
+
+                # Contact 2
+                first2 = safe_str(row.get("chrFirstName2", ""))
+                last2 = safe_str(row.get("chrLastName2", ""))
+                contact_name2 = f"{first2} {last2}".strip()
+                if contact_name2:
+                    contact2 = Contact(
+                        profile_id=profile.id,
+                        name=contact_name2,
+                        job_title=safe_str(row.get("chrTitle2", "")) or None,
+                        email=safe_str(row.get("chrEmailAddress2", "")) or None,
+                    )
+                    db.add(contact2)
+                    db.flush()
+
+                    phone2 = safe_str(row.get("chrPhoneNumber2", ""))
+                    if phone2:
+                        db.add(ContactPhone(contact_id=contact2.id, type=PhoneType.work, number=phone2))
+                    cell2 = safe_str(row.get("chrCell2", ""))
+                    if cell2:
+                        db.add(ContactPhone(contact_id=contact2.id, type=PhoneType.mobile, number=cell2))
+
+            counts["customers"] = count
+
+        # === 3. Vendors (tblVendors) ===
+        if "tblVendors.csv" in file_contents:
+            rows = parse_csv(file_contents["tblVendors.csv"])
+            count = 0
+            for row in rows:
+                legacy_id = safe_int(row.get("VendorID", ""))
+                name = safe_str(row.get("chrCompanyName", ""))
+
+                if not legacy_id or not name:
+                    warnings.append(f"Vendors: skipped row with empty ID or name")
+                    continue
+
+                addr_parts = [
+                    safe_str(row.get("chrAddress", "")),
+                    safe_str(row.get("chrCity", "")),
+                    safe_str(row.get("chrProvince", "")),
+                ]
+                address = ", ".join(p for p in addr_parts if p)
+
+                website = safe_str(row.get("chrWebPage", "")) or None
+
+                profile = Profile(
+                    name=name,
+                    type=ProfileType.vendor,
+                    pst=safe_str(row.get("chrProvincialTax", "")),
+                    address=address,
+                    postal_code=safe_str(row.get("chrPostalCode", "")),
+                    website=website,
+                )
+                db.add(profile)
+                db.flush()
+                vendor_map[legacy_id] = profile.id
+                count += 1
+
+                # One contact per vendor
+                first = safe_str(row.get("chrFirstName", ""))
+                last = safe_str(row.get("chrLastName", ""))
+                contact_name = f"{first} {last}".strip()
+                if contact_name:
+                    contact = Contact(
+                        profile_id=profile.id,
+                        name=contact_name,
+                        email=safe_str(row.get("chrEmailAddress", "")).strip("'") or None,
+                    )
+                    db.add(contact)
+                    db.flush()
+
+                    phone = safe_str(row.get("chrPhoneNumber", ""))
+                    if phone:
+                        db.add(ContactPhone(contact_id=contact.id, type=PhoneType.work, number=phone))
+
+            counts["vendors"] = count
+
+        # === 4. Parts (tblMaterial, skip LM- prefix) ===
+        if "tblMaterial.csv" in file_contents:
+            rows = parse_csv(file_contents["tblMaterial.csv"])
+            count = 0
+            skipped_lm = 0
+            for row in rows:
+                legacy_id = safe_int(row.get("ProductID", ""))
+                part_number = safe_str(row.get("chrProductName", ""))
+
+                if not legacy_id or not part_number:
+                    warnings.append(f"Parts: skipped row with empty ID or part_number")
+                    continue
+
+                # Skip LM- prefix rows (labor+material combos)
+                if part_number.upper().startswith("LM-"):
+                    skipped_lm += 1
+                    continue
+
+                cost = clean_currency(row.get("curNetPrice", ""))
+                markup = safe_float(row.get("intMarkup", ""))
+                vendor_legacy_id = safe_int(row.get("intVendor", ""))
+                cat_legacy_id = safe_int(row.get("intCategory", ""))
+
+                part = Part(
+                    part_number=part_number,
+                    description=safe_str(row.get("chrProductDescription", "")) or part_number,
+                    cost=cost,
+                    markup_percent=markup,
+                    category_id=cat_map_part.get(cat_legacy_id),
+                    vendor_id=vendor_map.get(vendor_legacy_id),
+                )
+                db.add(part)
+                db.flush()
+                part_map[legacy_id] = part.id
+                count += 1
+
+            if skipped_lm:
+                warnings.append(f"Parts: skipped {skipped_lm} LM- prefix rows")
+            counts["parts"] = count
+
+        # === 5. Labor (tblApplication) ===
+        if "tblApplication.csv" in file_contents:
+            rows = parse_csv(file_contents["tblApplication.csv"])
+            count = 0
+            for row in rows:
+                legacy_id = safe_int(row.get("ProductID", ""))
+                description = safe_str(row.get("chrProductDescription", ""))
+
+                if not legacy_id or not description:
+                    warnings.append(f"Labor: skipped row with empty ID or description")
+                    continue
+
+                hours_raw = safe_float(row.get("intTime", ""))
+                net_price = clean_currency(row.get("curNetPrice", ""))
+                markup = safe_float(row.get("intMarkup", ""))
+                cat_legacy_id = safe_int(row.get("intCategory", ""))
+
+                if hours_raw > 0:
+                    rate = net_price / hours_raw
+                    hours = hours_raw
+                else:
+                    rate = net_price
+                    hours = 1
+
+                labor_item = Labor(
+                    description=description,
+                    hours=hours,
+                    rate=rate,
+                    markup_percent=markup,
+                    category_id=cat_map_labor.get(cat_legacy_id),
+                )
+                db.add(labor_item)
+                db.flush()
+                labor_map[legacy_id] = labor_item.id
+                count += 1
+
+            counts["labor"] = count
+
+        # === 6. Miscellaneous (tblZones) ===
+        if "tblZones.csv" in file_contents:
+            rows = parse_csv(file_contents["tblZones.csv"])
+            count = 0
+            for row in rows:
+                legacy_id = safe_int(row.get("ZoneRateID", ""))
+
+                if not legacy_id:
+                    warnings.append(f"Miscellaneous: skipped row with empty ZoneRateID")
+                    continue
+
+                zone_name = safe_str(row.get("chrZones", ""))
+                distance = safe_str(row.get("chrDistance", ""))
+                if zone_name and distance:
+                    desc = f"{zone_name} - {distance}"
+                elif distance:
+                    desc = distance
+                elif zone_name:
+                    desc = zone_name
+                else:
+                    desc = f"Zone {legacy_id}"
+
+                unit_price = clean_currency(row.get("curNetPrice", ""))
+                markup = safe_float(row.get("intMarkup", ""))
+
+                misc = Miscellaneous(
+                    description=desc,
+                    unit_price=unit_price,
+                    markup_percent=markup,
+                    is_system_item=False,
+                )
+                db.add(misc)
+                db.flush()
+                misc_map[legacy_id] = misc.id
+                count += 1
+
+            counts["miscellaneous"] = count
+
+        # === 7. Projects (tblProjects) ===
+        if "tblProjects.csv" in file_contents:
+            rows = parse_csv(file_contents["tblProjects.csv"])
+            count = 0
+            # Track UCA numbers to handle duplicates
+            seen_uca: set[str] = set()
+
+            for row in rows:
+                legacy_id = safe_int(row.get("ProjectID", ""))
+                name = safe_str(row.get("ProjectName", "")) or f"Project {legacy_id}"
+                client_legacy_id = safe_int(row.get("ClientID", ""))
+
+                if not legacy_id:
+                    warnings.append(f"Projects: skipped row with empty ProjectID")
+                    continue
+
+                if client_legacy_id not in customer_map:
+                    warnings.append(f"Projects: skipped ProjectID {legacy_id} — unknown ClientID {client_legacy_id}")
+                    continue
+
+                uca_number = safe_str(row.get("UCAProjectNr", ""))
+                if not uca_number:
+                    uca_number = str(legacy_id)
+
+                # Handle duplicate UCA numbers
+                if uca_number in seen_uca:
+                    uca_number = f"{uca_number}-{legacy_id}"
+                seen_uca.add(uca_number)
+
+                created_on = parse_date(row.get("dtmStartDate", "")) or datetime.utcnow()
+                archive_flag = safe_str(row.get("blnArchive", ""))
+                status = "archived" if archive_flag == "1" else "active"
+
+                project = Project(
+                    name=name,
+                    customer_id=customer_map[client_legacy_id],
+                    created_on=created_on,
+                    status=status,
+                    ucsh_project_number=safe_str(row.get("UCSHProjectNr", "")) or None,
+                    uca_project_number=uca_number,
+                    project_lead=safe_str(row.get("EmployeeID", "")) or None,
+                )
+                db.add(project)
+                db.flush()
+                project_map[legacy_id] = project.id
+                count += 1
+
+            counts["projects"] = count
+
+        # === 8. Quotes (tblServiceRecords) ===
+        if "tblServiceRecords.csv" in file_contents:
+            rows = parse_csv(file_contents["tblServiceRecords.csv"])
+            count = 0
+
+            # Group by project for sequence assignment
+            project_quotes: dict[int, list[dict]] = {}
+            for row in rows:
+                legacy_wo_id = safe_int(row.get("WorkorderID", ""))
+                project_legacy_id = safe_int(row.get("PojectID", ""))
+
+                if not legacy_wo_id:
+                    warnings.append(f"Quotes: skipped row with empty WorkorderID")
+                    continue
+
+                if project_legacy_id not in project_map:
+                    warnings.append(f"Quotes: skipped WorkorderID {legacy_wo_id} — unknown PojectID {project_legacy_id}")
+                    continue
+
+                row["_legacy_wo_id"] = str(legacy_wo_id)
+                row["_project_legacy_id"] = str(project_legacy_id)
+                project_quotes.setdefault(project_legacy_id, []).append(row)
+
+            # Sort each group and assign sequences
+            for proj_legacy_id, quote_rows in project_quotes.items():
+                # Sort by date then by WorkorderID
+                def sort_key(r):
+                    dt = parse_date(r.get("dtmDateStarted", "")) or datetime.min
+                    return (dt, safe_int(r.get("WorkorderID", "")))
+
+                quote_rows.sort(key=sort_key)
+
+                for seq, row in enumerate(quote_rows, start=1):
+                    legacy_wo_id = int(row["_legacy_wo_id"])
+
+                    quote = Quote(
+                        project_id=project_map[proj_legacy_id],
+                        quote_sequence=seq,
+                        created_at=parse_date(row.get("dtmDateStarted", "")) or datetime.utcnow(),
+                        status="Closed",
+                        work_description=safe_str(row.get("memWorkDescription", "")) or None,
+                        client_po_number=safe_str(row.get("intPONumber", "")) or None,
+                        cost_code_id=None,
+                        current_version=0,
+                    )
+                    db.add(quote)
+                    db.flush()
+                    quote_map[legacy_wo_id] = quote.id
+                    count += 1
+
+            counts["quotes"] = count
+
+        # === 9. Quote Labor Items (tblWorkorderApplication) ===
+        if "tblWorkorderApplication.csv" in file_contents:
+            rows = parse_csv(file_contents["tblWorkorderApplication.csv"])
+            count = 0
+            for row in rows:
+                wo_legacy_id = safe_int(row.get("intWorkorderID", ""))
+                labor_legacy_id = safe_int(row.get("intProductName", ""))
+
+                if wo_legacy_id not in quote_map:
+                    warnings.append(f"Quote labor items: skipped row — unknown intWorkorderID {wo_legacy_id}")
+                    continue
+
+                quantity = max(1, safe_int(row.get("intQuantity", ""), 1))
+
+                item = QuoteLineItem(
+                    quote_id=quote_map[wo_legacy_id],
+                    item_type="labor",
+                    labor_id=labor_map.get(labor_legacy_id),
+                    description=safe_str(row.get("chrProductDescription", "")) or None,
+                    quantity=quantity,
+                    unit_price=clean_currency(row.get("curUnitPrice", "")),
+                    base_cost=clean_currency(row.get("curNetPrice", "")),
+                    qty_pending=0,
+                    qty_fulfilled=quantity,
+                )
+                db.add(item)
+                count += 1
+
+            counts["quote_labor_items"] = count
+
+        # === 10. Quote Part Items (tblWorkorderMaterial) ===
+        if "tblWorkorderMaterial.csv" in file_contents:
+            rows = parse_csv(file_contents["tblWorkorderMaterial.csv"])
+            count = 0
+            for row in rows:
+                wo_legacy_id = safe_int(row.get("intWorkorderID", ""))
+                part_legacy_id = safe_int(row.get("intProductName", ""))
+
+                if wo_legacy_id not in quote_map:
+                    warnings.append(f"Quote part items: skipped row — unknown intWorkorderID {wo_legacy_id}")
+                    continue
+
+                quantity = max(1, safe_int(row.get("intQuantity", ""), 1))
+
+                item = QuoteLineItem(
+                    quote_id=quote_map[wo_legacy_id],
+                    item_type="part",
+                    part_id=part_map.get(part_legacy_id),
+                    description=safe_str(row.get("chrProductDescription", "")) or None,
+                    quantity=quantity,
+                    unit_price=clean_currency(row.get("curUnitPrice", "")),
+                    base_cost=clean_currency(row.get("curNetPrice", "")),
+                    qty_pending=0,
+                    qty_fulfilled=quantity,
+                )
+                db.add(item)
+                count += 1
+
+            counts["quote_part_items"] = count
+
+        # === 11. Quote Misc Items (tblWorkorderZones) ===
+        if "tblWorkorderZones.csv" in file_contents:
+            rows = parse_csv(file_contents["tblWorkorderZones.csv"])
+            count = 0
+            for row in rows:
+                wo_legacy_id = safe_int(row.get("intWorkorderID", ""))
+                zone_legacy_id = safe_int(row.get("chrZones", ""))
+
+                if wo_legacy_id not in quote_map:
+                    warnings.append(f"Quote misc items: skipped row — unknown intWorkorderID {wo_legacy_id}")
+                    continue
+
+                quantity = max(1, safe_int(row.get("intQuantity", ""), 1))
+
+                item = QuoteLineItem(
+                    quote_id=quote_map[wo_legacy_id],
+                    item_type="misc",
+                    misc_id=misc_map.get(zone_legacy_id),
+                    description=safe_str(row.get("chrDistance", "")) or None,
+                    quantity=quantity,
+                    unit_price=clean_currency(row.get("curPrice", "")),
+                    base_cost=clean_currency(row.get("curNetPrice", "")),
+                    qty_pending=0,
+                    qty_fulfilled=quantity,
+                )
+                db.add(item)
+                count += 1
+
+            counts["quote_misc_items"] = count
+
+        # === 12. Purchase Orders (tblPurchaseOrders) ===
+        if "tblPurchaseOrders.csv" in file_contents:
+            rows = parse_csv(file_contents["tblPurchaseOrders.csv"])
+            count = 0
+
+            # Group by project for sequence assignment
+            project_pos: dict[int, list[dict]] = {}
+            for row in rows:
+                legacy_po_id = safe_int(row.get("PurchaseOrderID", ""))
+                proj_legacy_id = safe_int(row.get("intProjectID", ""))
+
+                if not legacy_po_id:
+                    warnings.append(f"POs: skipped row with empty PurchaseOrderID")
+                    continue
+
+                if proj_legacy_id not in project_map:
+                    warnings.append(f"POs: skipped POID {legacy_po_id} — unknown intProjectID {proj_legacy_id}")
+                    continue
+
+                vendor_legacy_id = safe_int(row.get("intVendorID", ""))
+                if vendor_legacy_id not in vendor_map:
+                    warnings.append(f"POs: skipped POID {legacy_po_id} — unknown intVendorID {vendor_legacy_id}")
+                    continue
+
+                row["_legacy_po_id"] = str(legacy_po_id)
+                row["_proj_legacy_id"] = str(proj_legacy_id)
+                row["_vendor_legacy_id"] = str(vendor_legacy_id)
+                project_pos.setdefault(proj_legacy_id, []).append(row)
+
+            for proj_legacy_id, po_rows in project_pos.items():
+                def sort_key(r):
+                    dt = parse_date(r.get("dtmOrderDate", "")) or datetime.min
+                    return (dt, safe_int(r.get("PurchaseOrderID", "")))
+
+                po_rows.sort(key=sort_key)
+
+                for seq, row in enumerate(po_rows, start=1):
+                    legacy_po_id = int(row["_legacy_po_id"])
+                    vendor_legacy_id = int(row["_vendor_legacy_id"])
+
+                    po = PurchaseOrder(
+                        project_id=project_map[proj_legacy_id],
+                        vendor_id=vendor_map[vendor_legacy_id],
+                        po_sequence=seq,
+                        created_at=parse_date(row.get("dtmOrderDate", "")) or datetime.utcnow(),
+                        status=POStatus.closed,
+                        work_description=safe_str(row.get("memNote", "")) or None,
+                        cost_code_id=None,
+                        current_version=0,
+                    )
+                    db.add(po)
+                    db.flush()
+                    po_map[legacy_po_id] = po.id
+                    count += 1
+
+            counts["purchase_orders"] = count
+
+        # === 13. PO Line Items (tblPurchaseOrdersMaterial) ===
+        if "tblPurchaseOrdersMaterial.csv" in file_contents:
+            rows = parse_csv(file_contents["tblPurchaseOrdersMaterial.csv"])
+            count = 0
+            for row in rows:
+                po_legacy_id = safe_int(row.get("intPurchaseOrderID", ""))
+                part_legacy_id = safe_int(row.get("intProductID", ""))
+
+                if po_legacy_id not in po_map:
+                    warnings.append(f"PO line items: skipped row — unknown intPurchaseOrderID {po_legacy_id}")
+                    continue
+
+                quantity = max(1, safe_int(row.get("intQtyOrdered", ""), 1))
+                qty_r1 = safe_int(row.get("intQtyReceived1", ""))
+                qty_r2 = safe_int(row.get("intQtyReceived2", ""))
+                qty_r3 = safe_int(row.get("intQtyReceived3", ""))
+                qty_received = qty_r1 + qty_r2 + qty_r3
+                qty_pending = max(0, quantity - qty_received)
+
+                item = POLineItem(
+                    purchase_order_id=po_map[po_legacy_id],
+                    item_type="part",
+                    part_id=part_map.get(part_legacy_id),
+                    description=safe_str(row.get("chrProductDescription", "")) or None,
+                    quantity=quantity,
+                    unit_price=clean_currency(row.get("curUnitPrice", "")),
+                    qty_received=qty_received,
+                    qty_pending=qty_pending,
+                )
+                db.add(item)
+                count += 1
+
+            counts["po_line_items"] = count
+
+        # Commit the entire import
+        db.commit()
+
+        return {
+            "success": True,
+            "counts": counts,
+            "warnings": warnings,
+            "errors": errors,
+            "skipped_files": skipped_files,
+        }
+
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail=f"Migration failed, all changes rolled back: {str(e)}",
+        )

--- a/backend/routes/projects.py
+++ b/backend/routes/projects.py
@@ -48,9 +48,6 @@ def generate_next_uca_number(db: Session) -> str:
     existing = db.query(Project.uca_project_number).all()
     existing_numbers = [row[0] for row in existing if row[0]]
 
-    if not existing_numbers:
-        return "A0001"
-
     def parse_uca(uca: str) -> tuple:
         """Parse UCA into (letter_prefix, number)"""
         match = re.match(r'^([A-Z]+)(\d{4})$', uca)
@@ -63,8 +60,14 @@ def generate_next_uca_number(db: Session) -> str:
         prefix, num = parse_uca(uca)
         return (len(prefix), prefix, num)
 
+    # Filter to only valid-format numbers for auto-generation
+    # (legacy imports may have plain integers like "1", "27", "3679")
+    valid_numbers = [n for n in existing_numbers if re.match(r'^[A-Z]+\d{4}$', n)]
+    if not valid_numbers:
+        return "A0001"
+
     # Find the highest existing UCA number
-    highest = max(existing_numbers, key=uca_sort_key)
+    highest = max(valid_numbers, key=uca_sort_key)
     prefix, number = parse_uca(highest)
 
     # Increment

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import { ProjectDetailsPage } from "@/pages/ProjectDetailsPage"
 import { DiscountCodesPage } from "@/pages/DiscountCodesPage"
 import { ReportsPage } from "@/pages/ReportsPage"
 import { SettingsPage } from "@/pages/SettingsPage"
+import { MigrationPage } from "@/pages/MigrationPage"
 import { api } from "@/api/client"
 import type { Part, Labor, Miscellaneous } from "@/types"
 import {
@@ -37,11 +38,12 @@ import {
   Search,
   BarChart3,
   Settings,
+  DatabaseZap,
 } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Toaster } from "@/components/ui/toaster"
 
-type AppView = "profiles" | "projects" | "project-details" | "inventory" | "discount-codes" | "reports" | "settings"
+type AppView = "profiles" | "projects" | "project-details" | "inventory" | "discount-codes" | "reports" | "settings" | "migration"
 
 function App() {
   const [currentView, setCurrentView] = useState<AppView>("projects")
@@ -198,6 +200,9 @@ function App() {
 
       case "settings":
         return <SettingsPage />
+
+      case "migration":
+        return <MigrationPage />
 
       case "project-details":
         if (selectedProjectId === null) {
@@ -617,6 +622,14 @@ function App() {
             >
               <Settings className="h-4 w-4" />
               Settings
+            </Button>
+            <Button
+              variant={currentView === "migration" ? "secondary" : "ghost"}
+              className="w-full justify-start gap-2"
+              onClick={() => setCurrentView("migration")}
+            >
+              <DatabaseZap className="h-4 w-4" />
+              Migration
             </Button>
           </nav>
         </ScrollArea>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -15,7 +15,7 @@ import type {
   MarkupControlToggleRequest, MarkupControlToggleResponse,
   CommitEditsRequest, CommitEditsResponse,
   CompanySettings, CompanySettingsUpdate, InvoiceSummaryItem,
-  BacklogQuoteItem, PricebookImportResult
+  BacklogQuoteItem, PricebookImportResult, MigrationResult
 } from '@/types';
 
 // API base URL - configurable via environment variable for production
@@ -279,6 +279,29 @@ export const api = {
   // ===== Reports =====
   reports: {
     getBacklogQuotes: () => request<BacklogQuoteItem[]>('/reports/backlog-quotes'),
+  },
+
+  // ===== Legacy Migration =====
+  migration: {
+    import: async (files: File[]): Promise<MigrationResult> => {
+      const formData = new FormData();
+      files.forEach(f => formData.append('files', f));
+      const response = await fetch(`${API_BASE}/migration/import`, {
+        method: 'POST',
+        body: formData,
+      });
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({}));
+        let message = `API error: ${response.status}`;
+        if (typeof error.detail === 'string') {
+          message = error.detail;
+        } else if (Array.isArray(error.detail)) {
+          message = error.detail.map((e: any) => e.msg).join('; ');
+        }
+        throw new Error(message);
+      }
+      return response.json();
+    },
   },
 
   // ===== Vendor Pricebook =====

--- a/frontend/src/pages/MigrationPage.tsx
+++ b/frontend/src/pages/MigrationPage.tsx
@@ -1,0 +1,271 @@
+import { useState, useRef, useCallback } from "react"
+import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Upload, FileCheck, FileX, AlertTriangle, CheckCircle2, Loader2 } from "lucide-react"
+import { api } from "@/api/client"
+import type { MigrationResult } from "@/types"
+
+const EXPECTED_FILES: Record<string, { label: string; entity: string; required: boolean }> = {
+  "tblPartsCategories.csv": { label: "Categories", entity: "categories", required: false },
+  "tblClients.csv": { label: "Customers", entity: "profiles", required: true },
+  "tblVendors.csv": { label: "Vendors", entity: "profiles", required: true },
+  "tblMaterial.csv": { label: "Parts", entity: "parts", required: false },
+  "tblApplication.csv": { label: "Labour", entity: "labor", required: false },
+  "tblZones.csv": { label: "Miscellaneous", entity: "miscellaneous", required: false },
+  "tblProjects.csv": { label: "Projects", entity: "projects", required: true },
+  "tblServiceRecords.csv": { label: "Quotes", entity: "quotes", required: false },
+  "tblWorkorderApplication.csv": { label: "Quote Labour Items", entity: "quote_line_items", required: false },
+  "tblWorkorderMaterial.csv": { label: "Quote Part Items", entity: "quote_line_items", required: false },
+  "tblWorkorderZones.csv": { label: "Quote Misc Items", entity: "quote_line_items", required: false },
+  "tblPurchaseOrders.csv": { label: "Purchase Orders", entity: "purchase_orders", required: false },
+  "tblPurchaseOrdersMaterial.csv": { label: "PO Line Items", entity: "po_line_items", required: false },
+}
+
+export function MigrationPage() {
+  const [files, setFiles] = useState<File[]>([])
+  const [showConfirm, setShowConfirm] = useState(false)
+  const [importing, setImporting] = useState(false)
+  const [result, setResult] = useState<MigrationResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [dragOver, setDragOver] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const recognized = files.filter(f => f.name in EXPECTED_FILES)
+  const unrecognized = files.filter(f => !(f.name in EXPECTED_FILES))
+  const missingRequired = Object.entries(EXPECTED_FILES)
+    .filter(([, meta]) => meta.required)
+    .filter(([name]) => !recognized.some(f => f.name === name))
+    .map(([name, meta]) => ({ name, label: meta.label }))
+
+  const handleFiles = useCallback((newFiles: FileList | null) => {
+    if (!newFiles) return
+    setFiles(Array.from(newFiles))
+    setResult(null)
+    setError(null)
+  }, [])
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    setDragOver(false)
+    handleFiles(e.dataTransfer.files)
+  }, [handleFiles])
+
+  const handleImport = async () => {
+    setShowConfirm(false)
+    setImporting(true)
+    setError(null)
+    setResult(null)
+
+    try {
+      const res = await api.migration.import(recognized)
+      setResult(res)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Import failed")
+    } finally {
+      setImporting(false)
+    }
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Legacy Data Migration</h1>
+        <p className="text-muted-foreground mt-1">
+          Import CSV exports from UC Vision (Access database) into UC Velocity.
+        </p>
+      </div>
+
+      {/* File Upload Zone */}
+      <Card
+        className={`border-2 border-dashed p-8 text-center cursor-pointer transition-colors ${
+          dragOver ? "border-primary bg-primary/5" : "border-muted-foreground/25 hover:border-muted-foreground/50"
+        }`}
+        onClick={() => fileInputRef.current?.click()}
+        onDragOver={(e) => { e.preventDefault(); setDragOver(true) }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={handleDrop}
+      >
+        <Upload className="h-10 w-10 mx-auto text-muted-foreground mb-3" />
+        <p className="font-medium">Drop CSV files here or click to browse</p>
+        <p className="text-sm text-muted-foreground mt-1">
+          Select all 13 legacy CSV files (tblClients.csv, tblVendors.csv, etc.)
+        </p>
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          accept=".csv"
+          className="hidden"
+          onChange={(e) => handleFiles(e.target.files)}
+        />
+      </Card>
+
+      {/* File Analysis */}
+      {files.length > 0 && (
+        <Card className="p-4 space-y-4">
+          <h2 className="font-semibold text-lg">File Analysis</h2>
+
+          {/* Recognized files */}
+          {recognized.length > 0 && (
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-muted-foreground">
+                Recognized ({recognized.length} / {Object.keys(EXPECTED_FILES).length})
+              </p>
+              {recognized.map(f => (
+                <div key={f.name} className="flex items-center gap-2 text-sm py-1">
+                  <FileCheck className="h-4 w-4 text-green-600 shrink-0" />
+                  <span className="font-mono">{f.name}</span>
+                  <span className="text-muted-foreground">&rarr;</span>
+                  <span>{EXPECTED_FILES[f.name].label}</span>
+                  {EXPECTED_FILES[f.name].required && (
+                    <Badge variant="outline" className="text-xs">Required</Badge>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Unrecognized files */}
+          {unrecognized.length > 0 && (
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-muted-foreground">
+                Skipped ({unrecognized.length})
+              </p>
+              {unrecognized.map(f => (
+                <div key={f.name} className="flex items-center gap-2 text-sm py-1 text-muted-foreground">
+                  <FileX className="h-4 w-4 shrink-0" />
+                  <span className="font-mono">{f.name}</span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Missing required files warning */}
+          {missingRequired.length > 0 && (
+            <div className="flex items-start gap-2 p-3 bg-yellow-500/10 border border-yellow-500/20 rounded-md">
+              <AlertTriangle className="h-4 w-4 text-yellow-600 mt-0.5 shrink-0" />
+              <div className="text-sm">
+                <p className="font-medium text-yellow-700 dark:text-yellow-400">Missing required files:</p>
+                <p className="text-muted-foreground">
+                  {missingRequired.map(m => m.name).join(", ")}
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Import Button */}
+          <div className="pt-2">
+            <Button
+              size="lg"
+              disabled={recognized.length === 0 || missingRequired.length > 0 || importing}
+              onClick={() => setShowConfirm(true)}
+            >
+              {importing ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Importing...
+                </>
+              ) : (
+                <>Import {recognized.length} files</>
+              )}
+            </Button>
+          </div>
+        </Card>
+      )}
+
+      {/* Error */}
+      {error && (
+        <Card className="p-4 border-red-500/50 bg-red-500/10">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="h-5 w-5 text-red-600 mt-0.5 shrink-0" />
+            <div>
+              <p className="font-medium text-red-700 dark:text-red-400">Import Failed</p>
+              <p className="text-sm mt-1">{error}</p>
+            </div>
+          </div>
+        </Card>
+      )}
+
+      {/* Results */}
+      {result && (
+        <Card className="p-4 space-y-4">
+          <div className="flex items-center gap-2">
+            <CheckCircle2 className="h-5 w-5 text-green-600" />
+            <h2 className="font-semibold text-lg">Import Complete</h2>
+          </div>
+
+          {/* Counts */}
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            {Object.entries(result.counts).map(([key, count]) => (
+              <div key={key} className="bg-muted/50 rounded-md p-3">
+                <p className="text-2xl font-bold">{count.toLocaleString()}</p>
+                <p className="text-sm text-muted-foreground capitalize">{key.replace(/_/g, " ")}</p>
+              </div>
+            ))}
+          </div>
+
+          {/* Warnings */}
+          {result.warnings.length > 0 && (
+            <div>
+              <p className="text-sm font-medium text-yellow-700 dark:text-yellow-400 mb-1">
+                Warnings ({result.warnings.length})
+              </p>
+              <div className="max-h-48 overflow-y-auto bg-muted/30 rounded-md p-2 space-y-1">
+                {result.warnings.map((w, i) => (
+                  <p key={i} className="text-xs font-mono text-muted-foreground">{w}</p>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Skipped Files */}
+          {result.skipped_files.length > 0 && (
+            <div>
+              <p className="text-sm font-medium text-muted-foreground mb-1">
+                Skipped files: {result.skipped_files.join(", ")}
+              </p>
+            </div>
+          )}
+        </Card>
+      )}
+
+      {/* Confirmation Dialog */}
+      <AlertDialog open={showConfirm} onOpenChange={setShowConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirm Data Wipe & Import</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will <strong>permanently delete all existing data</strong> (categories, profiles,
+              parts, labor, miscellaneous, projects, quotes, purchase orders, and all related records)
+              and replace it with data from the uploaded CSV files.
+              <br /><br />
+              Cost codes, discount codes, and company settings will be preserved.
+              <br /><br />
+              This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleImport}
+              className="bg-red-600 hover:bg-red-700 text-white"
+            >
+              Wipe & Import
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -614,6 +614,15 @@ export interface PricebookImportResult {
   errors: string[];
 }
 
+// ===== Legacy Migration =====
+export interface MigrationResult {
+  success: boolean;
+  counts: Record<string, number>;
+  warnings: string[];
+  errors: string[];
+  skipped_files: string[];
+}
+
 // ===== Quote Snapshots =====
 export type SnapshotActionType = 'create' | 'edit' | 'delete' | 'invoice' | 'revert';
 


### PR DESCRIPTION
## Summary

- **Alembic migration 011**: Makes `cost_code_id` nullable on `quotes` and `purchase_orders` tables (legacy data has no cost codes)
- **Migration endpoint** (`POST /migration/import`): Accepts 13 CSV file uploads, wipes existing data (preserving cost codes, discount codes, company settings), and imports all legacy entities in FK-dependency order within a single transaction
- **UCA number generator fix**: Filters out legacy plain-integer UCA numbers so auto-generation correctly starts at `A0001`
- **Frontend admin page**: Drag-and-drop CSV upload with file recognition, missing-file warnings, destructive-action confirmation dialog, and detailed import results

### Import processing order
1. Categories (dual-mapped for "Application & Material" types)
2. Customers → profiles + contacts + phones
3. Vendors → profiles + contacts + phones
4. Parts (skipping LM- prefix rows)
5. Labor
6. Miscellaneous (zones)
7. Projects (preserving legacy UCA numbers as-is)
8. Quotes (with per-project sequence assignment)
9–11. Quote line items (labor, part, misc)
12. Purchase orders (with per-project sequence assignment)
13. PO line items (with receiving quantity rollup)