### PR TITLE
Fix CSV encoding fallback for legacy Access exports

### DIFF
--- a/backend/routes/migration.py
+++ b/backend/routes/migration.py
@@ -43,8 +43,11 @@ EXPECTED_FILES = [
 
 
 def parse_csv(content: bytes) -> list[dict]:
-    """Parse CSV bytes into list of dicts, handling BOM."""
-    text = content.decode("utf-8-sig")
+    """Parse CSV bytes into list of dicts, handling BOM and legacy encodings."""
+    try:
+        text = content.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        text = content.decode("cp1252")
     reader = csv.DictReader(io.StringIO(text))
     return list(reader)
 


### PR DESCRIPTION
## Summary

- Legacy Access CSV exports use Windows-1252 encoding, causing `UnicodeDecodeError` on byte `0xa6`
- `parse_csv()` now tries UTF-8-sig first, falls back to cp1252 on decode failure
- Affects 10+ of the 13 migration CSV files (tblClients, tblMaterial, tblVendors, tblProjects, tblServiceRecords, etc.)