### PR TITLE
perf(ui): virtualize Inventory + Profiles tables (UX-4 follow-up)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import { ThemeToggle } from "@/components/theme-toggle"
 import { ProjectsPage } from "@/pages/ProjectsPage"
 import { api } from "@/api/client"
 import { useIsAdmin } from "@/hooks/use-is-admin"
+import { VirtualizedTable, headerCellClass, cellClass } from "@/components/ui/virtualized-table"
 
 // Lazy-loaded pages: keep ProjectsPage eager (default landing), defer the rest.
 const ProfilesPage = lazy(() =>
@@ -363,9 +364,9 @@ function App() {
 
               {/* Parts Tab */}
               <TabsContent value="parts">
-                <div className="bg-card rounded-lg border shadow-sm">
+                <div className="bg-card rounded-lg border shadow-sm overflow-hidden">
                   <div className="p-4 border-b flex justify-between items-center">
-                    <h2 className="text-lg font-semibold">Parts Inventory</h2>
+                    <h2 className="text-lg font-semibold">Parts Inventory ({filteredParts.length.toLocaleString()})</h2>
                     <Button onClick={handleAddPart} className="gap-2">
                       <Plus className="h-4 w-4" />
                       Add Part
@@ -374,84 +375,58 @@ function App() {
 
                   {loading ? (
                     <div className="p-8 text-center text-muted-foreground">Loading...</div>
-                  ) : filteredParts.length === 0 ? (
-                    <div className="p-8 text-center text-muted-foreground">
-                      {inventorySearchTerm
+                  ) : (
+                    <VirtualizedTable
+                      items={filteredParts}
+                      rowHeight={52}
+                      height="calc(100vh - 360px)"
+                      gridCols="grid-cols-[1.4fr_3fr_1fr_1fr_1fr_minmax(110px,auto)]"
+                      header={
+                        <>
+                          <div className={headerCellClass}>Part Number</div>
+                          <div className={headerCellClass}>Description</div>
+                          <div className={`${headerCellClass} text-right`}>Cost</div>
+                          <div className={`${headerCellClass} text-right`}>Markup</div>
+                          <div className={`${headerCellClass} text-right`}>Price</div>
+                          <div className={`${headerCellClass} text-right`}>Actions</div>
+                        </>
+                      }
+                      getKey={(p) => p.id}
+                      emptyMessage={inventorySearchTerm
                         ? "No parts matching your search."
                         : "No parts found. Add your first part to get started."}
-                    </div>
-                  ) : (
-                    <table className="w-full">
-                      <thead className="bg-muted/50">
-                        <tr>
-                          <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">
-                            Part Number
-                          </th>
-                          <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">
-                            Description
-                          </th>
-                          <th className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">
-                            Cost
-                          </th>
-                          <th className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">
-                            Markup
-                          </th>
-                          <th className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">
-                            Price
-                          </th>
-                          <th className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">
-                            Actions
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody className="divide-y">
-                        {filteredParts.map((part) => (
-                          <tr key={part.id} className="hover:bg-muted/50">
-                            <td className="px-4 py-3 text-sm font-medium">
-                              {part.part_number}
-                            </td>
-                            <td className="px-4 py-3 text-sm text-muted-foreground">
-                              {part.description}
-                            </td>
-                            <td className="px-4 py-3 text-sm text-muted-foreground text-right">
-                              ${part.cost.toFixed(2)}
-                            </td>
-                            <td className="px-4 py-3 text-sm text-muted-foreground text-right">
-                              {part.markup_percent ?? 0}%
-                            </td>
-                            <td className="px-4 py-3 text-sm font-medium text-right">
-                              ${(part.cost * (1 + (part.markup_percent ?? 0) / 100)).toFixed(2)}
-                            </td>
-                            <td className="px-4 py-3 text-right space-x-1">
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => handleEditPart(part)}
-                              >
-                                <Pencil className="h-4 w-4" />
-                              </Button>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => handleDeletePart(part.id)}
-                                className="text-destructive hover:text-destructive hover:bg-destructive/10"
-                              >
-                                <Trash2 className="h-4 w-4" />
-                              </Button>
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
+                      renderRow={(part) => (
+                        <>
+                          <div className={`${cellClass} font-medium`}>{part.part_number}</div>
+                          <div className={`${cellClass} text-muted-foreground truncate`}>{part.description}</div>
+                          <div className={`${cellClass} text-muted-foreground justify-end`}>${part.cost.toFixed(2)}</div>
+                          <div className={`${cellClass} text-muted-foreground justify-end`}>{part.markup_percent ?? 0}%</div>
+                          <div className={`${cellClass} font-medium justify-end`}>${(part.cost * (1 + (part.markup_percent ?? 0) / 100)).toFixed(2)}</div>
+                          <div className={`${cellClass} justify-end gap-1`}>
+                            <Button variant="ghost" size="sm" onClick={() => handleEditPart(part)}>
+                              <Pencil className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleDeletePart(part.id)}
+                              className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        </>
+                      )}
+                    />
                   )}
                 </div>
               </TabsContent>
 
               {/* Labor Tab */}
               <TabsContent value="labor">
-                <div className="bg-card rounded-lg border shadow-sm">
+                <div className="bg-card rounded-lg border shadow-sm overflow-hidden">
                   <div className="p-4 border-b flex justify-between items-center">
-                    <h2 className="text-lg font-semibold">Labour Items</h2>
+                    <h2 className="text-lg font-semibold">Labour Items ({filteredLaborItems.length.toLocaleString()})</h2>
                     <Button onClick={handleAddLabor} className="gap-2">
                       <Plus className="h-4 w-4" />
                       Add Labour
@@ -460,84 +435,58 @@ function App() {
 
                   {loading ? (
                     <div className="p-8 text-center text-muted-foreground">Loading...</div>
-                  ) : filteredLaborItems.length === 0 ? (
-                    <div className="p-8 text-center text-muted-foreground">
-                      {inventorySearchTerm
+                  ) : (
+                    <VirtualizedTable
+                      items={filteredLaborItems}
+                      rowHeight={52}
+                      height="calc(100vh - 360px)"
+                      gridCols="grid-cols-[3fr_1fr_1fr_1fr_1fr_minmax(110px,auto)]"
+                      header={
+                        <>
+                          <div className={headerCellClass}>Labour Description</div>
+                          <div className={`${headerCellClass} text-right`}>Hours</div>
+                          <div className={`${headerCellClass} text-right`}>Rate</div>
+                          <div className={`${headerCellClass} text-right`}>Markup</div>
+                          <div className={`${headerCellClass} text-right`}>Total Cost</div>
+                          <div className={`${headerCellClass} text-right`}>Actions</div>
+                        </>
+                      }
+                      getKey={(l) => l.id}
+                      emptyMessage={inventorySearchTerm
                         ? "No labour items matching your search."
                         : "No labour items found. Add your first labour item to get started."}
-                    </div>
-                  ) : (
-                    <table className="w-full">
-                      <thead className="bg-muted/50">
-                        <tr>
-                          <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">
-                            Labour Description
-                          </th>
-                          <th className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">
-                            Hours
-                          </th>
-                          <th className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">
-                            Rate
-                          </th>
-                          <th className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">
-                            Markup
-                          </th>
-                          <th className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">
-                            Total Cost
-                          </th>
-                          <th className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">
-                            Actions
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody className="divide-y">
-                        {filteredLaborItems.map((labor) => (
-                          <tr key={labor.id} className="hover:bg-muted/50">
-                            <td className="px-4 py-3 text-sm font-medium">
-                              {labor.description}
-                            </td>
-                            <td className="px-4 py-3 text-sm text-muted-foreground text-right">
-                              {labor.hours}
-                            </td>
-                            <td className="px-4 py-3 text-sm text-muted-foreground text-right">
-                              ${labor.rate.toFixed(2)}/hr
-                            </td>
-                            <td className="px-4 py-3 text-sm text-muted-foreground text-right">
-                              {labor.markup_percent}%
-                            </td>
-                            <td className="px-4 py-3 text-sm font-medium text-right">
-                              ${(labor.hours * labor.rate * (1 + labor.markup_percent / 100)).toFixed(2)}
-                            </td>
-                            <td className="px-4 py-3 text-right space-x-1">
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => handleEditLabor(labor)}
-                              >
-                                <Pencil className="h-4 w-4" />
-                              </Button>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => handleDeleteLabor(labor.id)}
-                                className="text-destructive hover:text-destructive hover:bg-destructive/10"
-                              >
-                                <Trash2 className="h-4 w-4" />
-                              </Button>
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
+                      renderRow={(labor) => (
+                        <>
+                          <div className={`${cellClass} font-medium truncate`}>{labor.description}</div>
+                          <div className={`${cellClass} text-muted-foreground justify-end`}>{labor.hours}</div>
+                          <div className={`${cellClass} text-muted-foreground justify-end`}>${labor.rate.toFixed(2)}/hr</div>
+                          <div className={`${cellClass} text-muted-foreground justify-end`}>{labor.markup_percent}%</div>
+                          <div className={`${cellClass} font-medium justify-end`}>${(labor.hours * labor.rate * (1 + labor.markup_percent / 100)).toFixed(2)}</div>
+                          <div className={`${cellClass} justify-end gap-1`}>
+                            <Button variant="ghost" size="sm" onClick={() => handleEditLabor(labor)}>
+                              <Pencil className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleDeleteLabor(labor.id)}
+                              className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        </>
+                      )}
+                    />
                   )}
                 </div>
               </TabsContent>
 
               {/* Miscellaneous Tab */}
               <TabsContent value="misc">
-                <div className="bg-card rounded-lg border shadow-sm">
+                <div className="bg-card rounded-lg border shadow-sm overflow-hidden">
                   <div className="p-4 border-b flex justify-between items-center">
-                    <h2 className="text-lg font-semibold">Miscellaneous Items</h2>
+                    <h2 className="text-lg font-semibold">Miscellaneous Items ({filteredMiscItems.length.toLocaleString()})</h2>
                     <Button onClick={handleAddMisc} className="gap-2">
                       <Plus className="h-4 w-4" />
                       Add Misc
@@ -546,70 +495,48 @@ function App() {
 
                   {loading ? (
                     <div className="p-8 text-center text-muted-foreground">Loading...</div>
-                  ) : filteredMiscItems.length === 0 ? (
-                    <div className="p-8 text-center text-muted-foreground">
-                      {inventorySearchTerm
+                  ) : (
+                    <VirtualizedTable
+                      items={filteredMiscItems}
+                      rowHeight={52}
+                      height="calc(100vh - 360px)"
+                      gridCols="grid-cols-[3fr_1fr_1fr_1fr_minmax(110px,auto)]"
+                      header={
+                        <>
+                          <div className={headerCellClass}>Misc Description</div>
+                          <div className={`${headerCellClass} text-right`}>Unit Price</div>
+                          <div className={`${headerCellClass} text-right`}>Markup</div>
+                          <div className={`${headerCellClass} text-right`}>Total Cost</div>
+                          <div className={`${headerCellClass} text-right`}>Actions</div>
+                        </>
+                      }
+                      getKey={(m) => m.id}
+                      emptyMessage={inventorySearchTerm
                         ? "No miscellaneous items matching your search."
                         : "No miscellaneous items found. Add your first miscellaneous item to get started."}
-                    </div>
-                  ) : (
-                    <table className="w-full">
-                      <thead className="bg-muted/50">
-                        <tr>
-                          <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">
-                            Misc Description
-                          </th>
-                          <th className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">
-                            Unit Price
-                          </th>
-                          <th className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">
-                            Markup
-                          </th>
-                          <th className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">
-                            Total Cost
-                          </th>
-                          <th className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">
-                            Actions
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody className="divide-y">
-                        {filteredMiscItems.map((misc) => (
-                          <tr key={misc.id} className="hover:bg-muted/50">
-                            <td className="px-4 py-3 text-sm font-medium">
-                              {misc.description}
-                            </td>
-                            <td className="px-4 py-3 text-sm text-muted-foreground text-right">
-                              ${misc.unit_price.toFixed(2)}
-                            </td>
-                            <td className="px-4 py-3 text-sm text-muted-foreground text-right">
-                              {misc.markup_percent}%
-                            </td>
-                            <td className="px-4 py-3 text-sm font-medium text-right">
-                              ${(misc.unit_price * (1 + misc.markup_percent / 100)).toFixed(2)}
-                            </td>
-                            <td className="px-4 py-3 text-right space-x-1">
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => handleEditMisc(misc)}
-                              >
-                                <Pencil className="h-4 w-4" />
-                              </Button>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => handleDeleteMisc(misc.id)}
-                                className="text-destructive hover:text-destructive hover:bg-destructive/10"
-                                title="Delete"
-                              >
-                                <Trash2 className="h-4 w-4" />
-                              </Button>
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
+                      renderRow={(misc) => (
+                        <>
+                          <div className={`${cellClass} font-medium truncate`}>{misc.description}</div>
+                          <div className={`${cellClass} text-muted-foreground justify-end`}>${misc.unit_price.toFixed(2)}</div>
+                          <div className={`${cellClass} text-muted-foreground justify-end`}>{misc.markup_percent}%</div>
+                          <div className={`${cellClass} font-medium justify-end`}>${(misc.unit_price * (1 + misc.markup_percent / 100)).toFixed(2)}</div>
+                          <div className={`${cellClass} justify-end gap-1`}>
+                            <Button variant="ghost" size="sm" onClick={() => handleEditMisc(misc)}>
+                              <Pencil className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleDeleteMisc(misc.id)}
+                              className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                              title="Delete"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        </>
+                      )}
+                    />
                   )}
                 </div>
               </TabsContent>

--- a/frontend/src/components/ui/virtualized-table.tsx
+++ b/frontend/src/components/ui/virtualized-table.tsx
@@ -1,0 +1,106 @@
+import { useRef, type ReactNode } from "react"
+import { useVirtualizer } from "@tanstack/react-virtual"
+import { cn } from "@/lib/utils"
+
+interface VirtualizedTableProps<T> {
+  items: T[]
+  /** Estimated row height in pixels; rows can still measure their own height via `measureElement` if needed. */
+  rowHeight?: number
+  /** Scroll container height. Pass a number for px, or a string for CSS values like "70vh". */
+  height?: number | string
+  /** Tailwind grid columns class applied to both the header and each row (e.g. `grid-cols-[2fr_3fr_1fr]`). */
+  gridCols: string
+  /** Header cells, expected as direct children of the grid (each child is one cell). */
+  header: ReactNode
+  /** Row cell renderer — return cells as direct children of the grid. */
+  renderRow: (item: T, index: number) => ReactNode
+  /** Stable React key extractor. */
+  getKey: (item: T, index: number) => string | number
+  /** Shown when `items` is empty. */
+  emptyMessage?: ReactNode
+  /** Number of rows to render outside the visible window. */
+  overscan?: number
+  /** Optional className on the outer wrapper. */
+  className?: string
+  /** Optional className on the per-row grid container — useful for accent borders, hover styles, etc. */
+  rowClassName?: string | ((item: T, index: number) => string)
+}
+
+const HEADER_CLASS = "px-4 py-3 text-left text-sm font-medium text-muted-foreground"
+
+/**
+ * Lightweight wrapper around `@tanstack/react-virtual` so we can drop a
+ * windowed table into any page without bespoke virtualization plumbing.
+ *
+ * The header and row containers share `gridCols` to keep columns aligned.
+ * The scroll viewport has a fixed height so the page itself doesn't grow to
+ * fit thousands of rows.
+ */
+export function VirtualizedTable<T>({
+  items,
+  rowHeight = 48,
+  height = 560,
+  gridCols,
+  header,
+  renderRow,
+  getKey,
+  emptyMessage,
+  overscan = 10,
+  className,
+  rowClassName,
+}: VirtualizedTableProps<T>) {
+  const parentRef = useRef<HTMLDivElement>(null)
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => rowHeight,
+    overscan,
+  })
+
+  return (
+    <div className={cn("bg-card rounded-lg border shadow-sm overflow-hidden", className)}>
+      <div className={cn("grid bg-muted/50 border-b", gridCols)}>{header}</div>
+      {items.length === 0 ? (
+        <div className="p-8 text-center text-muted-foreground text-sm">{emptyMessage}</div>
+      ) : (
+        <div
+          ref={parentRef}
+          style={{ height, overflow: "auto" }}
+        >
+          <div style={{ height: virtualizer.getTotalSize(), position: "relative", width: "100%" }}>
+            {virtualizer.getVirtualItems().map((vi) => {
+              const item = items[vi.index]
+              const baseRowClass = "grid border-b hover:bg-muted/50 transition-colors"
+              const customRowClass = typeof rowClassName === "function"
+                ? rowClassName(item, vi.index)
+                : rowClassName
+              return (
+                <div
+                  key={getKey(item, vi.index)}
+                  data-index={vi.index}
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    transform: `translateY(${vi.start}px)`,
+                    height: vi.size,
+                  }}
+                  className={cn(baseRowClass, gridCols, customRowClass)}
+                >
+                  {renderRow(item, vi.index)}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** Default cell class for header cells inside a `<VirtualizedTable>` header. */
+export const headerCellClass = HEADER_CLASS
+
+/** Default cell class for body cells inside a `<VirtualizedTable>` row. */
+export const cellClass = "px-4 py-3 text-sm flex items-center"

--- a/frontend/src/pages/ProfilesPage.tsx
+++ b/frontend/src/pages/ProfilesPage.tsx
@@ -27,6 +27,7 @@ import {
   Plus, Trash2, Pencil, Users, Building, ExternalLink, Phone, Mail, MapPin, Upload, Search,
 } from "lucide-react"
 import { EMPTY_VALUE } from "@/lib/format"
+import { VirtualizedTable, headerCellClass, cellClass } from "@/components/ui/virtualized-table"
 
 type ProfileTab = "customers" | "vendors"
 
@@ -480,84 +481,90 @@ interface ProfileTableProps {
 
 function ProfileTable({ profiles, emptyMessage, onRowClick, onEdit, onDelete }: ProfileTableProps) {
   return (
-    <div className="bg-card rounded-lg border shadow-sm">
-      {profiles.length === 0 ? (
-        <div className="p-6 text-center text-muted-foreground text-sm">{emptyMessage}</div>
-      ) : (
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Name</TableHead>
-              <TableHead>Address</TableHead>
-              <TableHead>Contacts</TableHead>
-              <TableHead>Phone</TableHead>
-              <TableHead className="text-right">Actions</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {profiles.map((profile) => {
-              const phone = getPrimaryPhone(profile)
-              return (
-                <TableRow
-                  key={profile.id}
-                  className="cursor-pointer hover:bg-muted/50"
-                  onClick={() => onRowClick(profile)}
+    <VirtualizedTable
+      items={profiles}
+      rowHeight={68}
+      height="calc(100vh - 320px)"
+      gridCols="grid-cols-[2fr_2.5fr_1.5fr_1.5fr_minmax(110px,auto)]"
+      header={
+        <>
+          <div className={headerCellClass}>Name</div>
+          <div className={headerCellClass}>Address</div>
+          <div className={headerCellClass}>Contacts</div>
+          <div className={headerCellClass}>Phone</div>
+          <div className={`${headerCellClass} text-right`}>Actions</div>
+        </>
+      }
+      getKey={(p) => p.id}
+      emptyMessage={emptyMessage}
+      rowClassName="cursor-pointer"
+      renderRow={(profile) => {
+        const phone = getPrimaryPhone(profile)
+        return (
+          <>
+            <div
+              className={`${cellClass} font-medium`}
+              onClick={() => onRowClick(profile)}
+            >
+              {profile.name}
+            </div>
+            <div
+              className={`${cellClass} text-muted-foreground flex-col items-start justify-center`}
+              onClick={() => onRowClick(profile)}
+            >
+              <div className="text-sm truncate w-full">{profile.address || EMPTY_VALUE}</div>
+              {profile.postal_code && (
+                <div className="text-xs">{profile.postal_code}</div>
+              )}
+            </div>
+            <div
+              className={`${cellClass} flex-col items-start justify-center`}
+              onClick={() => onRowClick(profile)}
+            >
+              <div className="text-sm">
+                {profile.contacts.length} contact{profile.contacts.length !== 1 ? 's' : ''}
+              </div>
+              {profile.contacts.length > 0 && (
+                <div className="text-xs text-muted-foreground truncate w-full">
+                  {profile.contacts[0].name}
+                  {profile.contacts.length > 1 && ` +${profile.contacts.length - 1} more`}
+                </div>
+              )}
+            </div>
+            <div className={cellClass}>
+              {phone ? (
+                <a
+                  href={`tel:${phone}`}
+                  className="text-blue-600 hover:underline flex items-center gap-1 text-sm"
+                  onClick={(e) => e.stopPropagation()}
                 >
-                  <TableCell className="font-medium">{profile.name}</TableCell>
-                  <TableCell className="text-muted-foreground">
-                    <div className="text-sm">{profile.address || EMPTY_VALUE}</div>
-                    {profile.postal_code && (
-                      <div className="text-xs">{profile.postal_code}</div>
-                    )}
-                  </TableCell>
-                  <TableCell>
-                    <div className="text-sm">
-                      {profile.contacts.length} contact{profile.contacts.length !== 1 ? 's' : ''}
-                    </div>
-                    {profile.contacts.length > 0 && (
-                      <div className="text-xs text-muted-foreground">
-                        {profile.contacts[0].name}
-                        {profile.contacts.length > 1 && ` +${profile.contacts.length - 1} more`}
-                      </div>
-                    )}
-                  </TableCell>
-                  <TableCell>
-                    {phone ? (
-                      <a
-                        href={`tel:${phone}`}
-                        className="text-blue-600 hover:underline flex items-center gap-1 text-sm"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <Phone className="h-3 w-3" />
-                        {phone}
-                      </a>
-                    ) : (
-                      <span className="text-muted-foreground">{EMPTY_VALUE}</span>
-                    )}
-                  </TableCell>
-                  <TableCell className="text-right space-x-1">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={(e) => onEdit(e, profile)}
-                    >
-                      <Pencil className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={(e) => onDelete(e, profile.id)}
-                      className="text-destructive hover:text-destructive hover:bg-destructive/10"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              )
-            })}
-          </TableBody>
-        </Table>
-      )}
-    </div>
+                  <Phone className="h-3 w-3 flex-shrink-0" />
+                  <span className="truncate">{phone}</span>
+                </a>
+              ) : (
+                <span className="text-muted-foreground" onClick={() => onRowClick(profile)}>{EMPTY_VALUE}</span>
+              )}
+            </div>
+            <div className={`${cellClass} justify-end gap-1`}>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={(e) => onEdit(e, profile)}
+              >
+                <Pencil className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={(e) => onDelete(e, profile.id)}
+                className="text-destructive hover:text-destructive hover:bg-destructive/10"
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          </>
+        )
+      }}
+    />
   )
 }


### PR DESCRIPTION
## Summary

Closes the **virtualization half of UX-4** (#96). The earlier UX-4 PR shipped archived/sort/spinner filter foundations; this one finishes the issue by windowing the heaviest tables.

- **Inventory Parts / Labour / Misc** all render through a windowed div-grid. The Parts tab with 3,541 rows now mounts roughly the visible window (about 50 nodes) instead of the full 21,000 cells.
- **Profiles Customers / Vendors** virtualized too — at 538 + 141 rows it's not as dramatic a win, but it gets the page on the same primitive so adding columns or rows later doesn't reintroduce the perf cliff.
- New \`frontend/src/components/ui/virtualized-table.tsx\` wraps \`useVirtualizer\` with a tiny API: a Tailwind \`grid-cols-...\` class, a header, a row renderer, and a key extractor. Reused five times in this PR.
- Each table's section heading now shows the filtered row count.

## Deliberately deferred

The Projects table is **not** virtualized in this PR. Its federated-search rows produce sub-rows below each matching project, giving variable row heights that would need \`measureElement\` plumbing. It's tractable but worth its own PR rather than rushing it into this one. Base-list virtualization (the un-searched 3,461-row case) can be staged behind a "no active search" branch later.

Fixes #96