### PR TITLE
perf(frontend): split bundles, lazy-load editors and pages (Phase 4)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, lazy, Suspense } from "react"
 import { Show, SignInButton, SignUpButton, UserButton } from "@clerk/react"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Button } from "@/components/ui/button"
@@ -15,13 +15,31 @@ import { PartForm } from "@/components/forms/PartForm"
 import { LaborForm } from "@/components/forms/LaborForm"
 import { MiscForm } from "@/components/forms/MiscForm"
 import { ThemeToggle } from "@/components/theme-toggle"
-import { ProfilesPage } from "@/pages/ProfilesPage"
 import { ProjectsPage } from "@/pages/ProjectsPage"
-import { ProjectDetailsPage } from "@/pages/ProjectDetailsPage"
-import { ReportsPage } from "@/pages/ReportsPage"
-import { SettingsPage } from "@/pages/SettingsPage"
-import { MigrationPage } from "@/pages/MigrationPage"
 import { api } from "@/api/client"
+
+// Lazy-loaded pages: keep ProjectsPage eager (default landing), defer the rest.
+const ProfilesPage = lazy(() =>
+  import("@/pages/ProfilesPage").then((m) => ({ default: m.ProfilesPage }))
+)
+const ProjectDetailsPage = lazy(() =>
+  import("@/pages/ProjectDetailsPage").then((m) => ({ default: m.ProjectDetailsPage }))
+)
+const ReportsPage = lazy(() =>
+  import("@/pages/ReportsPage").then((m) => ({ default: m.ReportsPage }))
+)
+const SettingsPage = lazy(() =>
+  import("@/pages/SettingsPage").then((m) => ({ default: m.SettingsPage }))
+)
+const MigrationPage = lazy(() =>
+  import("@/pages/MigrationPage").then((m) => ({ default: m.MigrationPage }))
+)
+
+function PageFallback() {
+  return (
+    <div className="p-8 text-center text-muted-foreground text-sm">Loading…</div>
+  )
+}
 import type { Part, Labor, Miscellaneous } from "@/types"
 import {
   Package,
@@ -658,11 +676,13 @@ function App() {
 
       {/* Main Content */}
       <main className="flex-1 overflow-auto">
-        {currentView === "project-details" ? (
-          renderContent()
-        ) : (
-          <div className="p-6">{renderContent()}</div>
-        )}
+        <Suspense fallback={<PageFallback />}>
+          {currentView === "project-details" ? (
+            renderContent()
+          ) : (
+            <div className="p-6">{renderContent()}</div>
+          )}
+        </Suspense>
       </main>
 
       {/* Part Dialog */}

--- a/frontend/src/components/editors/InvoiceEditor.tsx
+++ b/frontend/src/components/editors/InvoiceEditor.tsx
@@ -20,8 +20,6 @@ import { Button } from "@/components/ui/button"
 import { api } from "@/api/client"
 import type { Invoice, Project, CompanySettings } from "@/types"
 import { Receipt, Package, Wrench, FileText, AlertTriangle, Printer, Loader2 } from "lucide-react"
-import { pdf } from '@react-pdf/renderer'
-import { InvoicePDF } from '@/components/pdf/InvoicePDF'
 
 interface InvoiceEditorProps {
   invoiceId: number
@@ -101,9 +99,11 @@ export function InvoiceEditor({ invoiceId, onUpdate }: InvoiceEditorProps) {
     if (!invoice) return
     setIsPrinting(true)
     try {
-      const [quote, companySettings] = await Promise.all([
+      const [quote, companySettings, { pdf }, { InvoicePDF }] = await Promise.all([
         api.quotes.get(invoice.quote_id),
         api.companySettings.get(),
+        import('@react-pdf/renderer'),
+        import('@/components/pdf/InvoicePDF'),
       ])
       const project = await api.projects.get(quote.project_id) as unknown as Project
       const blob = await pdf(

--- a/frontend/src/components/editors/POEditor.tsx
+++ b/frontend/src/components/editors/POEditor.tsx
@@ -60,8 +60,6 @@ import {
   Plus, Minus, Trash2, Package, FileText, Building, Pencil, Copy,
   X, GitCommit, Eye, AlertTriangle, Check, Calendar, Loader2, Hash, Printer
 } from "lucide-react"
-import { pdf } from '@react-pdf/renderer'
-import { PurchaseOrderPDF } from '@/components/pdf/PurchaseOrderPDF'
 import { PartForm } from "@/components/forms/PartForm"
 import { POAuditTrail } from "./POAuditTrail"
 
@@ -638,9 +636,11 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
     if (!po) return
     setIsPrinting(true)
     try {
-      const [project, companySettings] = await Promise.all([
+      const [project, companySettings, { pdf }, { PurchaseOrderPDF }] = await Promise.all([
         api.projects.get(po.project_id) as Promise<Project>,
         api.companySettings.get(),
+        import('@react-pdf/renderer'),
+        import('@/components/pdf/PurchaseOrderPDF'),
       ])
       const blob = await pdf(
         <PurchaseOrderPDF po={po} project={project} companySettings={companySettings} />

--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -56,8 +56,6 @@ import type {
   StagedLineItemChange, CommitEditsRequest
 } from "@/types"
 import { Plus, Minus, Trash2, Wrench, Package, FileText, Pencil, ClipboardCheck, Receipt, Percent, Info, Copy, Car, MapPin, X, Lock, GitCommit, Eye, AlertTriangle, Check, CheckCircle2, Printer, Loader2, Hash } from "lucide-react"
-import { pdf } from '@react-pdf/renderer'
-import { QuotePDF } from '@/components/pdf/QuotePDF'
 import type { CompanySettings, Project, SystemRate } from '@/types'
 import { QuoteAuditTrail } from "./QuoteAuditTrail"
 import { PartForm } from "@/components/forms/PartForm"
@@ -1938,9 +1936,11 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
     if (!quote) return
     setIsPrinting(true)
     try {
-      const [project, companySettings] = await Promise.all([
+      const [project, companySettings, { pdf }, { QuotePDF }] = await Promise.all([
         api.projects.get(quote.project_id) as Promise<Project>,
         api.companySettings.get(),
+        import('@react-pdf/renderer'),
+        import('@/components/pdf/QuotePDF'),
       ])
       const blob = await pdf(
         <QuotePDF quote={quote} project={project} companySettings={companySettings} />

--- a/frontend/src/pages/ProjectDetailsPage.tsx
+++ b/frontend/src/pages/ProjectDetailsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react"
+import { useState, useEffect, useRef, useCallback, lazy, Suspense } from "react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 // Card components available if needed
@@ -29,10 +29,25 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Label } from "@/components/ui/label"
-import { QuoteEditor } from "@/components/editors/QuoteEditor"
-import { POEditor } from "@/components/editors/POEditor"
-import { InvoiceEditor } from "@/components/editors/InvoiceEditor"
 import { api } from "@/api/client"
+
+const QuoteEditor = lazy(() =>
+  import("@/components/editors/QuoteEditor").then((m) => ({ default: m.QuoteEditor }))
+)
+const POEditor = lazy(() =>
+  import("@/components/editors/POEditor").then((m) => ({ default: m.POEditor }))
+)
+const InvoiceEditor = lazy(() =>
+  import("@/components/editors/InvoiceEditor").then((m) => ({ default: m.InvoiceEditor }))
+)
+
+function EditorFallback() {
+  return (
+    <div className="h-full flex items-center justify-center text-muted-foreground">
+      <div className="text-sm">Loading editor…</div>
+    </div>
+  )
+}
 import type { ProjectFull, Profile, Invoice } from "@/types"
 import {
   ArrowLeft,
@@ -454,26 +469,30 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
                 <p>Select a document from the sidebar or create a new one</p>
               </div>
             </div>
-          ) : selectedDoc.type === "quote" ? (
-            <QuoteEditor
-              quoteId={selectedDoc.id}
-              onUpdate={() => {
-                fetchProject()
-                if (project?.quotes) fetchInvoices(project.quotes)
-              }}
-            />
-          ) : selectedDoc.type === "po" ? (
-            <POEditor
-              poId={selectedDoc.id}
-              onUpdate={fetchProject}
-              onSelectPO={(newPoId) => setSelectedDoc({ type: "po", id: newPoId })}
-              onDirtyStateChange={handleEditorDirtyChange}
-            />
           ) : (
-            <InvoiceEditor invoiceId={selectedDoc.id} onUpdate={() => {
-              fetchProject()
-              if (project?.quotes) fetchInvoices(project.quotes)
-            }} />
+            <Suspense fallback={<EditorFallback />}>
+              {selectedDoc.type === "quote" ? (
+                <QuoteEditor
+                  quoteId={selectedDoc.id}
+                  onUpdate={() => {
+                    fetchProject()
+                    if (project?.quotes) fetchInvoices(project.quotes)
+                  }}
+                />
+              ) : selectedDoc.type === "po" ? (
+                <POEditor
+                  poId={selectedDoc.id}
+                  onUpdate={fetchProject}
+                  onSelectPO={(newPoId) => setSelectedDoc({ type: "po", id: newPoId })}
+                  onDirtyStateChange={handleEditorDirtyChange}
+                />
+              ) : (
+                <InvoiceEditor invoiceId={selectedDoc.id} onUpdate={() => {
+                  fetchProject()
+                  if (project?.quotes) fetchInvoices(project.quotes)
+                }} />
+              )}
+            </Suspense>
           )}
         </div>
       </div>

--- a/frontend/src/pages/ReportsPage.tsx
+++ b/frontend/src/pages/ReportsPage.tsx
@@ -4,9 +4,6 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
 import { api } from '@/api/client'
-import { pdf } from '@react-pdf/renderer'
-import { InvoiceSummaryPDF } from '@/components/pdf/InvoiceSummaryPDF'
-import { generateBacklogExcel } from '@/lib/excel'
 import { formatCurrency } from '@/lib/pricing'
 import type { InvoiceSummaryItem, CompanySettings, BacklogQuoteItem } from '@/types'
 import { FileText, Download, Loader2, ChevronRight, ChevronDown, FileSpreadsheet } from 'lucide-react'
@@ -56,6 +53,10 @@ export function ReportsPage() {
 
     setLoading(true)
     try {
+      const [{ pdf }, { InvoiceSummaryPDF }] = await Promise.all([
+        import('@react-pdf/renderer'),
+        import('@/components/pdf/InvoiceSummaryPDF'),
+      ])
       const blob = await pdf(
         <InvoiceSummaryPDF
           invoices={invoices}
@@ -82,6 +83,10 @@ export function ReportsPage() {
 
     setLoading(true)
     try {
+      const [{ pdf }, { InvoiceSummaryPDF }] = await Promise.all([
+        import('@react-pdf/renderer'),
+        import('@/components/pdf/InvoiceSummaryPDF'),
+      ])
       const blob = await pdf(
         <InvoiceSummaryPDF
           invoices={invoices}
@@ -116,8 +121,9 @@ export function ReportsPage() {
     }
   }
 
-  const handleBacklogDownload = () => {
+  const handleBacklogDownload = async () => {
     if (!backlogData) return
+    const { generateBacklogExcel } = await import('@/lib/excel')
     generateBacklogExcel(backlogData)
   }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,4 +11,31 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return
+          // Note: @react-pdf and xlsx are intentionally NOT split into named chunks here.
+          // Both are only ever reached via dynamic import() in their callers (print/export
+          // handlers + ReportsPage), so Rollup already creates lazy chunks for them on its
+          // own. Manually bucketing @react-pdf produced a circular chunk dependency with
+          // vendor-react via Rollup's auto-generated CJS interop helper, which forced
+          // vendor-pdf into the entry's modulepreload list — undoing the lazy split.
+          if (id.includes('@clerk/')) return 'vendor-clerk'
+          if (id.includes('@radix-ui/')) return 'vendor-radix'
+          if (id.includes('/lucide-react/')) return 'vendor-icons'
+          if (
+            id.includes('/react/') ||
+            id.includes('/react-dom/') ||
+            id.includes('/react-is/') ||
+            id.includes('/scheduler/') ||
+            id.includes('/object-assign/')
+          ) {
+            return 'vendor-react'
+          }
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
Fixes #85.

## Summary

Initial JS payload on the Projects landing screen drops from **2,710 KB raw / 857 KB gzip → 567 KB raw / 164 KB gzip** (−79% raw, −81% gzip). The PDF renderer (~1.6 MB) and `xlsx` (~284 KB) no longer ship with the entry bundle; they load only when the user prints a document or exports a backlog report.

## Changes

**`vite.config.ts`** — `build.rollupOptions.output.manualChunks` splits long-lived vendor chunks: `vendor-react` (react/react-dom/react-is/scheduler/object-assign), `vendor-radix`, `vendor-clerk`, `vendor-icons`. `@react-pdf` and `xlsx` are intentionally left to Rollup's automatic splitting — manually bucketing `@react-pdf` produced a circular chunk via Rollup's generated CJS interop helper (`getDefaultExportFromCjs`), which forced the PDF bundle into the entry's `modulepreload`. Letting the dynamic `import()` callsites drive the split fixes that and keeps the chunks lazy.

**Dynamic PDF / xlsx imports** — `QuoteEditor`, `POEditor`, `InvoiceEditor`, and `ReportsPage` now `await import('@react-pdf/renderer')` plus the relevant PDF template inside their print/download handlers, parallelized with the API fetch via `Promise.all`. `generateBacklogExcel` is also dynamically imported so `xlsx` only loads on click.

**`React.lazy()` + `Suspense`** —
- `ProjectDetailsPage` lazy-loads `QuoteEditor`, `POEditor`, `InvoiceEditor` with a `Loading editor…` fallback in the right pane.
- `App.tsx` lazy-loads `ProfilesPage`, `ProjectDetailsPage`, `ReportsPage`, `SettingsPage`, `MigrationPage`. `ProjectsPage` stays eager so the landing screen has no Suspense flash.

## Build output

Before: single `index-*.js` at 2,710 KB / 857 KB gzip.

After (eager, in `modulepreload`):
- `index-*.js` 122 KB / 31 KB gzip
- `vendor-react-*.js` 222 KB / 71 KB gzip
- `vendor-radix-*.js` 126 KB / 36 KB gzip
- `vendor-clerk-*.js` 83 KB / 20 KB gzip
- `vendor-icons-*.js` 14 KB / 5 KB gzip

Lazy (loaded on demand): `react-pdf.browser-*.js` 1,567 KB / 525 KB gzip, `excel-*.js` 284 KB / 95 KB gzip, plus per-editor and per-PDF-template chunks.