### PR TITLE
Fix SearchableSelect dropdown width and LaborForm step validation

### DIFF
--- a/frontend/src/components/forms/LaborForm.tsx
+++ b/frontend/src/components/forms/LaborForm.tsx
@@ -105,8 +105,8 @@ export function LaborForm({ labor, onSuccess, onCancel }: LaborFormProps) {
           <Input
             id="hours"
             type="number"
-            step="0.25"
-            min="0.01"
+            step="any"
+            min="0"
             value={hours}
             onChange={(e) => setHours(e.target.value)}
             placeholder="1"

--- a/frontend/src/components/ui/searchable-multi-select.tsx
+++ b/frontend/src/components/ui/searchable-multi-select.tsx
@@ -132,7 +132,7 @@ export function SearchableMultiSelect<T>({
             <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+        <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
           <Command shouldFilter={false}>
             <CommandInput
               placeholder={searchPlaceholder}

--- a/frontend/src/components/ui/searchable-select.tsx
+++ b/frontend/src/components/ui/searchable-select.tsx
@@ -108,7 +108,7 @@ export function SearchableSelect<T>({
             <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+        <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
           <Command shouldFilter={false}>
             <CommandInput
               placeholder={searchPlaceholder}


### PR DESCRIPTION
## Summary
- **SearchableSelect/SearchableMultiSelect dropdown full-width bug**: `w-[--radix-popover-trigger-width]` compiled to invalid CSS in Tailwind v4 (missing `var()` wrapper). The browser ignored the width declaration, causing the popover to size to content — filling the viewport for large item lists (e.g., parts) and breaking scroll. Fixed by using `w-[var(--radix-popover-trigger-width)]`.
- **LaborForm hours rejecting round numbers**: `step="0.25"` + `min="0.01"` created a valid-step grid starting at 0.01 (0.01, 0.26, 0.51, 0.76, 1.01…), so entering `1` was rejected by the browser. Changed to `step="any"` + `min="0"` — the existing JS validation already enforces positive values with max 2 decimal places.