### PR TITLE
Increase Gunicorn timeout for legacy migration endpoint

### DIFF
--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn main:app -w 4 -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT
+web: gunicorn main:app -w 4 -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT --timeout 300


### PR DESCRIPTION
## Summary

- Gunicorn default worker timeout is 30 seconds
- Legacy migration processes ~200K CSV rows with FK mapping and DB inserts, exceeding 30s
- Worker gets killed with SIGABRT, returning no CORS headers, which browsers report as a CORS error
- Increased to 300s (5 min) to accommodate the migration workload