### PR TITLE
perf(backend): paginate list endpoints + add FK indexes (Phase 3)

### DIFF
--- a/backend/alembic/versions/20260511_017_add_fk_indexes.py
+++ b/backend/alembic/versions/20260511_017_add_fk_indexes.py
@@ -1,0 +1,57 @@
+"""Add indexes on FK columns used in list/join queries.
+
+Postgres does not auto-create indexes for foreign key columns. Without these,
+join-heavy reads (e.g. fetching the line items for a quote/PO, listing parts
+by vendor, listing projects by customer) fall back to sequential scans on the
+referenced tables. As table sizes grow this becomes the bottleneck for list
+endpoints and detail page loads.
+
+Indexes added:
+- quote_line_items.quote_id
+- po_line_items.purchase_order_id
+- quotes.project_id
+- purchase_orders.project_id
+- purchase_orders.vendor_id
+- projects.customer_id
+- parts.vendor_id
+
+All use IF NOT EXISTS guards per project convention.
+
+Revision ID: 017_add_fk_indexes
+Revises: 016_add_company_logo
+Create Date: 2026-05-11
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '017_add_fk_indexes'
+down_revision = '016_add_company_logo'
+branch_labels = None
+depends_on = None
+
+
+# (index_name, table, column) tuples
+_INDEXES = [
+    ('ix_quote_line_items_quote_id', 'quote_line_items', 'quote_id'),
+    ('ix_po_line_items_purchase_order_id', 'po_line_items', 'purchase_order_id'),
+    ('ix_quotes_project_id', 'quotes', 'project_id'),
+    ('ix_purchase_orders_project_id', 'purchase_orders', 'project_id'),
+    ('ix_purchase_orders_vendor_id', 'purchase_orders', 'vendor_id'),
+    ('ix_projects_customer_id', 'projects', 'customer_id'),
+    ('ix_parts_vendor_id', 'parts', 'vendor_id'),
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for name, table, column in _INDEXES:
+        conn.execute(sa.text(
+            f'CREATE INDEX IF NOT EXISTS {name} ON {table} ({column})'
+        ))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    for name, _table, _column in _INDEXES:
+        conn.execute(sa.text(f'DROP INDEX IF EXISTS {name}'))

--- a/backend/models.py
+++ b/backend/models.py
@@ -96,7 +96,7 @@ class Part(Base):
     cost = Column(Float, nullable=False)
     markup_percent = Column(Float, default=0.0)
     category_id = Column(Integer, ForeignKey('categories.id'))
-    vendor_id = Column(Integer, ForeignKey('profiles.id'), nullable=True)
+    vendor_id = Column(Integer, ForeignKey('profiles.id'), nullable=True, index=True)
     list_price = Column(Float, nullable=True)
     discount_percent = Column(Float, nullable=True)  # Per-part discount override (nullable)
 
@@ -150,7 +150,7 @@ class Project(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, nullable=False)
-    customer_id = Column(Integer, ForeignKey('profiles.id'), nullable=False)
+    customer_id = Column(Integer, ForeignKey('profiles.id'), nullable=False, index=True)
     created_on = Column(DateTime, default=datetime.utcnow)
     status = Column(String, default="active")
     ucsh_project_number = Column(String, nullable=True)
@@ -170,7 +170,7 @@ class Quote(Base):
     )
 
     id = Column(Integer, primary_key=True, index=True)
-    project_id = Column(Integer, ForeignKey('projects.id'), nullable=False)
+    project_id = Column(Integer, ForeignKey('projects.id'), nullable=False, index=True)
     quote_sequence = Column(Integer, nullable=False)  # Per-project sequence number (1, 2, 3...)
     created_at = Column(DateTime, default=datetime.utcnow)
     status = Column(String, default="Draft")  # "Draft", "Work Order", "Invoiced", "Closed" — computed by system
@@ -195,7 +195,7 @@ class QuoteLineItem(Base):
     __tablename__ = "quote_line_items"
 
     id = Column(Integer, primary_key=True, index=True)
-    quote_id = Column(Integer, ForeignKey('quotes.id'), nullable=False)
+    quote_id = Column(Integer, ForeignKey('quotes.id'), nullable=False, index=True)
     item_type = Column(String, nullable=False)  # "labor", "part", "misc"
     labor_id = Column(Integer, ForeignKey('labor.id'), nullable=True)
     part_id = Column(Integer, ForeignKey('parts.id'), nullable=True)
@@ -225,8 +225,8 @@ class PurchaseOrder(Base):
     )
 
     id = Column(Integer, primary_key=True, index=True)
-    project_id = Column(Integer, ForeignKey('projects.id'), nullable=False)
-    vendor_id = Column(Integer, ForeignKey('profiles.id'), nullable=False)
+    project_id = Column(Integer, ForeignKey('projects.id'), nullable=False, index=True)
+    vendor_id = Column(Integer, ForeignKey('profiles.id'), nullable=False, index=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     po_sequence = Column(Integer, nullable=False)
     current_version = Column(Integer, default=0)
@@ -249,7 +249,7 @@ class POLineItem(Base):
     __tablename__ = "po_line_items"
 
     id = Column(Integer, primary_key=True, index=True)
-    purchase_order_id = Column(Integer, ForeignKey('purchase_orders.id'), nullable=False)
+    purchase_order_id = Column(Integer, ForeignKey('purchase_orders.id'), nullable=False, index=True)
     item_type = Column(String, nullable=False)  # "part" or "misc" (NO labor for POs)
     part_id = Column(Integer, ForeignKey('parts.id'), nullable=True)
     description = Column(String)  # For misc items or override

--- a/backend/routes/parts.py
+++ b/backend/routes/parts.py
@@ -1,12 +1,18 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session, joinedload
 from typing import List
 
 from database import get_db
 from models import Part, Labor, Profile
-from schemas import PartCreate, PartUpdate, Part as PartSchema, PartWithLabor
+from schemas import PartCreate, PartUpdate, Part as PartSchema, PartWithLabor, Paginated
 
 router = APIRouter(prefix="/parts", tags=["parts"])
+
+# Default page size for list endpoints (issue #84).
+# `limit=0` is a sentinel meaning "no cap" — used by autocomplete/dropdown
+# loaders that legitimately need every row (e.g. PartForm vendor select).
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 10000
 
 
 def auto_calculate_cost(part: Part, db: Session) -> None:
@@ -22,17 +28,29 @@ def auto_calculate_cost(part: Part, db: Session) -> None:
             part.cost = part.list_price * (1 - effective_discount / 100)
 
 
-@router.get("/", response_model=List[PartWithLabor])
-def get_all_parts(skip: int = 0, limit: int = None, db: Session = Depends(get_db)):  # limit=None until pagination is implemented
-    """Get all parts with their linked labor items."""
-    parts = (
-        db.query(Part)
-        .options(joinedload(Part.labor_items), joinedload(Part.vendor))
-        .offset(skip)
-        .limit(limit)
-        .all()
+@router.get("/", response_model=Paginated[PartWithLabor])
+def get_all_parts(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(DEFAULT_LIMIT, ge=0, le=MAX_LIMIT),
+    skip: int = Query(0, ge=0, deprecated=True, description="Deprecated alias for offset"),
+    db: Session = Depends(get_db),
+):
+    """Paginated list of parts with their linked labor items.
+
+    Pass `limit=0` to fetch every row (used by autocomplete loaders).
+    """
+    effective_offset = offset or skip
+    base = db.query(Part).options(
+        joinedload(Part.labor_items), joinedload(Part.vendor)
     )
-    return parts
+    total = base.with_entities(Part.id).count()
+    q = base.order_by(Part.id).offset(effective_offset)
+    if limit > 0:
+        q = q.limit(limit)
+    items = q.all()
+    return Paginated[PartWithLabor](
+        items=items, total=total, limit=limit, offset=effective_offset
+    )
 
 
 @router.get("/{part_id}", response_model=PartWithLabor)

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 from database import get_db
 from models import Profile, ProfileType as ModelProfileType, Contact, ContactPhone, PhoneType as ModelPhoneType
 from schemas import (
+    Paginated,
     ProfileCreate, ProfileUpdate, Profile as ProfileSchema,
     ContactCreate, ContactUpdate, Contact as ContactSchema
 )
@@ -12,25 +13,38 @@ from schemas import (
 router = APIRouter(prefix="/profiles", tags=["profiles"])
 
 _CACHE_CONTROL = "private, max-age=60"
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 10000
 
 
-@router.get("/", response_model=List[ProfileSchema])
+@router.get("/", response_model=Paginated[ProfileSchema])
 def get_all_profiles(
     response: Response,
-    skip: int = 0,
-    limit: int = None,  # No default limit until pagination is implemented
+    offset: int = Query(0, ge=0),
+    limit: int = Query(DEFAULT_LIMIT, ge=0, le=MAX_LIMIT),
+    skip: int = Query(0, ge=0, deprecated=True, description="Deprecated alias for offset"),
     profile_type: Optional[str] = Query(None, description="Filter by profile type (customer or vendor)"),
     db: Session = Depends(get_db)
 ):
-    """Get all profiles with optional filtering by type."""
-    query = db.query(Profile).options(
+    """Paginated list of profiles with optional filtering by type.
+
+    Pass `limit=0` to fetch every row (used by autocomplete loaders).
+    """
+    effective_offset = offset or skip
+    base = db.query(Profile).options(
         joinedload(Profile.contacts).joinedload(Contact.phone_numbers)
     )
     if profile_type:
-        query = query.filter(Profile.type == ModelProfileType(profile_type))
-    profiles = query.offset(skip).limit(limit).all()
+        base = base.filter(Profile.type == ModelProfileType(profile_type))
+    total = base.with_entities(Profile.id).count()
+    q = base.order_by(Profile.id).offset(effective_offset)
+    if limit > 0:
+        q = q.limit(limit)
+    profiles = q.all()
     response.headers["Cache-Control"] = _CACHE_CONTROL
-    return profiles
+    return Paginated[ProfileSchema](
+        items=profiles, total=total, limit=limit, offset=effective_offset
+    )
 
 
 @router.get("/{profile_id}", response_model=ProfileSchema)

--- a/backend/routes/projects.py
+++ b/backend/routes/projects.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import String, and_, cast, func, literal, or_
 from sqlalchemy.orm import Session, aliased, joinedload
 from typing import Dict, List, Optional, Set
@@ -7,6 +7,7 @@ import re
 from database import get_db
 from models import Project, Profile, ProfileType, PurchaseOrder, Quote
 from schemas import (
+    Paginated,
     ProjectCreate,
     ProjectUpdate,
     Project as ProjectSchema,
@@ -18,6 +19,10 @@ from schemas import (
     Quote as QuoteSchema,
 )
 from routes.purchase_orders import format_po_number
+
+# See parts.py for the same constants — kept inline per-module for clarity.
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 10000
 
 
 def format_quote_number(uca_project_number: str, quote_sequence: int, current_version: int) -> str:
@@ -89,17 +94,27 @@ def generate_next_uca_number(db: Session) -> str:
         return f"{increment_letter_prefix(prefix)}0001"
 
 
-@router.get("/", response_model=List[ProjectSchema])
-def get_all_projects(skip: int = 0, limit: int = None, db: Session = Depends(get_db)):  # limit=None until pagination is implemented
-    """Get all projects with customer info."""
-    projects = (
-        db.query(Project)
-        .options(joinedload(Project.customer))
-        .offset(skip)
-        .limit(limit)
-        .all()
+@router.get("/", response_model=Paginated[ProjectSchema])
+def get_all_projects(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(DEFAULT_LIMIT, ge=0, le=MAX_LIMIT),
+    skip: int = Query(0, ge=0, deprecated=True, description="Deprecated alias for offset"),
+    db: Session = Depends(get_db),
+):
+    """Paginated list of projects with customer info.
+
+    Pass `limit=0` to fetch every row.
+    """
+    effective_offset = offset or skip
+    base = db.query(Project).options(joinedload(Project.customer))
+    total = base.with_entities(Project.id).count()
+    q = base.order_by(Project.id).offset(effective_offset)
+    if limit > 0:
+        q = q.limit(limit)
+    items = q.all()
+    return Paginated[ProjectSchema](
+        items=items, total=total, limit=limit, offset=effective_offset
     )
-    return projects
 
 
 def _build_list_view_rows(db: Session, project_ids: Optional[Set[int]] = None) -> List[ProjectListView]:

--- a/backend/routes/purchase_orders.py
+++ b/backend/routes/purchase_orders.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import func
 from typing import List, Optional
@@ -10,6 +10,7 @@ from models import (
     POReceiving, POReceivingLineItem, POSnapshot, POLineItemSnapshot, POStatus, CostCode
 )
 from schemas import (
+    Paginated,
     PurchaseOrderCreate, PurchaseOrderUpdate, PurchaseOrder as PurchaseOrderSchema,
     POLineItemCreate, POLineItem as POLineItemSchema,
     POReceiving as POReceivingSchema, POReceivingCreate, POReceivingLineItemCreate,
@@ -17,6 +18,9 @@ from schemas import (
     POSnapshot as POSnapshotSchema, POLineItemSnapshot as POLineItemSnapshotSchema,
     PORevertPreview, POCommitEditsRequest, POCommitEditsResponse, StagedPOLineItemChange
 )
+
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 10000
 
 
 def create_po_snapshot(
@@ -270,22 +274,33 @@ def recompute_line_item_aggregates(db: Session, line_item: POLineItem) -> None:
 router = APIRouter(prefix="/purchase-orders", tags=["purchase-orders"])
 
 
-@router.get("/", response_model=List[PurchaseOrderSchema])
-def get_all_purchase_orders(skip: int = 0, limit: int = None, db: Session = Depends(get_db)):  # limit=None until pagination is implemented
-    """Get all purchase orders."""
-    pos = (
-        db.query(PurchaseOrder)
-        .options(
-            joinedload(PurchaseOrder.vendor),
-            joinedload(PurchaseOrder.line_items),
-            joinedload(PurchaseOrder.project),
-            joinedload(PurchaseOrder.cost_code)
-        )
-        .offset(skip)
-        .limit(limit)
-        .all()
+@router.get("/", response_model=Paginated[PurchaseOrderSchema])
+def get_all_purchase_orders(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(DEFAULT_LIMIT, ge=0, le=MAX_LIMIT),
+    skip: int = Query(0, ge=0, deprecated=True, description="Deprecated alias for offset"),
+    db: Session = Depends(get_db),
+):
+    """Paginated list of purchase orders.
+
+    Pass `limit=0` to fetch every row.
+    """
+    effective_offset = offset or skip
+    base = db.query(PurchaseOrder).options(
+        joinedload(PurchaseOrder.vendor),
+        joinedload(PurchaseOrder.line_items),
+        joinedload(PurchaseOrder.project),
+        joinedload(PurchaseOrder.cost_code),
     )
-    return [populate_po_number(po, po.project.uca_project_number) for po in pos]
+    total = base.with_entities(PurchaseOrder.id).count()
+    q = base.order_by(PurchaseOrder.id).offset(effective_offset)
+    if limit > 0:
+        q = q.limit(limit)
+    pos = q.all()
+    items = [populate_po_number(po, po.project.uca_project_number) for po in pos]
+    return Paginated[PurchaseOrderSchema](
+        items=items, total=total, limit=limit, offset=effective_offset
+    )
 
 
 @router.get("/{po_id}", response_model=PurchaseOrderSchema)

--- a/backend/routes/quotes.py
+++ b/backend/routes/quotes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import func
 from typing import List, Optional
@@ -11,6 +11,7 @@ from models import (
 from datetime import datetime
 
 from schemas import (
+    Paginated,
     QuoteCreate, QuoteUpdate, Quote as QuoteSchema,
     QuoteLineItemCreate, QuoteLineItemUpdate, QuoteLineItem as QuoteLineItemSchema,
     QuoteSnapshot as QuoteSnapshotSchema,
@@ -18,6 +19,9 @@ from schemas import (
     RevertPreview, MarkupControlToggleRequest, MarkupControlToggleResponse,
     CommitEditsRequest, CommitEditsResponse
 )
+
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 10000
 
 
 def create_snapshot(
@@ -276,22 +280,32 @@ def populate_quote_number(quote: Quote, uca_project_number: str) -> QuoteSchema:
 router = APIRouter(prefix="/quotes", tags=["quotes"])
 
 
-@router.get("/", response_model=List[QuoteSchema])
-def get_all_quotes(skip: int = 0, limit: int = None, db: Session = Depends(get_db)):  # limit=None until pagination is implemented
-    """Get all quotes."""
-    quotes = (
-        db.query(Quote)
-        .options(
-            joinedload(Quote.project),  # Need project for uca_project_number
-            joinedload(Quote.line_items),
-            joinedload(Quote.cost_code)
-        )
-        .offset(skip)
-        .limit(limit)
-        .all()
+@router.get("/", response_model=Paginated[QuoteSchema])
+def get_all_quotes(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(DEFAULT_LIMIT, ge=0, le=MAX_LIMIT),
+    skip: int = Query(0, ge=0, deprecated=True, description="Deprecated alias for offset"),
+    db: Session = Depends(get_db),
+):
+    """Paginated list of quotes.
+
+    Pass `limit=0` to fetch every row.
+    """
+    effective_offset = offset or skip
+    base = db.query(Quote).options(
+        joinedload(Quote.project),
+        joinedload(Quote.line_items),
+        joinedload(Quote.cost_code),
     )
-    # Return with computed quote_numbers
-    return [populate_quote_number(q, q.project.uca_project_number) for q in quotes]
+    total = base.with_entities(Quote.id).count()
+    q = base.order_by(Quote.id).offset(effective_offset)
+    if limit > 0:
+        q = q.limit(limit)
+    quotes = q.all()
+    items = [populate_quote_number(quote, quote.project.uca_project_number) for quote in quotes]
+    return Paginated[QuoteSchema](
+        items=items, total=total, limit=limit, offset=effective_offset
+    )
 
 
 @router.get("/{quote_id}", response_model=QuoteSchema)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,7 +1,23 @@
 from pydantic import BaseModel, validator
-from typing import List, Optional
+from typing import Generic, List, Optional, TypeVar
 from datetime import datetime
 from enum import Enum
+
+
+# ===== Generic Pagination Envelope =====
+T = TypeVar('T')
+
+
+class Paginated(BaseModel, Generic[T]):
+    """Standard response shape for paginated list endpoints.
+
+    `total` is the unfiltered total matching the query (independent of offset/limit),
+    so clients can render "X of Y" without an extra count round trip.
+    """
+    items: List[T]
+    total: int
+    limit: int
+    offset: int
 
 
 class ProfileType(str, Enum):

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,5 @@
 import type {
+  Paginated, ListParams,
   Part, PartCreate,
   Labor, LaborCreate,
   Miscellaneous, MiscellaneousCreate,
@@ -48,10 +49,26 @@ async function request<T>(
   return response.json();
 }
 
+/** Build a `?key=value&...` querystring from a plain object, skipping null/undefined values. */
+function buildQuery(params: object): string {
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(params)) {
+    if (value === null || value === undefined) continue;
+    parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+  }
+  return parts.length ? `?${parts.join('&')}` : '';
+}
+
 export const api = {
   // ===== Parts =====
   parts: {
-    getAll: () => request<Part[]>('/parts/'),
+    // Paginated list for list views. Returns {items, total, limit, offset}.
+    list: (params: ListParams = {}) =>
+      request<Paginated<Part>>(`/parts/${buildQuery(params)}`),
+    // Convenience: unbounded fetch (limit=0) returning just items.
+    // Used by autocomplete/dropdown loaders that need every row.
+    getAll: () =>
+      request<Paginated<Part>>('/parts/?limit=0').then(r => r.items),
     get: (id: number) => request<Part>(`/parts/${id}`),
     create: (data: PartCreate) =>
       request<Part>('/parts/', { method: 'POST', body: JSON.stringify(data) }),
@@ -75,8 +92,13 @@ export const api = {
 
   // ===== Profiles =====
   profiles: {
+    list: (params: ListParams & { profile_type?: ProfileType } = {}) =>
+      request<Paginated<Profile>>(`/profiles/${buildQuery(params)}`),
+    // Convenience: unbounded fetch returning just items.
     getAll: (type?: ProfileType) =>
-      request<Profile[]>(`/profiles/${type ? `?profile_type=${type}` : ''}`),
+      request<Paginated<Profile>>(
+        `/profiles/${buildQuery({ limit: 0, profile_type: type })}`
+      ).then(r => r.items),
     get: (id: number) => request<Profile>(`/profiles/${id}`),
     create: (data: ProfileCreate) =>
       request<Profile>('/profiles/', { method: 'POST', body: JSON.stringify(data) }),
@@ -96,7 +118,10 @@ export const api = {
 
   // ===== Projects =====
   projects: {
-    getAll: () => request<Project[]>('/projects/'),
+    list: (params: ListParams = {}) =>
+      request<Paginated<Project>>(`/projects/${buildQuery(params)}`),
+    getAll: () =>
+      request<Paginated<Project>>('/projects/?limit=0').then(r => r.items),
     getListView: () => request<ProjectListView[]>('/projects/list-view'),
     search: (q: string) =>
       request<ProjectSearchResult[]>(`/projects/search?q=${encodeURIComponent(q)}`),
@@ -142,7 +167,10 @@ export const api = {
 
   // ===== Quotes =====
   quotes: {
-    getAll: () => request<Quote[]>('/quotes/'),
+    list: (params: ListParams = {}) =>
+      request<Paginated<Quote>>(`/quotes/${buildQuery(params)}`),
+    getAll: () =>
+      request<Paginated<Quote>>('/quotes/?limit=0').then(r => r.items),
     get: (id: number) => request<Quote>(`/quotes/${id}`),
     create: (data: QuoteCreate) =>
       request<Quote>('/quotes/', { method: 'POST', body: JSON.stringify(data) }),
@@ -211,7 +239,10 @@ export const api = {
   // ===== Purchase Orders =====
   purchaseOrders: {
     // Core CRUD
-    getAll: () => request<PurchaseOrder[]>('/purchase-orders/'),
+    list: (params: ListParams = {}) =>
+      request<Paginated<PurchaseOrder>>(`/purchase-orders/${buildQuery(params)}`),
+    getAll: () =>
+      request<Paginated<PurchaseOrder>>('/purchase-orders/?limit=0').then(r => r.items),
 
     get: (id: number) => request<PurchaseOrder>(`/purchase-orders/${id}`),
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,5 +1,22 @@
 // TypeScript interfaces matching backend schemas
 
+// ===== Pagination =====
+// Standard response envelope for paginated list endpoints (see backend
+// schemas.Paginated). `total` is the unfiltered total for the query
+// independent of offset/limit, so the UI can render "X of Y" without an
+// extra count round trip.
+export interface Paginated<T> {
+  items: T[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface ListParams {
+  offset?: number;
+  limit?: number;
+}
+
 // ===== Company Settings =====
 export interface CompanySettings {
   id: number;


### PR DESCRIPTION
## Summary

- Replace the `limit=None` TODOs on `GET /parts/`, `/profiles/`, `/projects/`, `/quotes/`, `/purchase-orders/` with a typed `Paginated[T]` envelope (`{items, total, limit, offset}`) defaulting to `limit=50`. `limit=0` is honored as an explicit unbounded mode for autocomplete/dropdown loaders.
- Add indexes on every FK column used in joins/lookups (`quote_line_items.quote_id`, `po_line_items.purchase_order_id`, `quotes.project_id`, `purchase_orders.project_id/vendor_id`, `projects.customer_id`, `parts.vendor_id`) via migration `017_add_fk_indexes` with `IF NOT EXISTS` / `IF EXISTS` guards on both sides.
- Add `Paginated<T>` + `ListParams` to frontend types and typed `list()` methods to the API client; rewrite `getAll()` helpers as thin wrappers over `?limit=0` so every existing autocomplete caller (PartForm, ProfilesPage, QuoteEditor, POEditor, ProjectDetailsPage, ProjectForm) keeps its array contract.

## Notes

- The Inventory and Profiles pages still load all rows by design — they call `getAll()` which now routes through `?limit=0`. Switching them to `list({offset, limit})` with infinite scroll is a localized follow-up once data volume warrants it; the load-bearing win in this PR is the FK indexes, which benefit every code path regardless.
- `Paginated[T]` is a Pydantic generic; verified to JSON-serialize correctly under the current Pydantic version used by the codebase.

Fixes #84