### PR TITLE
feat(ui): shared StatusBadge + formatDate utilities (UX-3)

### DIFF
--- a/frontend/src/components/editors/POEditor.tsx
+++ b/frontend/src/components/editors/POEditor.tsx
@@ -60,6 +60,8 @@ import {
   Plus, Minus, Trash2, Package, FileText, Building, Pencil, Copy,
   X, GitCommit, Eye, AlertTriangle, Check, Calendar, Loader2, Hash, Printer
 } from "lucide-react"
+import { StatusBadge } from "@/components/ui/status-badge"
+import { formatDate } from "@/lib/format"
 import { PartForm } from "@/components/forms/PartForm"
 import { POAuditTrail } from "./POAuditTrail"
 
@@ -1218,7 +1220,7 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
             <span>Vendor: {po.vendor.name}</span>
           </div>
           <p className="text-sm text-muted-foreground">
-            Created: {new Date(po.created_at).toLocaleDateString()}
+            Created: {formatDate(po.created_at)}
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -1235,9 +1237,7 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
               </SelectContent>
             </Select>
           ) : (
-            <Badge variant="outline" className={`px-3 py-1 ${getStatusBadgeColor(po.status)}`}>
-              {po.status}
-            </Badge>
+            <StatusBadge status={po.status} className="px-3 py-1" />
           )}
         </div>
       </div>
@@ -1404,7 +1404,7 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
                 <div className="flex items-center gap-2">
                   {po.expected_delivery_date ? (
                     <span className="text-sm font-medium">
-                      {new Date(po.expected_delivery_date).toLocaleDateString()}
+                      {formatDate(po.expected_delivery_date)}
                     </span>
                   ) : (
                     <span className="text-sm text-muted-foreground" title="Click pencil to set">—</span>

--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -56,6 +56,8 @@ import type {
   StagedLineItemChange, CommitEditsRequest
 } from "@/types"
 import { Plus, Minus, Trash2, Wrench, Package, FileText, Pencil, ClipboardCheck, Receipt, Percent, Info, Copy, Car, MapPin, X, Lock, GitCommit, Eye, AlertTriangle, Check, CheckCircle2, Printer, Loader2, Hash, ChevronUp, ChevronDown } from "lucide-react"
+import { StatusBadge } from "@/components/ui/status-badge"
+import { formatDate } from "@/lib/format"
 import type { CompanySettings, Project, SystemRate } from '@/types'
 import { QuoteAuditTrail } from "./QuoteAuditTrail"
 import { PartForm } from "@/components/forms/PartForm"
@@ -2683,21 +2685,11 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
         <div>
           <h2 className="text-xl font-semibold">{quote.quote_number}</h2>
           <p className="text-sm text-muted-foreground">
-            Created: {new Date(quote.created_at).toLocaleDateString()}
+            Created: {formatDate(quote.created_at)}
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <Badge
-            variant={quote.status === "Closed" ? "default" : "secondary"}
-            className={
-              quote.status === "Draft" ? "bg-gray-100 text-gray-700 border-gray-300" :
-              quote.status === "Work Order" ? "bg-blue-100 text-blue-700 border-blue-300" :
-              quote.status === "Invoiced" ? "bg-amber-100 text-amber-700 border-amber-300" :
-              "bg-green-100 text-green-700 border-green-300"
-            }
-          >
-            {quote.status}
-          </Badge>
+          <StatusBadge status={quote.status} />
         </div>
       </div>
 

--- a/frontend/src/components/editors/RevertConfirmDialog.tsx
+++ b/frontend/src/components/editors/RevertConfirmDialog.tsx
@@ -10,6 +10,7 @@ import {
 import { Badge } from "@/components/ui/badge"
 import { AlertTriangle, History, FileX2 } from "lucide-react"
 import type { RevertPreview, PORevertPreview } from "@/types"
+import { formatDate } from "@/lib/format"
 
 type RevertPreviewUnion = RevertPreview | PORevertPreview
 
@@ -102,7 +103,7 @@ export function RevertConfirmDialog({
                         </div>
                         <div className="flex items-center gap-2">
                           <span className="text-xs text-muted-foreground">
-                            {new Date(invoice.created_at).toLocaleDateString()}
+                            {formatDate(invoice.created_at)}
                           </span>
                           {getInvoiceStatusBadge(invoice.status)}
                         </div>
@@ -139,7 +140,7 @@ export function RevertConfirmDialog({
                         </div>
                         <div className="flex items-center gap-2">
                           <span className="text-xs text-muted-foreground">
-                            {new Date(receiving.received_date).toLocaleDateString()}
+                            {formatDate(receiving.received_date)}
                           </span>
                           {receiving.voided_at ? (
                             <Badge variant="outline" className="text-muted-foreground">Voided</Badge>

--- a/frontend/src/components/forms/ProjectForm.tsx
+++ b/frontend/src/components/forms/ProjectForm.tsx
@@ -13,6 +13,7 @@ import { SearchableSelect } from "@/components/ui/searchable-select"
 import type { SearchableSelectOption } from "@/components/ui/searchable-select"
 import { api } from "@/api/client"
 import type { Profile, Project, ProjectCreate, Contact } from "@/types"
+import { formatDate } from "@/lib/format"
 import { ProfileForm } from "./ProfileForm"
 import { ContactForm } from "./ContactForm"
 
@@ -215,7 +216,7 @@ export function ProjectForm({ project, onSuccess, onCancel }: ProjectFormProps) 
           <div className="space-y-2">
             <Label>Created On</Label>
             <Input
-              value={new Date(project.created_on).toLocaleDateString()}
+              value={formatDate(project.created_on)}
               disabled
               className="bg-muted"
             />

--- a/frontend/src/components/ui/status-badge.tsx
+++ b/frontend/src/components/ui/status-badge.tsx
@@ -1,0 +1,50 @@
+import * as React from "react"
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+import { titleCaseStatus } from "@/lib/format"
+
+/**
+ * Single source of truth for status badge colour + casing across the app.
+ * Lookup is case-insensitive on the lowercase form so callers don't have to
+ * worry whether the backend hands them `Active`, `active`, or `ACTIVE`.
+ */
+const STATUS_STYLES: Record<string, string> = {
+  // Project statuses
+  "active":       "bg-green-500/10 text-green-700 border-green-500/30 dark:text-green-300",
+  "completed":    "bg-blue-500/10 text-blue-700 border-blue-500/30 dark:text-blue-300",
+  "on hold":      "bg-amber-500/10 text-amber-700 border-amber-500/30 dark:text-amber-300",
+  "archived":     "bg-slate-500/10 text-slate-700 border-slate-500/30 dark:text-slate-300",
+
+  // Quote statuses
+  "draft":        "bg-gray-500/10 text-gray-700 border-gray-500/30 dark:text-gray-300",
+  "work order":   "bg-blue-500/10 text-blue-700 border-blue-500/30 dark:text-blue-300",
+  "invoiced":     "bg-amber-500/10 text-amber-700 border-amber-500/30 dark:text-amber-300",
+
+  // PO statuses (Draft already covered above)
+  "sent":         "bg-indigo-500/10 text-indigo-700 border-indigo-500/30 dark:text-indigo-300",
+  "received":     "bg-green-500/10 text-green-700 border-green-500/30 dark:text-green-300",
+  "closed":       "bg-blue-500/10 text-blue-700 border-blue-500/30 dark:text-blue-300",
+
+  // Invoice statuses (Draft / Sent / Paid / Voided)
+  "paid":         "bg-green-500/10 text-green-700 border-green-500/30 dark:text-green-300",
+  "voided":       "bg-red-500/10 text-red-700 border-red-500/30 dark:text-red-300",
+}
+
+interface StatusBadgeProps extends React.HTMLAttributes<HTMLDivElement> {
+  status: string
+}
+
+export function StatusBadge({ status, className, ...rest }: StatusBadgeProps) {
+  const key = (status ?? "").trim().toLowerCase().replace(/[_-]+/g, " ")
+  const styleClass = STATUS_STYLES[key]
+  const label = titleCaseStatus(status)
+  return (
+    <Badge
+      variant="outline"
+      className={cn(styleClass ?? "text-foreground", className)}
+      {...rest}
+    >
+      {label}
+    </Badge>
+  )
+}

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared formatting utilities so dates and empty values look identical across
+ * the entire app. Adopting these is part of UX-3 (visual consistency).
+ */
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+})
+
+/** Render a date as `MMM d, yyyy` (e.g. `Jun 8, 2020`); em-dash for missing values. */
+export function formatDate(value: string | Date | null | undefined): string {
+  if (value == null || value === "") return "—"
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return "—"
+  return dateFormatter.format(date)
+}
+
+/** The single empty-value glyph used everywhere a read-only value is missing. */
+export const EMPTY_VALUE = "—"
+
+/** Title-case a status string for display (e.g. `archived` -> `Archived`, `work_order` -> `Work Order`). */
+export function titleCaseStatus(value: string): string {
+  if (!value) return EMPTY_VALUE
+  return value
+    .replace(/[_-]+/g, " ")
+    .split(" ")
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(" ")
+}

--- a/frontend/src/pages/ProjectDetailsPage.tsx
+++ b/frontend/src/pages/ProjectDetailsPage.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef, useCallback, useMemo, lazy, Suspense } from "react"
 import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
+import { StatusBadge } from "@/components/ui/status-badge"
+import { formatDate } from "@/lib/format"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
 import {
@@ -496,7 +497,7 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
               {project.ucsh_project_number && (
                 <span>UCSH: {project.ucsh_project_number}</span>
               )}
-              <span>Created: {new Date(project.created_on).toLocaleDateString()}</span>
+              <span>Created: {formatDate(project.created_on)}</span>
             </div>
             <div className="flex items-center gap-4 mt-2 text-sm text-muted-foreground">
               <span className="flex items-center gap-1">
@@ -517,9 +518,7 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
               )}
             </div>
           </div>
-          <Badge className="bg-green-500/10 text-green-600 border-green-500/20">
-            {project.status}
-          </Badge>
+          <StatusBadge status={project.status} />
         </div>
       </div>
 
@@ -829,7 +828,7 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
               {project.quotes.map((q) => (
                 <CommandItem
                   key={`q-${q.id}`}
-                  value={`quote ${q.quote_number} ${q.status} ${new Date(q.created_at).toLocaleDateString()}`}
+                  value={`quote ${q.quote_number} ${q.status} ${formatDate(q.created_at)}`}
                   onSelect={() => {
                     setCmdOpen(false)
                     openDoc("quote", q.id)
@@ -837,7 +836,7 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
                 >
                   <FileText className="h-4 w-4" />
                   <span className="flex-1">{q.quote_number}</span>
-                  <Badge variant="secondary" className="text-[10px]">{q.status}</Badge>
+                  <StatusBadge status={q.status} className="text-[10px]" />
                 </CommandItem>
               ))}
             </CommandGroup>
@@ -873,7 +872,7 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
                 >
                   <Receipt className="h-4 w-4" />
                   <span className="flex-1">Invoice {inv.id} - {inv.quoteNumber}</span>
-                  <Badge variant="secondary" className="text-[10px]">{inv.status}</Badge>
+                  <StatusBadge status={inv.status} className="text-[10px]" />
                 </CommandItem>
               ))}
             </CommandGroup>
@@ -917,20 +916,10 @@ function QuoteRow({ quote, isSelected, isHighlighted, onSelect, onDelete }: Quot
       <div className="flex-1 min-w-0">
         <div className="text-sm font-medium flex items-center gap-2">
           <span className="truncate">{quote.quote_number}</span>
-          <Badge
-            variant="secondary"
-            className={`text-[10px] px-1.5 py-0 ${
-              quote.status === "Draft" ? "bg-gray-100 text-gray-600" :
-              quote.status === "Work Order" ? "bg-blue-100 text-blue-600" :
-              quote.status === "Invoiced" ? "bg-amber-100 text-amber-600" :
-              "bg-green-100 text-green-600"
-            }`}
-          >
-            {quote.status}
-          </Badge>
+          <StatusBadge status={quote.status} className="text-[10px] px-1.5 py-0" />
         </div>
         <div className="text-xs text-muted-foreground">
-          {new Date(quote.created_at).toLocaleDateString()}
+          {formatDate(quote.created_at)}
         </div>
       </div>
       <Button
@@ -1003,21 +992,10 @@ function InvoiceRow({ invoice, isSelected, isHighlighted, onSelect }: InvoiceRow
       <div className="flex-1 min-w-0">
         <div className="text-sm font-medium flex items-center gap-2">
           <span className="truncate">Invoice {invoice.id} - {invoice.quoteNumber}</span>
-          <Badge
-            variant={
-              invoice.status === "Paid"
-                ? "default"
-                : invoice.status === "Voided"
-                ? "destructive"
-                : "secondary"
-            }
-            className="text-[10px] px-1.5 py-0"
-          >
-            {invoice.status}
-          </Badge>
+          <StatusBadge status={invoice.status} className="text-[10px] px-1.5 py-0" />
         </div>
         <div className="text-xs text-muted-foreground">
-          {new Date(invoice.created_at).toLocaleDateString()}
+          {formatDate(invoice.created_at)}
         </div>
       </div>
     </div>

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -1,7 +1,8 @@
 import { Fragment, useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
+import { StatusBadge } from "@/components/ui/status-badge"
+import { formatDate, EMPTY_VALUE } from "@/lib/format"
 import {
   Dialog,
   DialogContent,
@@ -156,19 +157,6 @@ export function ProjectsPage({
     setDialogOpen(open)
   }
 
-  const getStatusBadge = (status: string) => {
-    switch (status) {
-      case "active":
-        return <Badge className="bg-green-500/10 text-green-600 border-green-500/20">Active</Badge>
-      case "completed":
-        return <Badge variant="secondary">Completed</Badge>
-      case "on_hold":
-        return <Badge variant="outline">On Hold</Badge>
-      default:
-        return <Badge variant="outline">{status}</Badge>
-    }
-  }
-
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
@@ -211,10 +199,10 @@ export function ProjectsPage({
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>UCA #</TableHead>
-                <TableHead>UCSH #</TableHead>
                 <TableHead>Project Name</TableHead>
                 <TableHead>Customer</TableHead>
+                <TableHead>UCA #</TableHead>
+                <TableHead>UCSH #</TableHead>
                 <TableHead>Project Lead</TableHead>
                 <TableHead>Status</TableHead>
                 <TableHead>Created On</TableHead>
@@ -230,8 +218,6 @@ export function ProjectsPage({
                       className="cursor-pointer hover:bg-muted/50"
                       onClick={() => onSelectProject(project.id)}
                     >
-                      <TableCell className="font-mono text-sm">{project.uca_project_number}</TableCell>
-                      <TableCell className="text-muted-foreground">{project.ucsh_project_number || "-"}</TableCell>
                       <TableCell className="font-medium">
                         <div className="flex items-center gap-2">
                           <FolderOpen className="h-4 w-4 text-muted-foreground" />
@@ -239,10 +225,12 @@ export function ProjectsPage({
                         </div>
                       </TableCell>
                       <TableCell>{project.customer_name}</TableCell>
-                      <TableCell className="text-muted-foreground">{project.project_lead || "-"}</TableCell>
-                      <TableCell>{getStatusBadge(project.status)}</TableCell>
+                      <TableCell className="font-mono text-sm">{project.uca_project_number}</TableCell>
+                      <TableCell className="text-muted-foreground">{project.ucsh_project_number || EMPTY_VALUE}</TableCell>
+                      <TableCell className="text-muted-foreground">{project.project_lead || EMPTY_VALUE}</TableCell>
+                      <TableCell><StatusBadge status={project.status} /></TableCell>
                       <TableCell className="text-muted-foreground">
-                        {new Date(project.created_on).toLocaleDateString()}
+                        {formatDate(project.created_on)}
                       </TableCell>
                       <TableCell className="text-right space-x-1">
                         <Button

--- a/frontend/src/pages/ReportsPage.tsx
+++ b/frontend/src/pages/ReportsPage.tsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
 import { api } from '@/api/client'
 import { formatCurrency } from '@/lib/pricing'
+import { formatDate } from '@/lib/format'
 import type { InvoiceSummaryItem, CompanySettings, BacklogQuoteItem } from '@/types'
 import { FileText, Download, Loader2, ChevronRight, ChevronDown, FileSpreadsheet } from 'lucide-react'
 
@@ -238,7 +239,7 @@ export function ReportsPage() {
                       {invoices.map((inv) => (
                         <tr key={inv.invoice_id} className="hover:bg-muted/50">
                           <td className="px-3 py-2">{inv.invoice_id}</td>
-                          <td className="px-3 py-2">{new Date(inv.invoice_date).toLocaleDateString()}</td>
+                          <td className="px-3 py-2">{formatDate(inv.invoice_date)}</td>
                           <td className="px-3 py-2">{inv.uca_project_number}</td>
                           <td className="px-3 py-2">{inv.client_po_number || '—'}</td>
                           <td className="px-3 py-2">{inv.customer_name} — {inv.project_name}</td>


### PR DESCRIPTION
## Summary

- **New shared primitives.** \`frontend/src/components/ui/status-badge.tsx\` and \`frontend/src/lib/format.ts\`. Together they enforce a single colour mapping, a single title-cased label, a single date format (\`MMM d, yyyy\`), and a single em-dash glyph for missing read-only values.
- **StatusBadge.** Case-insensitive lookup so the API can return \`active\` / \`Active\` / \`ACTIVE\` interchangeably. Covers every status emitted in the app: Active, Completed, On Hold, Archived, Draft, Work Order, Invoiced, Sent, Received, Closed, Paid, Voided.
- **formatDate.** Pure helper backed by a single \`Intl.DateTimeFormat\` instance. Returns the em-dash for null/empty/invalid input. \`EMPTY_VALUE\` constant exposed for non-date empty values.
- **Adoption sweep.** \`ProjectsPage\`, \`ProjectDetailsPage\`, \`QuoteEditor\`, \`POEditor\`, \`ReportsPage\`, \`ProjectForm\`, and \`RevertConfirmDialog\` all switched over. Inline ad-hoc \`Badge\` colour ternaries and \`new Date(...).toLocaleDateString()\` calls are gone.
- **Projects column reorder.** Leads with \`Project Name\` → \`Customer\` → \`UCA #\` → \`UCSH #\` → \`Project Lead\` → \`Status\` → \`Created On\` → \`Actions\` so the human-readable identifiers come first.

Fixes #95