### PR TITLE
perf: trim ProjectFull payload + server-side vendor parts filter (Phase 5)

### DIFF
--- a/backend/routes/parts.py
+++ b/backend/routes/parts.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session, joinedload
-from typing import List
+from typing import List, Optional
 
 from database import get_db
 from models import Part, Labor, Profile
@@ -32,17 +32,21 @@ def auto_calculate_cost(part: Part, db: Session) -> None:
 def get_all_parts(
     offset: int = Query(0, ge=0),
     limit: int = Query(DEFAULT_LIMIT, ge=0, le=MAX_LIMIT),
+    vendor_id: Optional[int] = Query(None, description="Filter to parts linked to this vendor"),
     skip: int = Query(0, ge=0, deprecated=True, description="Deprecated alias for offset"),
     db: Session = Depends(get_db),
 ):
     """Paginated list of parts with their linked labor items.
 
+    Optional `vendor_id` filters server-side to parts linked to that vendor.
     Pass `limit=0` to fetch every row (used by autocomplete loaders).
     """
     effective_offset = offset or skip
     base = db.query(Part).options(
         joinedload(Part.labor_items), joinedload(Part.vendor)
     )
+    if vendor_id is not None:
+        base = base.filter(Part.vendor_id == vendor_id)
     total = base.with_entities(Part.id).count()
     q = base.order_by(Part.id).offset(effective_offset)
     if limit > 0:

--- a/backend/routes/projects.py
+++ b/backend/routes/projects.py
@@ -358,16 +358,16 @@ def search_projects(q: str = "", db: Session = Depends(get_db)):
 
 @router.get("/{project_id}", response_model=ProjectFull)
 def get_project(project_id: int, db: Session = Depends(get_db)):
-    """Get a single project with full nested structure (quotes, POs, line items)."""
+    """Get a single project with its quote/PO summaries (no nested line items).
+
+    Open a specific quote or PO via its own endpoint to load its line items.
+    """
     project = (
         db.query(Project)
         .options(
             joinedload(Project.customer),
-            joinedload(Project.quotes).joinedload(Quote.line_items),
-            joinedload(Project.purchase_orders).options(
-                joinedload(PurchaseOrder.vendor),
-                joinedload(PurchaseOrder.line_items)
-            )
+            joinedload(Project.quotes),
+            joinedload(Project.purchase_orders).joinedload(PurchaseOrder.vendor),
         )
         .filter(Project.id == project_id)
         .first()

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -745,10 +745,39 @@ class POCommitEditsResponse(BaseModel):
     snapshot_version: int
 
 
-# ===== Project with nested documents =====
+# ===== Project-detail summary schemas =====
+# Lighter shapes used by ProjectFull so the project detail screen does not
+# hydrate every quote's and PO's line items. Open a specific quote/PO via
+# `GET /quotes/{id}` or `GET /purchase-orders/{id}` to get its line items.
+class QuoteSummary(QuoteBase):
+    id: int
+    quote_sequence: int
+    quote_number: Optional[str] = None
+    created_at: datetime
+    current_version: int = 0
+    cost_code_id: Optional[int] = None
+
+    class Config:
+        from_attributes = True
+
+
+class POSummary(PurchaseOrderBase):
+    id: int
+    created_at: datetime
+    po_sequence: int
+    current_version: int = 0
+    po_number: Optional[str] = None
+    cost_code_id: Optional[int] = None
+    vendor: Profile
+
+    class Config:
+        from_attributes = True
+
+
+# ===== Project with nested documents (no line items) =====
 class ProjectFull(Project):
-    quotes: List[Quote] = []
-    purchase_orders: List[PurchaseOrder] = []
+    quotes: List[QuoteSummary] = []
+    purchase_orders: List[POSummary] = []
 
     class Config:
         from_attributes = True

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -63,12 +63,14 @@ export const api = {
   // ===== Parts =====
   parts: {
     // Paginated list for list views. Returns {items, total, limit, offset}.
-    list: (params: ListParams = {}) =>
+    // Pass `vendor_id` to filter server-side to parts linked to that vendor.
+    list: (params: ListParams & { vendor_id?: number } = {}) =>
       request<Paginated<Part>>(`/parts/${buildQuery(params)}`),
     // Convenience: unbounded fetch (limit=0) returning just items.
     // Used by autocomplete/dropdown loaders that need every row.
-    getAll: () =>
-      request<Paginated<Part>>('/parts/?limit=0').then(r => r.items),
+    // Pass `{ vendor_id }` to filter server-side.
+    getAll: (params: { vendor_id?: number } = {}) =>
+      request<Paginated<Part>>(`/parts/${buildQuery({ ...params, limit: 0 })}`).then(r => r.items),
     get: (id: number) => request<Part>(`/parts/${id}`),
     create: (data: PartCreate) =>
       request<Part>('/parts/', { method: 'POST', body: JSON.stringify(data) }),

--- a/frontend/src/pages/ProfilesPage.tsx
+++ b/frontend/src/pages/ProfilesPage.tsx
@@ -60,8 +60,8 @@ export function ProfilesPage() {
     if (viewingProfile?.type === "vendor") {
       setLoadingParts(true)
       setImportResult(null)
-      api.parts.getAll()
-        .then(allParts => setVendorParts(allParts.filter(p => p.vendor_id === viewingProfile.id)))
+      api.parts.getAll({ vendor_id: viewingProfile.id })
+        .then(setVendorParts)
         .catch(() => setVendorParts([]))
         .finally(() => setLoadingParts(false))
     } else {
@@ -77,8 +77,8 @@ export function ProfilesPage() {
       const result = await api.vendorPricebook.import(viewingProfile.id, file)
       setImportResult(result)
       // Refresh vendor parts list
-      const allParts = await api.parts.getAll()
-      setVendorParts(allParts.filter(p => p.vendor_id === viewingProfile.id))
+      const refreshed = await api.parts.getAll({ vendor_id: viewingProfile.id })
+      setVendorParts(refreshed)
     } catch (err) {
       setImportResult({ created: 0, updated: 0, errors: [err instanceof Error ? err.message : "Import failed"] })
     } finally {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -293,9 +293,14 @@ export interface ProjectUpdate {
   project_lead?: string | null;
 }
 
+// Lighter shapes returned by GET /projects/{id} — no nested line items.
+// Open a specific quote/PO via its own endpoint to load its line items.
+export type QuoteSummary = Omit<Quote, 'line_items' | 'cost_code'>;
+export type POSummary = Omit<PurchaseOrder, 'line_items' | 'cost_code'>;
+
 export interface ProjectFull extends Project {
-  quotes: Quote[];
-  purchase_orders: PurchaseOrder[];
+  quotes: QuoteSummary[];
+  purchase_orders: POSummary[];
 }
 
 // ===== Projects List View (lightweight, aggregated) =====


### PR DESCRIPTION
Fixes #86.

## Summary

Two payload-bloat issues outside the Projects list:

- **`GET /projects/{id}` no longer hydrates every quote/PO's line items.** Adds `QuoteSummary` and `POSummary` Pydantic schemas (and matching TS `Omit<…>` types) so `ProjectFull` ships only the summary rows the project detail screen actually renders. Opening a specific quote or PO still loads its line items via `GET /quotes/{id}` / `GET /purchase-orders/{id}`. The `joinedload(Quote.line_items)` and `joinedload(PurchaseOrder.line_items)` chains are dropped; vendor join is preserved because the sidebar shows `po.vendor.name`.
- **`GET /parts` accepts an optional `?vendor_id=N` query param.** `ProfilesPage` now hits the filtered endpoint instead of fetching every part and calling `.filter(p => p.vendor_id === id)` client-side. This is a single `WHERE part.vendor_id = N` on the backend, served by the FK index added in Phase 3.

## Files changed

- `backend/schemas.py` — add `QuoteSummary`/`POSummary`, point `ProjectFull` at them
- `backend/routes/projects.py` — trim joinedload chain in `get_project`
- `backend/routes/parts.py` — add `vendor_id` query filter
- `frontend/src/types/index.ts` — `QuoteSummary` / `POSummary` mirror types
- `frontend/src/api/client.ts` — `parts.list` / `parts.getAll` accept `{ vendor_id }`
- `frontend/src/pages/ProfilesPage.tsx` — fetch via `api.parts.getAll({ vendor_id })` in both load and post-import refresh paths

## Backwards compatibility

`parts.getAll()` argument is optional, so the four other callers (`App.tsx`, `QuoteEditor`, `POEditor`, the second call site in `ProfilesPage`) keep working with no signature change.