### PR TITLE
Fix "Create New" item crash in SearchableSelect

### DIFF
--- a/frontend/src/components/forms/LaborForm.tsx
+++ b/frontend/src/components/forms/LaborForm.tsx
@@ -7,7 +7,7 @@ import type { Labor, LaborCreate } from "@/types"
 
 interface LaborFormProps {
   labor?: Labor // If provided, we're editing; otherwise creating
-  onSuccess?: () => void
+  onSuccess?: (item?: Labor) => void
   onCancel?: () => void
 }
 
@@ -66,12 +66,13 @@ export function LaborForm({ labor, onSuccess, onCancel }: LaborFormProps) {
     }
 
     try {
+      let result: Labor | undefined
       if (isEditing && labor) {
-        await api.labor.update(labor.id, laborData)
+        result = await api.labor.update(labor.id, laborData)
       } else {
-        await api.labor.create(laborData)
+        result = await api.labor.create(laborData)
       }
-      onSuccess?.()
+      onSuccess?.(result)
     } catch (err) {
       setError(err instanceof Error ? err.message : `Failed to ${isEditing ? 'update' : 'create'} labor`)
     } finally {

--- a/frontend/src/components/forms/MiscForm.tsx
+++ b/frontend/src/components/forms/MiscForm.tsx
@@ -7,7 +7,7 @@ import type { Miscellaneous, MiscellaneousCreate } from "@/types"
 
 interface MiscFormProps {
   misc?: Miscellaneous // If provided, we're editing; otherwise creating
-  onSuccess?: () => void
+  onSuccess?: (item?: Miscellaneous) => void
   onCancel?: () => void
 }
 
@@ -48,12 +48,13 @@ export function MiscForm({ misc, onSuccess, onCancel }: MiscFormProps) {
     }
 
     try {
+      let result: Miscellaneous | undefined
       if (isEditing && misc) {
-        await api.misc.update(misc.id, miscData)
+        result = await api.misc.update(misc.id, miscData)
       } else {
-        await api.misc.create(miscData)
+        result = await api.misc.create(miscData)
       }
-      onSuccess?.()
+      onSuccess?.(result)
     } catch (err) {
       setError(err instanceof Error ? err.message : `Failed to ${isEditing ? 'update' : 'create'} miscellaneous item`)
     } finally {

--- a/frontend/src/components/forms/PartForm.tsx
+++ b/frontend/src/components/forms/PartForm.tsx
@@ -17,7 +17,7 @@ import { LaborForm } from "./LaborForm"
 
 interface PartFormProps {
   part?: Part // If provided, we're editing; otherwise creating
-  onSuccess?: () => void
+  onSuccess?: (item?: Part) => void
   onCancel?: () => void
 }
 
@@ -128,12 +128,13 @@ export function PartForm({ part, onSuccess, onCancel }: PartFormProps) {
     }
 
     try {
+      let result: Part | undefined
       if (isEditing && part) {
-        await api.parts.update(part.id, partData)
+        result = await api.parts.update(part.id, partData)
       } else {
-        await api.parts.create(partData)
+        result = await api.parts.create(partData)
       }
-      onSuccess?.()
+      onSuccess?.(result)
     } catch (err) {
       setError(err instanceof Error ? err.message : `Failed to ${isEditing ? 'update' : 'create'} part`)
     } finally {


### PR DESCRIPTION
## Summary
- **Root cause**: `PartForm`, `LaborForm`, and `MiscForm` called `onSuccess()` with no arguments after `api.*.create()`, discarding the API response. `SearchableSelect` injects `onSuccess` via `cloneElement` expecting the created item back — accessing `.id` on `undefined` caused a TypeError and blank screen.
- **Fix**: Capture the return value from `create()`/`update()` and forward it through `onSuccess(result)`. The callback type is widened to `(item?: T) => void` so existing no-arg callers remain compatible.

Fixes #45