### PR TITLE
feat(auth): gate Migration page to admin role (UX-5)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import { MiscForm } from "@/components/forms/MiscForm"
 import { ThemeToggle } from "@/components/theme-toggle"
 import { ProjectsPage } from "@/pages/ProjectsPage"
 import { api } from "@/api/client"
+import { useIsAdmin } from "@/hooks/use-is-admin"
 
 // Lazy-loaded pages: keep ProjectsPage eager (default landing), defer the rest.
 const ProfilesPage = lazy(() =>
@@ -67,6 +68,14 @@ function App() {
   const [projectSearchTerm, setProjectSearchTerm] = useState("")
   // When navigating into a project from a search-result chip, seed the editor to open that doc directly.
   const [pendingInitialDoc, setPendingInitialDoc] = useState<{ type: "quote" | "po"; id: number } | null>(null)
+
+  // Migration is an admin-only destructive surface; non-admins shouldn't see it.
+  const isAdmin = useIsAdmin()
+  useEffect(() => {
+    if (currentView === "migration" && !isAdmin) {
+      setCurrentView("projects")
+    }
+  }, [currentView, isAdmin])
 
   // Inventory state
   const [parts, setParts] = useState<Part[]>([])
@@ -233,6 +242,9 @@ function App() {
         return <SettingsPage />
 
       case "migration":
+        // Defensive gate in case state somehow lands here for a non-admin
+        // (the useEffect above will then redirect to projects on the next tick).
+        if (!isAdmin) return null
         return <MigrationPage />
 
       case "project-details":
@@ -662,14 +674,16 @@ function App() {
               <Settings className="h-4 w-4" />
               Settings
             </Button>
-            <Button
-              variant={currentView === "migration" ? "secondary" : "ghost"}
-              className="w-full justify-start gap-2"
-              onClick={() => setCurrentView("migration")}
-            >
-              <DatabaseZap className="h-4 w-4" />
-              Migration
-            </Button>
+            {isAdmin && (
+              <Button
+                variant={currentView === "migration" ? "secondary" : "ghost"}
+                className="w-full justify-start gap-2"
+                onClick={() => setCurrentView("migration")}
+              >
+                <DatabaseZap className="h-4 w-4" />
+                Migration
+              </Button>
+            )}
           </nav>
         </ScrollArea>
       </aside>

--- a/frontend/src/hooks/use-is-admin.ts
+++ b/frontend/src/hooks/use-is-admin.ts
@@ -1,0 +1,14 @@
+import { useUser } from "@clerk/react"
+
+/**
+ * Returns true only when the signed-in user has `publicMetadata.role === "admin"`.
+ *
+ * Note: this is a client-side gate for hiding UI surfaces only. The backend must
+ * still enforce admin-only operations independently — never trust the client.
+ */
+export function useIsAdmin(): boolean {
+  const { isLoaded, isSignedIn, user } = useUser()
+  if (!isLoaded || !isSignedIn || !user) return false
+  const role = user.publicMetadata?.role
+  return role === "admin"
+}


### PR DESCRIPTION
## Summary

- New \`useIsAdmin\` hook (\`frontend/src/hooks/use-is-admin.ts\`) reads Clerk \`publicMetadata.role\` and returns \`true\` only for \`role === "admin"\`.
- The Migration sidebar entry in \`App.tsx\` is hidden for non-admins.
- The \`migration\` view case in \`renderContent()\` no-ops for non-admins, and a \`useEffect\` redirects state back to \`projects\` if it somehow lands on \`migration\` for a non-admin (covers the case where an admin loses the role mid-session).
- This is a client-side hide-the-UI gate. The Migration page still hits the backend, which is responsible for enforcing admin-only operations on its own — never trust the client.

## How to grant admin

In the Clerk dashboard, set the user's **Public metadata** to:

\`\`\`json
{ "role": "admin" }
\`\`\`

(Public metadata is what \`useUser()\` exposes to the client. Don't put secrets there.)

Fixes #97