### PR TITLE
Fix Gunicorn timeout in railway.toml startCommand

### DIFF
--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -16,7 +16,7 @@
 builder = "nixpacks"
 
 [deploy]
-startCommand = "gunicorn main:app -w 4 -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT"
+startCommand = "gunicorn main:app -w 4 -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT --timeout 300"
 healthcheckPath = "/health"
 healthcheckTimeout = 100
 restartPolicyType = "on_failure"


### PR DESCRIPTION
## Summary

- Adds `--timeout 300` to the `startCommand` in `backend/railway.toml`, which is the config Railway actually uses
- The Procfile fix from PR #38 was correct but ineffective because `railway.toml`'s `startCommand` takes precedence
- Without this, Gunicorn kills workers after 30s (default), aborting the migration import and returning a CORS error to the browser (no CORS headers on worker timeout responses)