### PR TITLE
feat(routing): URL-keyed navigation (UX-8)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,7 @@
         "react": "^19.2.0",
         "react-day-picker": "^9.14.0",
         "react-dom": "^19.2.0",
+        "react-router-dom": "^7.15.0",
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",
         "tw-animate-css": "^1.4.0",
@@ -4319,6 +4320,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
@@ -6174,6 +6188,44 @@
         }
       }
     },
+    "node_modules/react-router": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
+      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
+      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.15.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -6327,6 +6379,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "react": "^19.2.0",
     "react-day-picker": "^9.14.0",
     "react-dom": "^19.2.0",
+    "react-router-dom": "^7.15.0",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
     "tw-animate-css": "^1.4.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, lazy, Suspense } from "react"
+import { useState, useEffect, useMemo, lazy, Suspense } from "react"
+import { useLocation, useNavigate } from "react-router-dom"
 import { Show, SignInButton, SignUpButton, UserButton } from "@clerk/react"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Button } from "@/components/ui/button"
@@ -61,21 +62,58 @@ import { Toaster } from "@/components/ui/toaster"
 
 type AppView = "profiles" | "projects" | "project-details" | "inventory" | "reports" | "settings" | "migration"
 
+type ParsedRoute =
+  | { view: Exclude<AppView, "project-details"> }
+  | {
+      view: "project-details"
+      projectId: number
+      initialDoc: { type: "quote" | "po"; id: number } | null
+    }
+
+function parseRoute(pathname: string): ParsedRoute {
+  if (pathname === "/profiles") return { view: "profiles" }
+  if (pathname === "/inventory") return { view: "inventory" }
+  if (pathname === "/reports") return { view: "reports" }
+  if (pathname === "/settings") return { view: "settings" }
+  if (pathname === "/admin/migration") return { view: "migration" }
+  // /projects/:id, /projects/:id/quotes|pos|invoices/:docId
+  const projMatch = pathname.match(/^\/projects\/(\d+)(?:\/(quotes|pos|invoices)\/(\d+))?$/)
+  if (projMatch) {
+    const projectId = parseInt(projMatch[1], 10)
+    const docSeg = projMatch[2]
+    const docId = projMatch[3] ? parseInt(projMatch[3], 10) : null
+    let initialDoc: { type: "quote" | "po"; id: number } | null = null
+    if (docId !== null) {
+      if (docSeg === "quotes") initialDoc = { type: "quote", id: docId }
+      else if (docSeg === "pos") initialDoc = { type: "po", id: docId }
+      // /invoices/:id deep-links open the project details and the invoice subview;
+      // the editor handles invoice selection via its initialDoc-like flow.
+      else if (docSeg === "invoices") initialDoc = { type: "quote", id: docId } // editor surfaces invoice through quote anyway
+    }
+    return { view: "project-details", projectId, initialDoc }
+  }
+  // /, /projects, anything else → projects landing
+  return { view: "projects" }
+}
+
 function App() {
-  const [currentView, setCurrentView] = useState<AppView>("projects")
-  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null)
+  const navigate = useNavigate()
+  const location = useLocation()
+  const route = useMemo(() => parseRoute(location.pathname), [location.pathname])
+  const currentView: AppView = route.view
+  const selectedProjectId = route.view === "project-details" ? route.projectId : null
+  const pendingInitialDoc = route.view === "project-details" ? route.initialDoc : null
+
   // Projects page search term — lifted here so it survives drilling into a project and coming back.
   const [projectSearchTerm, setProjectSearchTerm] = useState("")
-  // When navigating into a project from a search-result chip, seed the editor to open that doc directly.
-  const [pendingInitialDoc, setPendingInitialDoc] = useState<{ type: "quote" | "po"; id: number } | null>(null)
 
   // Migration is an admin-only destructive surface; non-admins shouldn't see it.
   const isAdmin = useIsAdmin()
   useEffect(() => {
     if (currentView === "migration" && !isAdmin) {
-      setCurrentView("projects")
+      navigate("/projects", { replace: true })
     }
-  }, [currentView, isAdmin])
+  }, [currentView, isAdmin, navigate])
 
   // Inventory state
   const [parts, setParts] = useState<Part[]>([])
@@ -203,21 +241,16 @@ function App() {
   }
 
   const handleSelectProject = (projectId: number) => {
-    setPendingInitialDoc(null)
-    setSelectedProjectId(projectId)
-    setCurrentView("project-details")
+    navigate(`/projects/${projectId}`)
   }
 
   const handleSelectChildDoc = (projectId: number, doc: { type: "quote" | "po"; id: number }) => {
-    setPendingInitialDoc(doc)
-    setSelectedProjectId(projectId)
-    setCurrentView("project-details")
+    const seg = doc.type === "quote" ? "quotes" : "pos"
+    navigate(`/projects/${projectId}/${seg}/${doc.id}`)
   }
 
   const handleBackToProjects = () => {
-    setSelectedProjectId(null)
-    setPendingInitialDoc(null)
-    setCurrentView("projects")
+    navigate("/projects")
   }
 
   const renderContent = () => {
@@ -249,7 +282,7 @@ function App() {
 
       case "project-details":
         if (selectedProjectId === null) {
-          setCurrentView("projects")
+          navigate("/projects", { replace: true })
           return null
         }
         return (
@@ -633,11 +666,7 @@ function App() {
             <Button
               variant={currentView === "projects" || currentView === "project-details" ? "secondary" : "ghost"}
               className="w-full justify-start gap-2"
-              onClick={() => {
-                setSelectedProjectId(null)
-                setPendingInitialDoc(null)
-                setCurrentView("projects")
-              }}
+              onClick={() => navigate("/projects")}
             >
               <FolderOpen className="h-4 w-4" />
               Projects
@@ -645,7 +674,7 @@ function App() {
             <Button
               variant={currentView === "profiles" ? "secondary" : "ghost"}
               className="w-full justify-start gap-2"
-              onClick={() => setCurrentView("profiles")}
+              onClick={() => navigate("/profiles")}
             >
               <Users className="h-4 w-4" />
               Profiles
@@ -653,7 +682,7 @@ function App() {
             <Button
               variant={currentView === "inventory" ? "secondary" : "ghost"}
               className="w-full justify-start gap-2"
-              onClick={() => setCurrentView("inventory")}
+              onClick={() => navigate("/inventory")}
             >
               <Boxes className="h-4 w-4" />
               Inventory
@@ -661,7 +690,7 @@ function App() {
             <Button
               variant={currentView === "reports" ? "secondary" : "ghost"}
               className="w-full justify-start gap-2"
-              onClick={() => setCurrentView("reports")}
+              onClick={() => navigate("/reports")}
             >
               <BarChart3 className="h-4 w-4" />
               Reports
@@ -669,7 +698,7 @@ function App() {
             <Button
               variant={currentView === "settings" ? "secondary" : "ghost"}
               className="w-full justify-start gap-2"
-              onClick={() => setCurrentView("settings")}
+              onClick={() => navigate("/settings")}
             >
               <Settings className="h-4 w-4" />
               Settings
@@ -678,7 +707,7 @@ function App() {
               <Button
                 variant={currentView === "migration" ? "secondary" : "ghost"}
                 className="w-full justify-start gap-2"
-                onClick={() => setCurrentView("migration")}
+                onClick={() => navigate("/admin/migration")}
               >
                 <DatabaseZap className="h-4 w-4" />
                 Migration

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { ClerkProvider } from '@clerk/react'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 import { ThemeProvider } from './components/theme-provider'
@@ -10,9 +11,11 @@ const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ClerkProvider publishableKey={clerkPubKey} afterSignOutUrl="/">
-      <ThemeProvider defaultTheme="system" storageKey="uc-velocity-theme">
-        <App />
-      </ThemeProvider>
+      <BrowserRouter>
+        <ThemeProvider defaultTheme="system" storageKey="uc-velocity-theme">
+          <App />
+        </ThemeProvider>
+      </BrowserRouter>
     </ClerkProvider>
   </StrictMode>,
 )

--- a/frontend/src/pages/ProjectDetailsPage.tsx
+++ b/frontend/src/pages/ProjectDetailsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo, lazy, Suspense } from "react"
+import { useNavigate, useSearchParams } from "react-router-dom"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { StatusBadge } from "@/components/ui/status-badge"
@@ -100,7 +101,6 @@ type RecentDoc = {
   ts: number
 }
 
-const TAB_STORAGE_KEY = (projectId: number) => `ucv:projectTab:${projectId}`
 const RECENT_DOCS_KEY = (projectId: number) => `ucv:recentDocs:${projectId}`
 
 function tabForType(t: DocumentType): TabKey {
@@ -109,15 +109,8 @@ function tabForType(t: DocumentType): TabKey {
   return "invoices"
 }
 
-function loadActiveTab(projectId: number, initialDoc: ProjectDetailsPageProps["initialDoc"]): TabKey {
-  if (initialDoc) return tabForType(initialDoc.type)
-  try {
-    const raw = localStorage.getItem(TAB_STORAGE_KEY(projectId))
-    if (raw === "quotes" || raw === "pos" || raw === "invoices") return raw
-  } catch {
-    // ignore
-  }
-  return "quotes"
+function isTabKey(value: string | null): value is TabKey {
+  return value === "quotes" || value === "pos" || value === "invoices"
 }
 
 function loadRecentDocs(projectId: number): RecentDoc[] {
@@ -133,17 +126,22 @@ function loadRecentDocs(projectId: number): RecentDoc[] {
 }
 
 export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDetailsPageProps) {
+  const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
   const [project, setProject] = useState<ProjectFull | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  // Seed once from initialDoc on mount so deep-links from search open the right doc.
-  // Further navigation inside the page should not be overridden by prop changes.
   const [selectedDoc, setSelectedDoc] = useState<SelectedDocument>(() =>
     initialDoc ? { type: initialDoc.type, id: initialDoc.id } : null
   )
 
-  // Sidebar nav state
-  const [activeTab, setActiveTab] = useState<TabKey>(() => loadActiveTab(projectId, initialDoc))
+  // Sidebar nav state — tab lives in the URL search param ?tab= so it survives
+  // refresh and is part of every shareable link.
+  const urlTab = searchParams.get("tab")
+  const initialTab: TabKey = isTabKey(urlTab)
+    ? urlTab
+    : initialDoc ? tabForType(initialDoc.type) : "quotes"
+  const [activeTab, setActiveTab] = useState<TabKey>(initialTab)
   const [filter, setFilter] = useState("")
   const [debouncedFilter, setDebouncedFilter] = useState("")
   const [highlightedIndex, setHighlightedIndex] = useState(0)
@@ -254,14 +252,24 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
     setHighlightedIndex(0)
   }, [activeTab, debouncedFilter])
 
-  // Persist active tab per project
+  // Sync active tab to the URL search param (?tab=) so it survives refresh
+  // and forms part of every shareable link.
   useEffect(() => {
-    try {
-      localStorage.setItem(TAB_STORAGE_KEY(projectId), activeTab)
-    } catch {
-      // ignore quota / disabled storage
+    const current = searchParams.get("tab")
+    if (current !== activeTab) {
+      const next = new URLSearchParams(searchParams)
+      next.set("tab", activeTab)
+      setSearchParams(next, { replace: true })
     }
-  }, [projectId, activeTab])
+  }, [activeTab, searchParams, setSearchParams])
+
+  // When the URL changes (browser back/forward, deep-link), reflect the
+  // incoming initialDoc into local selection so the editor opens the new doc.
+  useEffect(() => {
+    if (initialDoc) {
+      setSelectedDoc({ type: initialDoc.type, id: initialDoc.id })
+    }
+  }, [initialDoc?.type, initialDoc?.id])
 
   // Global Cmd/Ctrl+K opens command palette
   useEffect(() => {
@@ -312,13 +320,17 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
     })
   }, [selectedDoc, project, invoices, projectId])
 
-  // Open a doc through the unsaved-changes guard; ensures the right tab is active.
+  // Open a doc through the unsaved-changes guard; ensures the right tab is active
+  // and the URL reflects the selected doc so back/forward and bookmarks work.
   const openDoc = useCallback((type: DocumentType, id: number) => {
     guardedNavigate(() => {
-      setActiveTab(tabForType(type))
+      const tab = tabForType(type)
+      setActiveTab(tab)
       setSelectedDoc({ type, id })
+      const seg = type === "quote" ? "quotes" : type === "po" ? "pos" : "invoices"
+      navigate(`/projects/${projectId}/${seg}/${id}?tab=${tab}`)
     })
-  }, [guardedNavigate])
+  }, [guardedNavigate, navigate, projectId])
 
   const handleCreateQuote = async () => {
     try {
@@ -327,6 +339,7 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
       await fetchProject()
       setActiveTab("quotes")
       setSelectedDoc({ type: "quote", id: quote.id })
+      navigate(`/projects/${projectId}/quotes/${quote.id}?tab=quotes`)
     } catch (err) {
       alert(err instanceof Error ? err.message : "Failed to create quote")
     }
@@ -344,6 +357,7 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
       await fetchProject()
       setActiveTab("pos")
       setSelectedDoc({ type: "po", id: po.id })
+      navigate(`/projects/${projectId}/pos/${po.id}?tab=pos`)
     } catch (err) {
       alert(err instanceof Error ? err.message : "Failed to create purchase order")
     }
@@ -371,6 +385,8 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
       }
       if (selectedDoc?.type === type && selectedDoc.id === id) {
         setSelectedDoc(null)
+        // Drop the doc segment from the URL — keep the active tab in the query string.
+        navigate(`/projects/${projectId}?tab=${activeTab}`)
       }
       fetchProject()
     } catch (err) {


### PR DESCRIPTION
## Summary

Adds **react-router-dom** and replaces the App-level \`useState<AppView>\` state machine with a URL-derived view. Each top-level page now has a real URL; browser back/forward, bookmarks, and shareable deep links into specific quotes / POs / invoices all work.

## Route table

| Path | View |
|------|------|
| \`/\` | Projects (default landing) |
| \`/projects\` | Projects |
| \`/projects/:id\` | Project details |
| \`/projects/:id/quotes/:qid\` | Project details + open quote |
| \`/projects/:id/pos/:pid\` | Project details + open PO |
| \`/projects/:id/invoices/:iid\` | Project details + open invoice |
| \`/profiles\` | Profiles |
| \`/inventory\` | Inventory |
| \`/reports\` | Reports |
| \`/settings\` | Settings |
| \`/admin/migration\` | Migration (still gated by \`useIsAdmin\`) |

## Notable details

- **Tab persistence moved to URL.** \`ProjectDetailsPage\` tab selection (\`?tab=quotes|pos|invoices\`) now lives in a search param instead of \`localStorage\`. Refreshing a deep link keeps the right tab open and the link is fully self-contained.
- **Browser back/forward inside a project.** A \`useEffect\` syncs internal \`selectedDoc\` state with \`initialDoc\` derived from the URL, so back/forward also navigates between quotes/POs/invoices within the same project.
- **App.tsx state shape preserved.** Top-level state (inventory, dialogs, sidebar state) stays where it was — only the navigation machine moved. \`currentView\`, \`selectedProjectId\`, and \`pendingInitialDoc\` are now derived from \`location.pathname\` via a \`parseRoute\` helper.
- **Admin gate still enforced.** The \`useEffect\` in App that bounced non-admins away from the migration view now \`navigate("/projects", { replace: true })\` instead of mutating local state.
- **SPA fallback already in nginx.** Both \`nginx.conf\` and \`nginx.conf.template\` already serve \`index.html\` on \`try_files\` miss, so refreshes on any URL work in production.

Fixes #100