### PR TITLE
Add company logo upload to Company Info (#73)

### DIFF
--- a/backend/alembic/versions/20260420_016_add_company_logo.py
+++ b/backend/alembic/versions/20260420_016_add_company_logo.py
@@ -1,0 +1,28 @@
+"""Add logo_data_url column to company_settings
+
+Stores the company logo as a base64 data URL (e.g. 'data:image/png;base64,...').
+Nullable — when NULL the frontend falls back to the bundled default logo.
+
+Revision ID: 016_add_company_logo
+Revises: 015_fix_backfill_base_cost
+Create Date: 2026-04-20
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '016_add_company_logo'
+down_revision = '015_fix_backfill_base_cost'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute(sa.text(
+        "ALTER TABLE company_settings ADD COLUMN IF NOT EXISTS logo_data_url TEXT"
+    ))
+
+
+def downgrade():
+    op.drop_column('company_settings', 'logo_data_url')

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Float, ForeignKey, Enum, Table, DateTime, Boolean, UniqueConstraint
+from sqlalchemy import Column, Integer, String, Float, ForeignKey, Enum, Table, DateTime, Boolean, UniqueConstraint, Text
 from sqlalchemy.orm import relationship
 from datetime import datetime
 import enum
@@ -426,6 +426,7 @@ class CompanySettings(Base):
     gst_number = Column(String)
     hst_rate = Column(Float, default=13.0)
     default_pms_percent = Column(Float, nullable=True)
+    logo_data_url = Column(Text, nullable=True)
 
 
 class QuoteLineItemSnapshot(Base):

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -18,6 +18,7 @@ class CompanySettingsBase(BaseModel):
     gst_number: Optional[str] = None
     hst_rate: float = 13.0
     default_pms_percent: Optional[float] = None
+    logo_data_url: Optional[str] = None
 
 
 class CompanySettingsUpdate(BaseModel):
@@ -28,6 +29,7 @@ class CompanySettingsUpdate(BaseModel):
     gst_number: Optional[str] = None
     hst_rate: Optional[float] = None
     default_pms_percent: Optional[float] = None
+    logo_data_url: Optional[str] = None
 
 
 class CompanySettings(CompanySettingsBase):

--- a/frontend/src/components/pdf/PDFHeader.tsx
+++ b/frontend/src/components/pdf/PDFHeader.tsx
@@ -16,7 +16,7 @@ export function PDFHeader({ companySettings, title, children }: PDFHeaderProps) 
       <View style={styles.headerRow}>
         {/* Left: Logo + Company Info */}
         <View style={styles.headerLeft}>
-          <Image src={logo} style={styles.logo} />
+          <Image src={companySettings.logo_data_url || logo} style={styles.logo} />
           <View style={styles.companyInfo}>
             <Text style={styles.companyName}>{companySettings.name}</Text>
             {companySettings.address && <Text>{companySettings.address}</Text>}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -24,7 +24,7 @@ import {
 } from '@/components/ui/alert-dialog'
 import { api } from '@/api/client'
 import type { CompanySettings, CompanySettingsUpdate, CostCode, CostCodeCreate, SystemRate, SystemRateCreate, SystemRateUpdate } from '@/types'
-import { Loader2, Save, Pencil, Trash2, Plus, X, Check } from 'lucide-react'
+import { Loader2, Save, Pencil, Trash2, Plus, X, Check, Upload } from 'lucide-react'
 
 // Inline editing row state
 interface CostCodeEditState {
@@ -80,6 +80,10 @@ export function SettingsPage() {
   // PMS default state
   const [pmsDefault, setPmsDefault] = useState('')
 
+  // Company logo state (base64 data URL)
+  const [logoDataUrl, setLogoDataUrl] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+
   useEffect(() => {
     fetchSettings()
     fetchCostCodes()
@@ -100,11 +104,41 @@ export function SettingsPage() {
       setGstNumber(data.gst_number || '')
       setHstRate(String(data.hst_rate ?? 13.0))
       setPmsDefault(data.default_pms_percent != null ? String(data.default_pms_percent) : '')
+      setLogoDataUrl(data.logo_data_url ?? null)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load settings')
     } finally {
       setLoading(false)
     }
+  }
+
+  const handleLogoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    const MAX_BYTES = 2 * 1024 * 1024
+    if (file.size > MAX_BYTES) {
+      setError('Logo image must be 2MB or smaller.')
+      e.target.value = ''
+      return
+    }
+
+    const reader = new FileReader()
+    reader.onload = () => {
+      if (typeof reader.result === 'string') {
+        setLogoDataUrl(reader.result)
+        setError(null)
+      }
+    }
+    reader.onerror = () => {
+      setError('Failed to read logo image.')
+    }
+    reader.readAsDataURL(file)
+    e.target.value = ''
+  }
+
+  const handleRemoveLogo = () => {
+    setLogoDataUrl(null)
   }
 
   const fetchCostCodes = async () => {
@@ -295,6 +329,7 @@ export function SettingsPage() {
         gst_number: gstNumber,
         hst_rate: hstValue,
         default_pms_percent: pmsValue,
+        logo_data_url: logoDataUrl,
       }
       const data = await api.companySettings.update(update)
       setSettings(data)
@@ -475,6 +510,42 @@ export function SettingsPage() {
                 value={fax}
                 onChange={(e) => setFax(e.target.value)}
               />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Company Logo</Label>
+            <div className="flex items-start gap-4">
+              <div className="flex h-20 w-20 shrink-0 items-center justify-center rounded-md border bg-muted/30 overflow-hidden">
+                {logoDataUrl ? (
+                  <img src={logoDataUrl} alt="Company logo" className="max-h-full max-w-full object-contain" />
+                ) : (
+                  <span className="text-xs text-muted-foreground">No logo</span>
+                )}
+              </div>
+              <div className="space-y-2">
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp"
+                  onChange={handleLogoChange}
+                  className="hidden"
+                />
+                <div className="flex gap-2">
+                  <Button type="button" variant="outline" size="sm" onClick={() => fileInputRef.current?.click()} className="gap-1">
+                    <Upload className="h-3.5 w-3.5" />
+                    {logoDataUrl ? 'Replace logo' : 'Upload logo'}
+                  </Button>
+                  {logoDataUrl && (
+                    <Button type="button" variant="ghost" size="sm" onClick={handleRemoveLogo}>
+                      Remove
+                    </Button>
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  PNG, JPEG, or WebP. Max 2MB. Appears on quote, invoice, and PO PDFs. Click "Save Settings" below to apply.
+                </p>
+              </div>
             </div>
           </div>
         </CardContent>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -10,6 +10,7 @@ export interface CompanySettings {
   gst_number?: string;
   hst_rate: number;
   default_pms_percent?: number | null;
+  logo_data_url?: string | null;
 }
 
 export interface CompanySettingsUpdate {
@@ -20,6 +21,7 @@ export interface CompanySettingsUpdate {
   gst_number?: string;
   hst_rate?: number;
   default_pms_percent?: number | null;
+  logo_data_url?: string | null;
 }
 
 // ===== System Rates =====


### PR DESCRIPTION
## Summary
- Adds `logo_data_url` TEXT column to `company_settings` (new migration `016_add_company_logo`) storing the logo as a base64 data URL.
- Adds a logo upload field (PNG/JPEG/WebP, 2MB cap) to the Company Information card on the Settings page with preview and Remove controls.
- Wires `PDFHeader` to use `companySettings.logo_data_url` for Quote, Invoice, Purchase Order, and Invoice Summary PDFs, falling back to the bundled `logo.png` when no logo is uploaded.

Fixes #73