### PR TITLE
perf(projects): kill Projects list payload (Phase 1)

### DIFF
--- a/backend/routes/projects.py
+++ b/backend/routes/projects.py
@@ -1,11 +1,22 @@
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.orm import Session, joinedload
-from typing import List
+from sqlalchemy import String, and_, cast, func, literal, or_
+from sqlalchemy.orm import Session, aliased, joinedload
+from typing import Dict, List, Optional, Set
 import re
 
 from database import get_db
 from models import Project, Profile, ProfileType, PurchaseOrder, Quote
-from schemas import ProjectCreate, ProjectUpdate, Project as ProjectSchema, ProjectFull, Quote as QuoteSchema
+from schemas import (
+    ProjectCreate,
+    ProjectUpdate,
+    Project as ProjectSchema,
+    ProjectFull,
+    ProjectListView,
+    ProjectSearchResult,
+    MatchedQuoteRef,
+    MatchedPORef,
+    Quote as QuoteSchema,
+)
 from routes.purchase_orders import format_po_number
 
 
@@ -89,6 +100,245 @@ def get_all_projects(skip: int = 0, limit: int = None, db: Session = Depends(get
         .all()
     )
     return projects
+
+
+def _build_list_view_rows(db: Session, project_ids: Optional[Set[int]] = None) -> List[ProjectListView]:
+    """
+    Build the aggregated list-view rows for projects.
+
+    Uses window functions to compute quote_count, po_count, and latest sequence/version
+    per project in a single query — avoids hydrating line items or full child documents.
+    Optionally filters to a specific set of project IDs (used by /search).
+    """
+    quote_agg = (
+        db.query(
+            Quote.project_id.label("pid"),
+            Quote.quote_sequence.label("seq"),
+            Quote.current_version.label("ver"),
+            func.count(Quote.id).over(partition_by=Quote.project_id).label("cnt"),
+            func.row_number()
+            .over(partition_by=Quote.project_id, order_by=Quote.quote_sequence.desc())
+            .label("rn"),
+        )
+        .subquery()
+    )
+
+    po_agg = (
+        db.query(
+            PurchaseOrder.project_id.label("pid"),
+            PurchaseOrder.po_sequence.label("seq"),
+            PurchaseOrder.current_version.label("ver"),
+            func.count(PurchaseOrder.id).over(partition_by=PurchaseOrder.project_id).label("cnt"),
+            func.row_number()
+            .over(partition_by=PurchaseOrder.project_id, order_by=PurchaseOrder.po_sequence.desc())
+            .label("rn"),
+        )
+        .subquery()
+    )
+
+    query = (
+        db.query(
+            Project.id,
+            Project.name,
+            Project.uca_project_number,
+            Project.ucsh_project_number,
+            Project.customer_id,
+            Project.project_lead,
+            Project.status,
+            Project.created_on,
+            Profile.name.label("customer_name"),
+            func.coalesce(quote_agg.c.cnt, 0).label("quote_count"),
+            quote_agg.c.seq.label("latest_quote_seq"),
+            quote_agg.c.ver.label("latest_quote_ver"),
+            func.coalesce(po_agg.c.cnt, 0).label("po_count"),
+            po_agg.c.seq.label("latest_po_seq"),
+            po_agg.c.ver.label("latest_po_ver"),
+        )
+        .outerjoin(Profile, Project.customer_id == Profile.id)
+        .outerjoin(quote_agg, and_(quote_agg.c.pid == Project.id, quote_agg.c.rn == 1))
+        .outerjoin(po_agg, and_(po_agg.c.pid == Project.id, po_agg.c.rn == 1))
+        .order_by(Project.id)
+    )
+
+    if project_ids is not None:
+        if not project_ids:
+            return []
+        query = query.filter(Project.id.in_(project_ids))
+
+    rows = query.all()
+
+    result: List[ProjectListView] = []
+    for r in rows:
+        latest_quote_number = (
+            format_quote_number(r.uca_project_number, r.latest_quote_seq, r.latest_quote_ver)
+            if r.latest_quote_seq is not None
+            else None
+        )
+        latest_po_number = (
+            format_po_number(r.uca_project_number, r.latest_po_seq, r.latest_po_ver)
+            if r.latest_po_seq is not None
+            else None
+        )
+        result.append(
+            ProjectListView(
+                id=r.id,
+                name=r.name,
+                uca_project_number=r.uca_project_number,
+                ucsh_project_number=r.ucsh_project_number,
+                customer_id=r.customer_id,
+                customer_name=r.customer_name or "",
+                project_lead=r.project_lead,
+                status=r.status,
+                created_on=r.created_on,
+                quote_count=r.quote_count,
+                po_count=r.po_count,
+                latest_quote_number=latest_quote_number,
+                latest_po_number=latest_po_number,
+            )
+        )
+    return result
+
+
+@router.get("/list-view", response_model=List[ProjectListView])
+def get_projects_list_view(db: Session = Depends(get_db)):
+    """
+    Lightweight aggregated list of projects for the Projects page.
+
+    Returns a flat shape per project with child-doc counts and latest quote/PO
+    numbers, computed in a single SQL query. Avoids hydrating line items, vendors,
+    or cost codes — payload is tens of KB instead of MB for typical data sizes.
+    """
+    return _build_list_view_rows(db)
+
+
+@router.get("/search", response_model=List[ProjectSearchResult])
+def search_projects(q: str = "", db: Session = Depends(get_db)):
+    """
+    Server-side cross-entity search across projects, quotes, POs, and vendors.
+
+    A project is returned if it matches directly (name, UCA, UCSH, customer,
+    project lead, status) OR has matching child quotes or POs. Matched child
+    refs are returned alongside so the UI can offer click-through hints.
+    """
+    term = q.strip()
+    if not term:
+        return []
+
+    pattern = f"%{term}%"
+
+    # Direct project matches (project fields + customer name)
+    direct_q = (
+        db.query(Project.id)
+        .outerjoin(Profile, Project.customer_id == Profile.id)
+        .filter(
+            or_(
+                Project.name.ilike(pattern),
+                Project.uca_project_number.ilike(pattern),
+                func.coalesce(Project.ucsh_project_number, "").ilike(pattern),
+                func.coalesce(Profile.name, "").ilike(pattern),
+                func.coalesce(Project.project_lead, "").ilike(pattern),
+                Project.status.ilike(pattern),
+            )
+        )
+    )
+    direct_ids: Set[int] = {row[0] for row in direct_q.all()}
+
+    # Quote matches — formatted quote_number is "{UCA}-{seq:04d}-{ver}"
+    quote_number_expr = (
+        Project.uca_project_number
+        + literal("-")
+        + func.lpad(cast(Quote.quote_sequence, String), 4, "0")
+        + literal("-")
+        + cast(Quote.current_version, String)
+    )
+    quote_rows = (
+        db.query(
+            Quote.id,
+            Quote.project_id,
+            Quote.quote_sequence,
+            Quote.current_version,
+            Project.uca_project_number,
+        )
+        .join(Project, Quote.project_id == Project.id)
+        .filter(
+            or_(
+                quote_number_expr.ilike(pattern),
+                func.coalesce(Quote.client_po_number, "").ilike(pattern),
+                func.coalesce(Quote.work_description, "").ilike(pattern),
+            )
+        )
+        .order_by(Quote.project_id, Quote.quote_sequence)
+        .all()
+    )
+
+    # PO matches — formatted po_number is "PO-{UCA}-{seq:04d}-{ver}"
+    Vendor = aliased(Profile)
+    po_number_expr = (
+        literal("PO-")
+        + Project.uca_project_number
+        + literal("-")
+        + func.lpad(cast(PurchaseOrder.po_sequence, String), 4, "0")
+        + literal("-")
+        + cast(PurchaseOrder.current_version, String)
+    )
+    po_rows = (
+        db.query(
+            PurchaseOrder.id,
+            PurchaseOrder.project_id,
+            PurchaseOrder.po_sequence,
+            PurchaseOrder.current_version,
+            Project.uca_project_number,
+            Vendor.name.label("vendor_name"),
+        )
+        .join(Project, PurchaseOrder.project_id == Project.id)
+        .outerjoin(Vendor, PurchaseOrder.vendor_id == Vendor.id)
+        .filter(
+            or_(
+                po_number_expr.ilike(pattern),
+                func.coalesce(Vendor.name, "").ilike(pattern),
+                func.coalesce(PurchaseOrder.vendor_po_number, "").ilike(pattern),
+                func.coalesce(PurchaseOrder.work_description, "").ilike(pattern),
+            )
+        )
+        .order_by(PurchaseOrder.project_id, PurchaseOrder.po_sequence)
+        .all()
+    )
+
+    matched_quotes_by_pid: Dict[int, List[MatchedQuoteRef]] = {}
+    for r in quote_rows:
+        matched_quotes_by_pid.setdefault(r.project_id, []).append(
+            MatchedQuoteRef(
+                id=r.id,
+                quote_number=format_quote_number(r.uca_project_number, r.quote_sequence, r.current_version),
+            )
+        )
+
+    matched_pos_by_pid: Dict[int, List[MatchedPORef]] = {}
+    for r in po_rows:
+        matched_pos_by_pid.setdefault(r.project_id, []).append(
+            MatchedPORef(
+                id=r.id,
+                po_number=format_po_number(r.uca_project_number, r.po_sequence, r.current_version),
+                vendor_name=r.vendor_name or "",
+            )
+        )
+
+    all_project_ids = direct_ids | set(matched_quotes_by_pid.keys()) | set(matched_pos_by_pid.keys())
+    if not all_project_ids:
+        return []
+
+    list_view_rows = _build_list_view_rows(db, project_ids=all_project_ids)
+
+    result: List[ProjectSearchResult] = []
+    for lv in list_view_rows:
+        result.append(
+            ProjectSearchResult(
+                **lv.model_dump(),
+                matched_quotes=matched_quotes_by_pid.get(lv.id, []),
+                matched_pos=matched_pos_by_pid.get(lv.id, []),
+            )
+        )
+    return result
 
 
 @router.get("/{project_id}", response_model=ProjectFull)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -738,6 +738,39 @@ class ProjectFull(Project):
         from_attributes = True
 
 
+# ===== Project List View (lightweight, aggregated) =====
+class ProjectListView(BaseModel):
+    id: int
+    name: str
+    uca_project_number: str
+    ucsh_project_number: Optional[str] = None
+    customer_id: int
+    customer_name: str
+    project_lead: Optional[str] = None
+    status: str
+    created_on: datetime
+    quote_count: int = 0
+    po_count: int = 0
+    latest_quote_number: Optional[str] = None
+    latest_po_number: Optional[str] = None
+
+
+class MatchedQuoteRef(BaseModel):
+    id: int
+    quote_number: str
+
+
+class MatchedPORef(BaseModel):
+    id: int
+    po_number: str
+    vendor_name: str
+
+
+class ProjectSearchResult(ProjectListView):
+    matched_quotes: List[MatchedQuoteRef] = []
+    matched_pos: List[MatchedPORef] = []
+
+
 # ===== Invoice Line Item Schemas =====
 class InvoiceLineItemBase(BaseModel):
     quote_line_item_id: Optional[int] = None

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5,7 +5,7 @@ import type {
   CostCode, CostCodeCreate, CostCodeUpdate,
   Profile, ProfileCreate, ProfileUpdate, ProfileType,
   Contact, ContactCreate, ContactUpdate,
-  Project, ProjectCreate, ProjectFull,
+  Project, ProjectCreate, ProjectFull, ProjectListView, ProjectSearchResult,
   Quote, QuoteCreate, QuoteUpdate, QuoteLineItem, QuoteLineItemCreate, QuoteLineItemUpdate,
   PurchaseOrder, PurchaseOrderCreate, PurchaseOrderUpdate, POLineItem, POLineItemCreate,
   POReceiving, POReceivingCreate, POSnapshot, PORevertPreview,
@@ -97,6 +97,9 @@ export const api = {
   // ===== Projects =====
   projects: {
     getAll: () => request<Project[]>('/projects/'),
+    getListView: () => request<ProjectListView[]>('/projects/list-view'),
+    search: (q: string) =>
+      request<ProjectSearchResult[]>(`/projects/search?q=${encodeURIComponent(q)}`),
     get: (id: number) => request<ProjectFull>(`/projects/${id}`),
     create: (data: ProjectCreate) =>
       request<Project>('/projects/', { method: 'POST', body: JSON.stringify(data) }),

--- a/frontend/src/components/forms/ProjectForm.tsx
+++ b/frontend/src/components/forms/ProjectForm.tsx
@@ -16,8 +16,15 @@ import type { Profile, Project, ProjectCreate, Contact } from "@/types"
 import { ProfileForm } from "./ProfileForm"
 import { ContactForm } from "./ContactForm"
 
+// Only the fields the form actually reads — lets us accept both a full Project
+// and the lighter ProjectListView shape (which omits the nested customer profile).
+export type ProjectFormInput = Pick<
+  Project,
+  "id" | "name" | "customer_id" | "status" | "ucsh_project_number" | "project_lead" | "uca_project_number" | "created_on"
+>
+
 interface ProjectFormProps {
-  project?: Project // If provided, we're editing; otherwise creating
+  project?: ProjectFormInput // If provided, we're editing; otherwise creating
   onSuccess?: () => void
   onCancel?: () => void
 }

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, useEffect, useMemo } from "react"
+import { Fragment, useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
@@ -18,8 +18,9 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { ProjectForm } from "@/components/forms/ProjectForm"
+import type { ProjectFormInput } from "@/components/forms/ProjectForm"
 import { api } from "@/api/client"
-import type { Project, Quote, PurchaseOrder } from "@/types"
+import type { ProjectListView, ProjectSearchResult } from "@/types"
 import { Plus, Trash2, Pencil, FolderOpen, Search, FileText, ShoppingCart } from "lucide-react"
 
 interface ProjectsPageProps {
@@ -29,32 +30,48 @@ interface ProjectsPageProps {
   onSearchTermChange: (value: string) => void
 }
 
+const SEARCH_DEBOUNCE_MS = 300
+
+const toSearchResultShape = (p: ProjectListView): ProjectSearchResult => ({
+  ...p,
+  matched_quotes: [],
+  matched_pos: [],
+})
+
+const toFormInput = (p: ProjectListView): ProjectFormInput => ({
+  id: p.id,
+  name: p.name,
+  customer_id: p.customer_id,
+  status: p.status,
+  ucsh_project_number: p.ucsh_project_number,
+  project_lead: p.project_lead,
+  uca_project_number: p.uca_project_number,
+  created_on: p.created_on,
+})
+
 export function ProjectsPage({
   onSelectProject,
   onSelectChildDoc,
   searchTerm,
   onSearchTermChange,
 }: ProjectsPageProps) {
-  const [projects, setProjects] = useState<Project[]>([])
-  const [quotes, setQuotes] = useState<Quote[]>([])
-  const [purchaseOrders, setPurchaseOrders] = useState<PurchaseOrder[]>([])
+  const [baseProjects, setBaseProjects] = useState<ProjectSearchResult[]>([])
+  const [searchResults, setSearchResults] = useState<ProjectSearchResult[] | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [debouncedTerm, setDebouncedTerm] = useState(searchTerm)
   const [dialogOpen, setDialogOpen] = useState(false)
-  const [editingProject, setEditingProject] = useState<Project | null>(null)
+  const [editingProject, setEditingProject] = useState<ProjectFormInput | null>(null)
 
-  const fetchData = async () => {
+  // When a search is active, show search results; otherwise show the full list.
+  const displayProjects = searchResults ?? baseProjects
+
+  const fetchBaseList = async () => {
     setLoading(true)
     setError(null)
     try {
-      const [projectsData, quotesData, posData] = await Promise.all([
-        api.projects.getAll(),
-        api.quotes.getAll(),
-        api.purchaseOrders.getAll(),
-      ])
-      setProjects(projectsData)
-      setQuotes(quotesData)
-      setPurchaseOrders(posData)
+      const data = await api.projects.getListView()
+      setBaseProjects(data.map(toSearchResultShape))
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to fetch projects")
     } finally {
@@ -63,23 +80,67 @@ export function ProjectsPage({
   }
 
   useEffect(() => {
-    fetchData()
+    fetchBaseList()
   }, [])
+
+  // Debounce raw search term so we don't fire a request on every keystroke.
+  useEffect(() => {
+    const handle = setTimeout(() => setDebouncedTerm(searchTerm), SEARCH_DEBOUNCE_MS)
+    return () => clearTimeout(handle)
+  }, [searchTerm])
+
+  // Run cross-entity search when the debounced term changes. Use a cancelled flag
+  // so a stale response from an earlier query can't overwrite a newer one.
+  useEffect(() => {
+    const term = debouncedTerm.trim()
+    if (!term) {
+      setSearchResults(null)
+      return
+    }
+    let cancelled = false
+    api.projects
+      .search(term)
+      .then((data) => {
+        if (!cancelled) setSearchResults(data)
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Search failed")
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [debouncedTerm])
+
+  // After a mutation, refresh both the base list and any active search.
+  const refreshAll = async () => {
+    await fetchBaseList()
+    const term = debouncedTerm.trim()
+    if (!term) {
+      setSearchResults(null)
+      return
+    }
+    try {
+      const data = await api.projects.search(term)
+      setSearchResults(data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Search failed")
+    }
+  }
 
   const handleDelete = async (id: number, e: React.MouseEvent) => {
     e.stopPropagation()
     if (!confirm("Are you sure you want to delete this project? All quotes and purchase orders will be deleted.")) return
     try {
       await api.projects.delete(id)
-      fetchData()
+      refreshAll()
     } catch (err) {
       alert(err instanceof Error ? err.message : "Failed to delete project")
     }
   }
 
-  const handleEdit = (project: Project, e: React.MouseEvent) => {
+  const handleEdit = (project: ProjectListView, e: React.MouseEvent) => {
     e.stopPropagation()
-    setEditingProject(project)
+    setEditingProject(toFormInput(project))
     setDialogOpen(true)
   }
 
@@ -107,75 +168,6 @@ export function ProjectsPage({
         return <Badge variant="outline">{status}</Badge>
     }
   }
-
-  const quotesByProject = useMemo(() => {
-    const map = new Map<number, Quote[]>()
-    for (const q of quotes) {
-      const arr = map.get(q.project_id) ?? []
-      arr.push(q)
-      map.set(q.project_id, arr)
-    }
-    return map
-  }, [quotes])
-
-  const posByProject = useMemo(() => {
-    const map = new Map<number, PurchaseOrder[]>()
-    for (const po of purchaseOrders) {
-      const arr = map.get(po.project_id) ?? []
-      arr.push(po)
-      map.set(po.project_id, arr)
-    }
-    return map
-  }, [purchaseOrders])
-
-  // Cross-entity search: a project is kept if it matches directly OR any of its
-  // quotes/POs match. When kept via children, we record which ones matched so
-  // the user can click straight into that doc.
-  const { filteredProjects, matchesByProject } = useMemo(() => {
-    const term = searchTerm.toLowerCase().trim()
-    if (!term) {
-      return {
-        filteredProjects: projects,
-        matchesByProject: new Map<number, { quotes: Quote[]; pos: PurchaseOrder[] }>(),
-      }
-    }
-    const matches = new Map<number, { quotes: Quote[]; pos: PurchaseOrder[] }>()
-    const filtered = projects.filter((project) => {
-      const directMatch =
-        project.name.toLowerCase().includes(term) ||
-        project.uca_project_number.toLowerCase().includes(term) ||
-        (project.ucsh_project_number?.toLowerCase().includes(term) ?? false) ||
-        project.customer.name.toLowerCase().includes(term) ||
-        (project.project_lead?.toLowerCase().includes(term) ?? false) ||
-        project.status.toLowerCase().includes(term)
-
-      const projectQuotes = quotesByProject.get(project.id) ?? []
-      const projectPOs = posByProject.get(project.id) ?? []
-
-      const matchedQuotes = projectQuotes.filter(
-        (q) =>
-          q.quote_number.toLowerCase().includes(term) ||
-          (q.client_po_number?.toLowerCase().includes(term) ?? false) ||
-          (q.work_description?.toLowerCase().includes(term) ?? false),
-      )
-      const matchedPOs = projectPOs.filter(
-        (po) =>
-          po.po_number.toLowerCase().includes(term) ||
-          po.vendor.name.toLowerCase().includes(term) ||
-          (po.vendor_po_number?.toLowerCase().includes(term) ?? false) ||
-          (po.work_description?.toLowerCase().includes(term) ?? false),
-      )
-
-      if (directMatch || matchedQuotes.length > 0 || matchedPOs.length > 0) {
-        if (matchedQuotes.length > 0 || matchedPOs.length > 0) {
-          matches.set(project.id, { quotes: matchedQuotes, pos: matchedPOs })
-        }
-        return true
-      }
-      return false
-    })
-    return { filteredProjects: filtered, matchesByProject: matches }
-  }, [projects, quotesByProject, posByProject, searchTerm])
 
   return (
     <div className="space-y-6">
@@ -209,9 +201,9 @@ export function ProjectsPage({
       <div className="bg-card rounded-lg border shadow-sm">
         {loading ? (
           <div className="p-8 text-center text-muted-foreground">Loading...</div>
-        ) : filteredProjects.length === 0 ? (
+        ) : displayProjects.length === 0 ? (
           <div className="p-8 text-center text-muted-foreground">
-            {projects.length === 0
+            {baseProjects.length === 0
               ? "No projects found. Create your first project to get started."
               : "No projects match your search."}
           </div>
@@ -230,8 +222,8 @@ export function ProjectsPage({
               </TableRow>
             </TableHeader>
             <TableBody>
-              {filteredProjects.map((project) => {
-                const childMatches = matchesByProject.get(project.id)
+              {displayProjects.map((project) => {
+                const hasChildMatches = project.matched_quotes.length > 0 || project.matched_pos.length > 0
                 return (
                   <Fragment key={project.id}>
                     <TableRow
@@ -246,7 +238,7 @@ export function ProjectsPage({
                           {project.name}
                         </div>
                       </TableCell>
-                      <TableCell>{project.customer.name}</TableCell>
+                      <TableCell>{project.customer_name}</TableCell>
                       <TableCell className="text-muted-foreground">{project.project_lead || "-"}</TableCell>
                       <TableCell>{getStatusBadge(project.status)}</TableCell>
                       <TableCell className="text-muted-foreground">
@@ -270,12 +262,12 @@ export function ProjectsPage({
                         </Button>
                       </TableCell>
                     </TableRow>
-                    {childMatches && (
+                    {hasChildMatches && (
                       <TableRow className="bg-muted/30 hover:bg-muted/30">
                         <TableCell colSpan={8} className="py-2">
                           <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground pl-6">
                             <span className="uppercase tracking-wide">Matches:</span>
-                            {childMatches.quotes.map((q) => (
+                            {project.matched_quotes.map((q) => (
                               <Badge
                                 key={`q-${q.id}`}
                                 variant="outline"
@@ -289,7 +281,7 @@ export function ProjectsPage({
                                 {q.quote_number}
                               </Badge>
                             ))}
-                            {childMatches.pos.map((po) => (
+                            {project.matched_pos.map((po) => (
                               <Badge
                                 key={`po-${po.id}`}
                                 variant="outline"
@@ -301,7 +293,7 @@ export function ProjectsPage({
                               >
                                 <ShoppingCart className="h-3 w-3" />
                                 {po.po_number}
-                                <span className="text-muted-foreground font-sans">— {po.vendor.name}</span>
+                                <span className="text-muted-foreground font-sans">— {po.vendor_name}</span>
                               </Badge>
                             ))}
                           </div>
@@ -328,7 +320,7 @@ export function ProjectsPage({
             project={editingProject ?? undefined}
             onSuccess={() => {
               handleDialogClose(false)
-              fetchData()
+              refreshAll()
             }}
             onCancel={() => handleDialogClose(false)}
           />

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -281,6 +281,39 @@ export interface ProjectFull extends Project {
   purchase_orders: PurchaseOrder[];
 }
 
+// ===== Projects List View (lightweight, aggregated) =====
+export interface ProjectListView {
+  id: number;
+  name: string;
+  uca_project_number: string;
+  ucsh_project_number: string | null;
+  customer_id: number;
+  customer_name: string;
+  project_lead: string | null;
+  status: string;
+  created_on: string;
+  quote_count: number;
+  po_count: number;
+  latest_quote_number: string | null;
+  latest_po_number: string | null;
+}
+
+export interface MatchedQuoteRef {
+  id: number;
+  quote_number: string;
+}
+
+export interface MatchedPORef {
+  id: number;
+  po_number: string;
+  vendor_name: string;
+}
+
+export interface ProjectSearchResult extends ProjectListView {
+  matched_quotes: MatchedQuoteRef[];
+  matched_pos: MatchedPORef[];
+}
+
 // ===== Quote Line Items =====
 export type LineItemType = 'labor' | 'part' | 'misc';
 


### PR DESCRIPTION
## Summary

- Replace three full-table dumps (`projects`, `quotes`, `purchase_orders`) on the Projects page with a single aggregated endpoint that uses window functions to compute `quote_count`, `po_count`, and `latest_quote_number` / `latest_po_number` in one SQL query — no `joinedload` of line items, vendors, or cost codes.
- Add `GET /projects/search?q=...` for server-side cross-entity ILIKE search across projects, quotes, POs, and vendors. Returns the list-view shape plus optional `matched_quotes` / `matched_pos` refs for the UI click-through hints.
- Rewrite `ProjectsPage` to fetch list-view on mount, cache it, debounce search input 300 ms, and route non-empty terms through `/search`. Stale-response guard prevents an earlier search from overwriting a newer one. `ProjectForm` is widened to a `Pick<Project, …>` so list-view rows can drive the edit dialog without re-fetching.

Fixes #82