### PR TITLE
Fix Add Line Item dialog width when part name is long (#71)

### DIFF
--- a/frontend/src/components/editors/POEditor.tsx
+++ b/frontend/src/components/editors/POEditor.tsx
@@ -1614,7 +1614,7 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
 
       {/* Add Line Item Dialog */}
       <Dialog open={addDialogOpen} onOpenChange={setAddDialogOpen}>
-        <DialogContent>
+        <DialogContent className="max-w-2xl">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               {getTypeIcon(addDialogType)}

--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -3166,7 +3166,7 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
 
       {/* Add Line Item Dialog */}
       <Dialog open={addDialogOpen} onOpenChange={setAddDialogOpen}>
-        <DialogContent>
+        <DialogContent className="max-w-2xl">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               {getTypeIcon(addDialogType)}


### PR DESCRIPTION
Fixes #71.

## Summary
- Long part labels (e.g. `10MS41-RA - 10MS41-RA Magic Switch, Touchess, SS 6" ROUND, ACCESS LOGO`) were pushing the **Add Part** dialog past its intended max width. Root cause: `DialogContent`'s `grid` layout refuses to shrink below min-content, and `SearchableSelect` renders the selected label as a raw text node with no truncation — so the button's min-content became the dialog's floor and blew past `max-w-lg`.
- Widen the Add Line Item dialog in both `POEditor.tsx` and `QuoteEditor.tsx` from the default `max-w-lg` (32rem) to `max-w-2xl` (42rem). This matches the existing Receiving and Edit Preview dialogs in `POEditor` and gives long labels room to breathe without introducing truncation.