### PR TITLE
perf(backend): cut RAM, cold start, and read traffic (Phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,10 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt -r requirements-test.txt
 
-      - name: Validate app startup (runs migrations + imports)
+      - name: Apply migrations (app no longer migrates on boot by default)
+        run: alembic upgrade head
+
+      - name: Validate app startup (imports + seed)
         run: python -c "from main import app; print('App startup OK')"
 
       - name: Run tests

--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn main:app -w 4 -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT --timeout 300
+web: gunicorn main:app -w 2 -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT --timeout 300

--- a/backend/main.py
+++ b/backend/main.py
@@ -16,35 +16,37 @@ from seed import seed_system_items
 
 
 def run_migrations():
-    """Run Alembic migrations on startup.
+    """Run Alembic migrations on startup, gated by ALEMBIC_AUTO_UPGRADE=1.
 
-    Replaces Railway's unreliable releaseCommand. The web process has
-    guaranteed database access, so running migrations here is reliable.
-    Safe for single-instance test environments (no worker race condition).
+    Gating rationale: with multiple Gunicorn workers, this runs once per
+    worker on cold start — which loads alembic, inspects the schema, and
+    optionally runs `upgrade head`. For RAM and cold-start cost, we skip
+    all of that unless the operator opts in by setting ALEMBIC_AUTO_UPGRADE=1.
+    Schema changes should be triggered explicitly (set the env var for the
+    schema-change deploy, or run `railway run alembic upgrade head` manually).
 
-    Handles legacy databases that predate the migration system by
-    auto-stamping to the latest revision when tables exist but
-    alembic_version does not.
+    Legacy-stamp self-healing is preserved when the gate is open: if app
+    tables exist but alembic_version doesn't, we stamp instead of upgrading.
     """
-    from sqlalchemy import text, inspect
+    if os.getenv("ALEMBIC_AUTO_UPGRADE") != "1":
+        print("[STARTUP] Skipping migrations (set ALEMBIC_AUTO_UPGRADE=1 to enable)")
+        return
+
+    from sqlalchemy import inspect
     from alembic.config import Config
     from alembic import command
 
     alembic_cfg = Config(os.path.join(os.path.dirname(__file__), "alembic.ini"))
 
-    # Detect legacy database: tables exist but no alembic_version tracking
     inspector = inspect(engine)
     tables = inspector.get_table_names()
     has_app_tables = "quotes" in tables or "profiles" in tables
     has_alembic = "alembic_version" in tables
 
     if has_app_tables and not has_alembic:
-        # Legacy deploy: stamp to latest revision so Alembic knows the
-        # current state, then only future migrations will run.
         command.stamp(alembic_cfg, "head")
         print("[STARTUP] Legacy database detected — stamped alembic_version to head")
     else:
-        # Normal path: run any pending migrations
         command.upgrade(alembic_cfg, "head")
         print("[STARTUP] Alembic migrations applied")
 

--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -16,7 +16,7 @@
 builder = "nixpacks"
 
 [deploy]
-startCommand = "gunicorn main:app -w 4 -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT --timeout 300"
+startCommand = "gunicorn main:app -w 2 -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT --timeout 300"
 healthcheckPath = "/health"
 healthcheckTimeout = 100
 restartPolicyType = "on_failure"

--- a/backend/routes/cost_codes.py
+++ b/backend/routes/cost_codes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlalchemy.orm import Session
 from typing import List
 
@@ -10,19 +10,23 @@ from schemas import (
 
 router = APIRouter(prefix="/cost-codes", tags=["cost-codes"])
 
+_CACHE_CONTROL = "private, max-age=60"
+
 
 @router.get("/", response_model=List[CostCodeSchema])
-def get_all_cost_codes(db: Session = Depends(get_db)):
+def get_all_cost_codes(response: Response, db: Session = Depends(get_db)):
     """Get all cost codes, ordered by code."""
+    response.headers["Cache-Control"] = _CACHE_CONTROL
     return db.query(CostCode).order_by(CostCode.code).all()
 
 
 @router.get("/{cost_code_id}", response_model=CostCodeSchema)
-def get_cost_code(cost_code_id: int, db: Session = Depends(get_db)):
+def get_cost_code(cost_code_id: int, response: Response, db: Session = Depends(get_db)):
     """Get a single cost code."""
     cc = db.query(CostCode).filter(CostCode.id == cost_code_id).first()
     if not cc:
         raise HTTPException(status_code=404, detail="Cost code not found")
+    response.headers["Cache-Control"] = _CACHE_CONTROL
     return cc
 
 

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from sqlalchemy.orm import Session, joinedload
 from typing import List, Optional
 
@@ -11,9 +11,12 @@ from schemas import (
 
 router = APIRouter(prefix="/profiles", tags=["profiles"])
 
+_CACHE_CONTROL = "private, max-age=60"
+
 
 @router.get("/", response_model=List[ProfileSchema])
 def get_all_profiles(
+    response: Response,
     skip: int = 0,
     limit: int = None,  # No default limit until pagination is implemented
     profile_type: Optional[str] = Query(None, description="Filter by profile type (customer or vendor)"),
@@ -26,17 +29,19 @@ def get_all_profiles(
     if profile_type:
         query = query.filter(Profile.type == ModelProfileType(profile_type))
     profiles = query.offset(skip).limit(limit).all()
+    response.headers["Cache-Control"] = _CACHE_CONTROL
     return profiles
 
 
 @router.get("/{profile_id}", response_model=ProfileSchema)
-def get_profile(profile_id: int, db: Session = Depends(get_db)):
+def get_profile(profile_id: int, response: Response, db: Session = Depends(get_db)):
     """Get a single profile by ID with nested contacts."""
     profile = db.query(Profile).options(
         joinedload(Profile.contacts).joinedload(Contact.phone_numbers)
     ).filter(Profile.id == profile_id).first()
     if not profile:
         raise HTTPException(status_code=404, detail="Profile not found")
+    response.headers["Cache-Control"] = _CACHE_CONTROL
     return profile
 
 

--- a/backend/routes/system_rates.py
+++ b/backend/routes/system_rates.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlalchemy.orm import Session
 from typing import List
 
@@ -10,6 +10,8 @@ from schemas import (
 )
 
 router = APIRouter(prefix="/system-rates", tags=["system-rates"])
+
+_CACHE_CONTROL = "private, max-age=60"
 
 
 def _sync_misc_shadow(db: Session, system_rate: SystemRate) -> None:
@@ -36,7 +38,7 @@ def _sync_misc_shadow(db: Session, system_rate: SystemRate) -> None:
 # ===== Parking =====
 
 @router.get("/parking", response_model=SystemRateSchema)
-def get_parking_rate(db: Session = Depends(get_db)):
+def get_parking_rate(response: Response, db: Session = Depends(get_db)):
     """Get the parking system rate."""
     rate = db.query(SystemRate).filter(
         SystemRate.rate_type == "parking",
@@ -44,6 +46,7 @@ def get_parking_rate(db: Session = Depends(get_db)):
     ).first()
     if not rate:
         raise HTTPException(status_code=404, detail="Parking rate not found")
+    response.headers["Cache-Control"] = _CACHE_CONTROL
     return rate
 
 
@@ -73,8 +76,9 @@ def update_parking_rate(data: SystemRateUpdate, db: Session = Depends(get_db)):
 # ===== Travel Distance =====
 
 @router.get("/travel-distance", response_model=List[SystemRateSchema])
-def get_travel_distance_tiers(db: Session = Depends(get_db)):
+def get_travel_distance_tiers(response: Response, db: Session = Depends(get_db)):
     """Get all active travel distance tiers, ordered by sort_order."""
+    response.headers["Cache-Control"] = _CACHE_CONTROL
     return db.query(SystemRate).filter(
         SystemRate.rate_type == "travel_distance",
         SystemRate.is_active == True,
@@ -146,11 +150,12 @@ def delete_travel_distance_tier(rate_id: int, db: Session = Depends(get_db)):
 # ===== PMS Default =====
 
 @router.get("/pms-default")
-def get_pms_default(db: Session = Depends(get_db)):
+def get_pms_default(response: Response, db: Session = Depends(get_db)):
     """Get the default PMS percentage."""
     settings = db.query(CompanySettings).first()
     if not settings:
         raise HTTPException(status_code=404, detail="Company settings not found")
+    response.headers["Cache-Control"] = _CACHE_CONTROL
     return {"default_pms_percent": settings.default_pms_percent}
 
 

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -75,16 +75,24 @@ def seed_system_items(db: Session) -> None:
     Seed system miscellaneous items and company settings if they don't exist.
     Called at application startup.
     """
-    for item_data in SYSTEM_MISC_ITEMS:
-        # Check if item already exists by description
-        existing = db.query(Miscellaneous).filter(
-            Miscellaneous.description == item_data["description"],
-            Miscellaneous.is_system_item == True
-        ).first()
+    # Fast path: if the count matches what we expect to seed, nothing to do.
+    # Avoids N filter().first() queries on every cold start (× every worker).
+    expected_count = len(SYSTEM_MISC_ITEMS)
+    actual_count = db.query(Miscellaneous).filter(
+        Miscellaneous.is_system_item == True
+    ).count()
 
-        if not existing:
-            db_item = Miscellaneous(**item_data)
-            db.add(db_item)
+    if actual_count < expected_count:
+        # Some (or all) system items are missing — fetch existing descriptions
+        # in a single query, then only insert what's not already there.
+        existing_descriptions = {
+            row[0] for row in db.query(Miscellaneous.description).filter(
+                Miscellaneous.is_system_item == True
+            ).all()
+        }
+        for item_data in SYSTEM_MISC_ITEMS:
+            if item_data["description"] not in existing_descriptions:
+                db.add(Miscellaneous(**item_data))
 
     # Seed company settings (singleton)
     existing_settings = db.query(CompanySettings).first()


### PR DESCRIPTION
## Summary

Fixes #83 — Phase 2 of backend cost reduction. Five separate, independently revertible changes:

- **Gunicorn workers 4 → 2** (`backend/railway.toml`, `backend/Procfile`). Each worker holds its own SQLAlchemy engine + model classes + Pydantic schemas; cutting in half is the single biggest RAM win for a low-concurrency internal tool.
- **Migration gate** (`backend/main.py`). `run_migrations()` now no-ops unless `ALEMBIC_AUTO_UPGRADE=1` is set. Legacy-stamp self-healing is preserved when the gate is open. Schema changes are now explicitly triggered — set the env var on the schema-change deploy, or run `railway run alembic upgrade head`. Saves alembic import + schema inspection on every worker cold start.
- **Seed short-circuit** (`backend/seed.py`). Replaces N `filter().first()` queries with a single `count()` pre-check; only when count < expected do we run one bulk `description` query and insert what's missing. Steady-state cost drops from 8 queries per worker boot to 1.
- **HTTP cache headers**. `Cache-Control: private, max-age=60` on read-only GETs in `cost_codes.py`, `system_rates.py`, `profiles.py`. Cuts repeat traffic on page navigation; `private` avoids shared-cache exposure if auth is added later.
- **CI alembic step** (`.github/workflows/ci.yml`). Adds explicit `alembic upgrade head` before the Backend `Validate app startup` step — needed because the migration gate means `from main import app` no longer applies the schema transitively.

## Rollout

The **first** deploy after merge must have `ALEMBIC_AUTO_UPGRADE=1` set on the Railway service (no pending migrations to apply right now, but it's the cleanest way to confirm the gate works end-to-end). After that, the variable can stay unset for steady-state savings and be set again only for deploys that introduce new migrations.

## Acceptance criteria (from #83)

- [x] Memory baseline expected to drop (target 30–50%) — driven primarily by worker count
- [x] Cold start faster on deploy — no alembic load when gate is off
- [x] No functional regression: seeding still works on empty DB; migrations still run when explicitly triggered