### PR TITLE
feat(projects): archived toggle, sort + search spinner (UX-4 foundations)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "@react-pdf/renderer": "^4.3.2",
         "@tailwindcss/postcss": "^4.1.18",
         "@tailwindcss/vite": "^4.1.18",
+        "@tanstack/react-virtual": "^3.13.24",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -3248,6 +3249,33 @@
       "version": "5.90.16",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.16.tgz",
       "integrity": "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "@react-pdf/renderer": "^4.3.2",
     "@tailwindcss/postcss": "^4.1.18",
     "@tailwindcss/vite": "^4.1.18",
+    "@tanstack/react-virtual": "^3.13.24",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useState } from "react"
+import { Fragment, useEffect, useMemo, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { StatusBadge } from "@/components/ui/status-badge"
@@ -22,7 +22,7 @@ import { ProjectForm } from "@/components/forms/ProjectForm"
 import type { ProjectFormInput } from "@/components/forms/ProjectForm"
 import { api } from "@/api/client"
 import type { ProjectListView, ProjectSearchResult } from "@/types"
-import { Plus, Trash2, Pencil, FolderOpen, Search, FileText, ShoppingCart } from "lucide-react"
+import { Plus, Trash2, Pencil, FolderOpen, Search, FileText, ShoppingCart, Loader2, ChevronUp, ChevronDown, ArrowUpDown } from "lucide-react"
 
 interface ProjectsPageProps {
   onSelectProject: (projectId: number) => void
@@ -59,13 +59,52 @@ export function ProjectsPage({
   const [baseProjects, setBaseProjects] = useState<ProjectSearchResult[]>([])
   const [searchResults, setSearchResults] = useState<ProjectSearchResult[] | null>(null)
   const [loading, setLoading] = useState(true)
+  const [searchLoading, setSearchLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [debouncedTerm, setDebouncedTerm] = useState(searchTerm)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [editingProject, setEditingProject] = useState<ProjectFormInput | null>(null)
 
-  // When a search is active, show search results; otherwise show the full list.
-  const displayProjects = searchResults ?? baseProjects
+  // UX-4 filter controls
+  const [showArchived, setShowArchived] = useState(false)
+  type SortColumn = "name" | "customer_name" | "uca_project_number" | "ucsh_project_number" | "project_lead" | "status" | "created_on"
+  const [sortBy, setSortBy] = useState<SortColumn>("uca_project_number")
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc")
+
+  // Apply archived filter + sort to the raw results before render.
+  const rawProjects = searchResults ?? baseProjects
+  const archivedCount = useMemo(
+    () => rawProjects.filter((p) => p.status.toLowerCase() === "archived").length,
+    [rawProjects]
+  )
+  const displayProjects = useMemo(() => {
+    const filtered = showArchived
+      ? rawProjects
+      : rawProjects.filter((p) => p.status.toLowerCase() !== "archived")
+    const sorted = [...filtered].sort((a, b) => {
+      const av = (a[sortBy] ?? "") as string
+      const bv = (b[sortBy] ?? "") as string
+      const cmp = av.localeCompare(bv, undefined, { numeric: true, sensitivity: "base" })
+      return sortDir === "asc" ? cmp : -cmp
+    })
+    return sorted
+  }, [rawProjects, showArchived, sortBy, sortDir])
+
+  const toggleSort = (col: SortColumn) => {
+    if (sortBy === col) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"))
+    } else {
+      setSortBy(col)
+      setSortDir(col === "uca_project_number" ? "desc" : "asc")
+    }
+  }
+
+  const renderSortIcon = (col: SortColumn) => {
+    if (sortBy !== col) return <ArrowUpDown className="h-3 w-3 opacity-40" />
+    return sortDir === "asc"
+      ? <ChevronUp className="h-3 w-3" />
+      : <ChevronDown className="h-3 w-3" />
+  }
 
   const fetchBaseList = async () => {
     setLoading(true)
@@ -90,22 +129,37 @@ export function ProjectsPage({
     return () => clearTimeout(handle)
   }, [searchTerm])
 
+  // Reflect the debounce-to-fetch gap with a spinner inside the search input.
+  useEffect(() => {
+    if (searchTerm.trim() && searchTerm !== debouncedTerm) {
+      setSearchLoading(true)
+    }
+  }, [searchTerm, debouncedTerm])
+
   // Run cross-entity search when the debounced term changes. Use a cancelled flag
   // so a stale response from an earlier query can't overwrite a newer one.
   useEffect(() => {
     const term = debouncedTerm.trim()
     if (!term) {
       setSearchResults(null)
+      setSearchLoading(false)
       return
     }
     let cancelled = false
+    setSearchLoading(true)
     api.projects
       .search(term)
       .then((data) => {
-        if (!cancelled) setSearchResults(data)
+        if (!cancelled) {
+          setSearchResults(data)
+          setSearchLoading(false)
+        }
       })
       .catch((err) => {
-        if (!cancelled) setError(err instanceof Error ? err.message : "Search failed")
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Search failed")
+          setSearchLoading(false)
+        }
       })
     return () => {
       cancelled = true
@@ -176,14 +230,27 @@ export function ProjectsPage({
         </div>
       )}
 
-      <div className="relative max-w-md">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-        <Input
-          placeholder="Search projects, POs, quotes, vendors..."
-          value={searchTerm}
-          onChange={(e) => onSearchTermChange(e.target.value)}
-          className="pl-9"
-        />
+      <div className="flex items-center gap-3 flex-wrap">
+        <div className="relative max-w-md flex-1 min-w-[260px]">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search projects, POs, quotes, vendors..."
+            value={searchTerm}
+            onChange={(e) => onSearchTermChange(e.target.value)}
+            className="pl-9 pr-9"
+          />
+          {searchLoading && (
+            <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground animate-spin" />
+          )}
+        </div>
+        <Button
+          variant={showArchived ? "secondary" : "outline"}
+          size="sm"
+          onClick={() => setShowArchived((v) => !v)}
+          className="gap-2"
+        >
+          {showArchived ? "Hide archived" : `Show archived (${archivedCount})`}
+        </Button>
       </div>
 
       <div className="bg-card rounded-lg border shadow-sm">
@@ -199,13 +266,41 @@ export function ProjectsPage({
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Project Name</TableHead>
-                <TableHead>Customer</TableHead>
-                <TableHead>UCA #</TableHead>
-                <TableHead>UCSH #</TableHead>
-                <TableHead>Project Lead</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Created On</TableHead>
+                <TableHead>
+                  <button type="button" onClick={() => toggleSort("name")} className="inline-flex items-center gap-1 hover:text-foreground">
+                    Project Name {renderSortIcon("name")}
+                  </button>
+                </TableHead>
+                <TableHead>
+                  <button type="button" onClick={() => toggleSort("customer_name")} className="inline-flex items-center gap-1 hover:text-foreground">
+                    Customer {renderSortIcon("customer_name")}
+                  </button>
+                </TableHead>
+                <TableHead>
+                  <button type="button" onClick={() => toggleSort("uca_project_number")} className="inline-flex items-center gap-1 hover:text-foreground">
+                    UCA # {renderSortIcon("uca_project_number")}
+                  </button>
+                </TableHead>
+                <TableHead>
+                  <button type="button" onClick={() => toggleSort("ucsh_project_number")} className="inline-flex items-center gap-1 hover:text-foreground">
+                    UCSH # {renderSortIcon("ucsh_project_number")}
+                  </button>
+                </TableHead>
+                <TableHead>
+                  <button type="button" onClick={() => toggleSort("project_lead")} className="inline-flex items-center gap-1 hover:text-foreground">
+                    Project Lead {renderSortIcon("project_lead")}
+                  </button>
+                </TableHead>
+                <TableHead>
+                  <button type="button" onClick={() => toggleSort("status")} className="inline-flex items-center gap-1 hover:text-foreground">
+                    Status {renderSortIcon("status")}
+                  </button>
+                </TableHead>
+                <TableHead>
+                  <button type="button" onClick={() => toggleSort("created_on")} className="inline-flex items-center gap-1 hover:text-foreground">
+                    Created On {renderSortIcon("created_on")}
+                  </button>
+                </TableHead>
                 <TableHead className="text-right">Actions</TableHead>
               </TableRow>
             </TableHeader>


### PR DESCRIPTION
## Summary

This PR ships the **filter/sort foundation** half of UX-4 (#96) and closes the two referenced filter issues. Table virtualization is deferred to a follow-up.

- **Archived hidden by default.** A \`Show archived (N)\` toolbar toggle reveals them, with the live archived count in the button label.
- **Default sort UCA # DESC.** Every column header on the Projects table is now a clickable sort toggle with an arrow indicator. Repeat-clicking flips direction.
- **Search loading spinner.** The global Projects search shows a small spinner inside the input while the 300ms debounce + fetch is in flight, so the UI doesn't feel frozen on the first keystroke.
- **@tanstack/react-virtual added as a dep** — staged for the follow-up that virtualizes Inventory / Profiles / Projects.

### Deferred

Virtualization of the Projects / Inventory / Profiles tables (the other half of #96) is **not** in this PR. The Inventory Parts tab is the biggest perf target (3,541 rows) and merits a dedicated follow-up because the existing HTML \`<table>\` markup needs a small structural shift to play nicely with a virtualizer.

Fixes #56
Fixes #77