### PR TITLE
feat(data-hygiene): legacy_imported flag + Inventory Health report (UX-7 additive parts)

### DIFF
--- a/backend/alembic/versions/20260512_018_add_legacy_imported_flag.py
+++ b/backend/alembic/versions/20260512_018_add_legacy_imported_flag.py
@@ -1,0 +1,56 @@
+"""Add legacy_imported flag to quotes and purchase_orders.
+
+UX-7 asks for a way to distinguish records that came in from the original
+UC Vision CSV migration from records that are real, fulfilled work. The flag
+is purely additive — defaults to FALSE for everything — so existing data is
+untouched. A separate, explicit backfill (or a manual update) can mark
+pre-migration rows later if desired; this migration deliberately does not
+attempt that classification itself.
+
+Revision ID: 018_legacy_imported_flag
+Revises: 017_add_fk_indexes
+Create Date: 2026-05-12
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '018_legacy_imported_flag'
+down_revision = '017_add_fk_indexes'
+branch_labels = None
+depends_on = None
+
+
+# (table, column) pairs — kept as a tuple so upgrade/downgrade stay symmetric.
+_COLUMNS = [
+    ('quotes', 'legacy_imported'),
+    ('purchase_orders', 'legacy_imported'),
+]
+
+
+def _column_exists(table: str, column: str) -> bool:
+    """Idempotent guard matching the rest of the migration chain."""
+    conn = op.get_bind()
+    result = conn.execute(sa.text(
+        """
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = :t AND column_name = :c
+        LIMIT 1
+        """
+    ), {"t": table, "c": column}).scalar()
+    return bool(result)
+
+
+def upgrade() -> None:
+    for table, column in _COLUMNS:
+        if not _column_exists(table, column):
+            op.add_column(
+                table,
+                sa.Column(column, sa.Boolean(), nullable=False, server_default=sa.text('FALSE')),
+            )
+
+
+def downgrade() -> None:
+    for table, column in _COLUMNS:
+        if _column_exists(table, column):
+            op.drop_column(table, column)

--- a/backend/models.py
+++ b/backend/models.py
@@ -182,6 +182,7 @@ class Quote(Base):
     labor_markup_percent = Column(Float, nullable=True)  # Section-level markup for labor
     misc_markup_percent = Column(Float, nullable=True)  # Section-level markup for misc
     cost_code_id = Column(Integer, ForeignKey('cost_codes.id'), nullable=True)
+    legacy_imported = Column(Boolean, nullable=False, server_default='false')
 
     # Relationships
     project = relationship("Project", back_populates="quotes")
@@ -235,6 +236,7 @@ class PurchaseOrder(Base):
     expected_delivery_date = Column(DateTime, nullable=True)
     status = Column(Enum(POStatus), default=POStatus.draft)
     cost_code_id = Column(Integer, ForeignKey('cost_codes.id'), nullable=True)
+    legacy_imported = Column(Boolean, nullable=False, server_default='false')
 
     # Relationships
     project = relationship("Project", back_populates="purchase_orders")

--- a/backend/routes/reports.py
+++ b/backend/routes/reports.py
@@ -3,8 +3,13 @@ from sqlalchemy.orm import Session, joinedload
 from typing import List
 
 from database import get_db
-from models import Quote, QuoteLineItem, Project, Profile
-from schemas import BacklogQuoteItem, BacklogLineItem
+from models import Quote, QuoteLineItem, Project, Profile, Part
+from schemas import (
+    BacklogQuoteItem,
+    BacklogLineItem,
+    InventoryHealthIssue,
+    InventoryHealthReport,
+)
 from routes.quotes import compute_quote_status, format_quote_number, get_line_item_description
 
 router = APIRouter(prefix="/reports", tags=["reports"])
@@ -109,3 +114,53 @@ def get_backlog_quotes(db: Session = Depends(get_db)):
     # Sort by quote number for consistent output
     result.sort(key=lambda q: q.quote_number)
     return result
+
+
+@router.get("/inventory-health", response_model=InventoryHealthReport)
+def get_inventory_health(db: Session = Depends(get_db)):
+    """List parts with obvious data-quality issues.
+
+    Quality signals currently flagged:
+    - zero_cost: part.cost rounds to 0 (a leftover from CSV migration placeholders)
+    - description_matches_part_number: description text equals the part number, with nothing else
+    - description_has_escaped_quotes: description contains four consecutive double-quote characters
+      (an over-escaped CSV artifact)
+
+    The report is read-only and additive: it never mutates parts. Use it to
+    surface candidates for cleanup; the actual cleanup is a separate, gated step.
+    """
+    parts = db.query(Part).all()
+    items: List[InventoryHealthIssue] = []
+
+    for part in parts:
+        issues: List[str] = []
+
+        if (part.cost or 0) < 0.005:
+            issues.append("zero_cost")
+
+        desc = (part.description or "").strip()
+        if desc and desc == (part.part_number or "").strip():
+            issues.append("description_matches_part_number")
+
+        # Spot the CSV-escape artifact: 4+ consecutive double-quote chars,
+        # produced when a description with embedded `"` got re-escaped during import.
+        if '""""' in desc:
+            issues.append("description_has_escaped_quotes")
+
+        if issues:
+            items.append(InventoryHealthIssue(
+                part_id=part.id,
+                part_number=part.part_number,
+                description=part.description or "",
+                cost=part.cost or 0.0,
+                issues=issues,
+            ))
+
+    # Most-flagged first, then by part number for stable ordering.
+    items.sort(key=lambda it: (-len(it.issues), it.part_number))
+
+    return InventoryHealthReport(
+        total_parts=len(parts),
+        flagged=len(items),
+        items=items,
+    )

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -125,6 +125,22 @@ class BacklogQuoteItem(BaseModel):
     line_items: List[BacklogLineItem] = []
 
 
+# ===== Inventory Health (UX-7) =====
+class InventoryHealthIssue(BaseModel):
+    """A single quality issue against an inventory part."""
+    part_id: int
+    part_number: str
+    description: str
+    cost: float
+    issues: List[str]  # e.g. ["zero_cost", "description_matches_part_number"]
+
+
+class InventoryHealthReport(BaseModel):
+    total_parts: int
+    flagged: int
+    items: List[InventoryHealthIssue]
+
+
 class PhoneType(str, Enum):
     work = "work"
     mobile = "mobile"
@@ -508,6 +524,7 @@ class Quote(QuoteBase):
     current_version: int = 0
     cost_code_id: Optional[int] = None
     cost_code: Optional[CostCode] = None
+    legacy_imported: bool = False
     line_items: List[QuoteLineItem] = []
 
     class Config:
@@ -579,6 +596,7 @@ class PurchaseOrder(PurchaseOrderBase):
     po_number: Optional[str] = None
     cost_code_id: Optional[int] = None
     cost_code: Optional[CostCode] = None
+    legacy_imported: bool = False
     vendor: Profile
     line_items: List[POLineItem] = []
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -15,7 +15,7 @@ import type {
   MarkupControlToggleRequest, MarkupControlToggleResponse,
   CommitEditsRequest, CommitEditsResponse,
   CompanySettings, CompanySettingsUpdate, InvoiceSummaryItem,
-  BacklogQuoteItem, PricebookImportResult, MigrationResult,
+  BacklogQuoteItem, InventoryHealthReport, PricebookImportResult, MigrationResult,
   SystemRate, SystemRateCreate, SystemRateUpdate
 } from '@/types';
 
@@ -315,6 +315,7 @@ export const api = {
   // ===== Reports =====
   reports: {
     getBacklogQuotes: () => request<BacklogQuoteItem[]>('/reports/backlog-quotes'),
+    getInventoryHealth: () => request<InventoryHealthReport>('/reports/inventory-health'),
   },
 
   // ===== Legacy Migration =====

--- a/frontend/src/components/editors/POEditor.tsx
+++ b/frontend/src/components/editors/POEditor.tsx
@@ -1239,6 +1239,15 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
           ) : (
             <StatusBadge status={po.status} className="px-3 py-1" />
           )}
+          {po.legacy_imported && (
+            <Badge
+              variant="outline"
+              className="bg-slate-500/10 text-slate-700 border-slate-500/30 dark:text-slate-300"
+              title="This PO was brought in from the original UC Vision CSV migration."
+            >
+              Imported
+            </Badge>
+          )}
         </div>
       </div>
 

--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -2689,6 +2689,15 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
           </p>
         </div>
         <div className="flex items-center gap-2">
+          {quote.legacy_imported && (
+            <Badge
+              variant="outline"
+              className="bg-slate-500/10 text-slate-700 border-slate-500/30 dark:text-slate-300"
+              title="This quote was brought in from the original UC Vision CSV migration."
+            >
+              Imported
+            </Badge>
+          )}
           <StatusBadge status={quote.status} />
         </div>
       </div>

--- a/frontend/src/pages/ReportsPage.tsx
+++ b/frontend/src/pages/ReportsPage.tsx
@@ -6,8 +6,8 @@ import { Badge } from '@/components/ui/badge'
 import { api } from '@/api/client'
 import { formatCurrency } from '@/lib/pricing'
 import { formatDate } from '@/lib/format'
-import type { InvoiceSummaryItem, CompanySettings, BacklogQuoteItem } from '@/types'
-import { FileText, Download, Loader2, ChevronRight, ChevronDown, FileSpreadsheet } from 'lucide-react'
+import type { InvoiceSummaryItem, CompanySettings, BacklogQuoteItem, InventoryHealthReport, InventoryHealthIssueCode } from '@/types'
+import { FileText, Download, Loader2, ChevronRight, ChevronDown, FileSpreadsheet, ShieldAlert } from 'lucide-react'
 
 export function ReportsPage() {
   // Invoice Summary state
@@ -23,6 +23,25 @@ export function ReportsPage() {
   const [backlogError, setBacklogError] = useState<string | null>(null)
   const [backlogData, setBacklogData] = useState<BacklogQuoteItem[] | null>(null)
   const [expandedQuotes, setExpandedQuotes] = useState<Set<number>>(new Set())
+
+  // Inventory Health state (UX-7)
+  const [healthLoading, setHealthLoading] = useState(false)
+  const [healthError, setHealthError] = useState<string | null>(null)
+  const [healthData, setHealthData] = useState<InventoryHealthReport | null>(null)
+
+  const handleInventoryHealthGenerate = async () => {
+    setHealthLoading(true)
+    setHealthError(null)
+    setHealthData(null)
+    try {
+      const data = await api.reports.getInventoryHealth()
+      setHealthData(data)
+    } catch (err) {
+      setHealthError(err instanceof Error ? err.message : 'Failed to load inventory health')
+    } finally {
+      setHealthLoading(false)
+    }
+  }
 
   // ===== Invoice Summary handlers =====
   const handleGenerate = async () => {
@@ -350,8 +369,88 @@ export function ReportsPage() {
           )}
         </div>
       </div>
+
+      {/* Inventory Health Report (UX-7) */}
+      <div className="bg-card rounded-lg border shadow-sm">
+        <div className="p-4 border-b">
+          <h2 className="text-lg font-semibold flex items-center gap-2">
+            <ShieldAlert className="h-5 w-5" />
+            Inventory Health Report
+          </h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            Parts flagged with data-quality issues — zero cost, description equal to part number,
+            or CSV-escape artifacts. Surfaces cleanup candidates; never mutates data.
+          </p>
+        </div>
+
+        <div className="p-4 space-y-4">
+          <Button onClick={handleInventoryHealthGenerate} disabled={healthLoading}>
+            {healthLoading ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
+            Generate
+          </Button>
+
+          {healthError && (
+            <div className="p-3 bg-destructive/10 border border-destructive/20 rounded-md text-destructive text-sm">
+              {healthError}
+            </div>
+          )}
+
+          {healthData !== null && (
+            <div className="space-y-3">
+              <p className="text-sm text-muted-foreground">
+                <span className="font-medium text-foreground">{healthData.flagged.toLocaleString()}</span> of{' '}
+                <span className="font-medium text-foreground">{healthData.total_parts.toLocaleString()}</span>{' '}
+                parts flagged ({healthData.total_parts > 0
+                  ? ((healthData.flagged / healthData.total_parts) * 100).toFixed(1)
+                  : '0.0'}%).
+              </p>
+
+              {healthData.items.length > 0 && (
+                <div className="border rounded-md overflow-hidden">
+                  <table className="w-full text-sm">
+                    <thead className="bg-muted/50">
+                      <tr>
+                        <th className="px-3 py-2 text-left font-medium text-muted-foreground">Part Number</th>
+                        <th className="px-3 py-2 text-left font-medium text-muted-foreground">Description</th>
+                        <th className="px-3 py-2 text-right font-medium text-muted-foreground">Cost</th>
+                        <th className="px-3 py-2 text-left font-medium text-muted-foreground">Issues</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y">
+                      {healthData.items.map((it) => (
+                        <tr key={it.part_id} className="hover:bg-muted/50">
+                          <td className="px-3 py-2 font-mono text-xs">{it.part_number}</td>
+                          <td className="px-3 py-2 max-w-md truncate" title={it.description}>{it.description || '—'}</td>
+                          <td className="px-3 py-2 text-right">${it.cost.toFixed(2)}</td>
+                          <td className="px-3 py-2">
+                            <div className="flex flex-wrap gap-1">
+                              {it.issues.map((code) => (
+                                <Badge key={code} variant="outline" className="text-[10px]">
+                                  {issueLabel(code)}
+                                </Badge>
+                              ))}
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   )
+}
+
+function issueLabel(code: InventoryHealthIssueCode): string {
+  switch (code) {
+    case "zero_cost": return "Zero cost"
+    case "description_matches_part_number": return "Description = part number"
+    case "description_has_escaped_quotes": return "Escaped quotes"
+  }
 }
 
 function BacklogQuoteRow({

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -105,6 +105,26 @@ export interface BacklogQuoteItem {
   line_items: BacklogLineItem[];
 }
 
+// ===== Inventory Health (UX-7) =====
+export type InventoryHealthIssueCode =
+  | "zero_cost"
+  | "description_matches_part_number"
+  | "description_has_escaped_quotes";
+
+export interface InventoryHealthIssue {
+  part_id: number;
+  part_number: string;
+  description: string;
+  cost: number;
+  issues: InventoryHealthIssueCode[];
+}
+
+export interface InventoryHealthReport {
+  total_parts: number;
+  flagged: number;
+  items: InventoryHealthIssue[];
+}
+
 // ===== Cost Codes =====
 export interface CostCode {
   id: number;
@@ -400,6 +420,7 @@ export interface Quote {
   misc_markup_percent?: number | null;  // Section-level markup for misc
   cost_code_id?: number | null;
   cost_code?: CostCode | null;
+  legacy_imported?: boolean;  // True when the row came in from the original UC Vision CSV migration
   line_items: QuoteLineItem[];
 }
 
@@ -456,6 +477,7 @@ export interface PurchaseOrder {
   expected_delivery_date?: string | null;
   cost_code_id?: number | null;
   cost_code?: CostCode | null;
+  legacy_imported?: boolean;  // True when the row came in from the original UC Vision CSV migration
   vendor: Profile;
   line_items: POLineItem[];
 }


### PR DESCRIPTION
## Summary

This PR ships the **additive, non-destructive** half of UX-7 (#99). The two destructive pieces from the issue's scope are explicitly **deferred** to a separate authorized PR:

- Unescaping the CSV double-quote artifacts inside \`inventory_part.description\` (irreversibly rewrites historical strings)
- Dropping \`Website\` / \`GP Properties\` / \`UCH Dept Properties\` columns (irreversible schema change against live data)

Everything in this PR is purely additive — every existing row, schema, and response remains backward compatible.

## Backend

- **Alembic migration \`018_legacy_imported_flag\`** adds a boolean \`legacy_imported\` column to \`quotes\` and \`purchase_orders\` with a \`DEFAULT FALSE\` server default. No backfill — every existing row stays untouched. The migration uses the \`_column_exists\` idempotent guard matching the rest of the chain, and the downgrade restores by dropping both columns.
- **Models + schemas** (\`models.py\`, \`schemas.py\`) expose the new field, so API responses now include \`legacy_imported: false\` for all rows transparently.
- **New endpoint \`GET /reports/inventory-health\`** flags parts with three quality signals:
  - \`zero_cost\` — \`part.cost\` rounds to zero (a leftover from CSV migration placeholders).
  - \`description_matches_part_number\` — description text equals the part number, suggesting a placeholder.
  - \`description_has_escaped_quotes\` — description contains four consecutive double-quote characters (an over-escaped CSV artifact).
  Read-only; never mutates parts.

## Frontend

- \`types/index.ts\` + \`api/client.ts\` pick up the new endpoint and the new \`legacy_imported\` field on Quote / PurchaseOrder.
- \`ReportsPage\` adds an **Inventory Health Report** section beneath Backlog Quotes — total / flagged counts, percent, and per-row badges for each issue kind.
- \`QuoteEditor\` and \`POEditor\` headers render a small \`Imported\` badge when \`legacy_imported\` is true, so a migrated row is distinguishable from real fulfilled work at a glance.

## Deferred pieces of #99 (need explicit authorization)

- Alembic data mutation to unescape \`""""\` in \`inventory_part.description\` / \`inventory_labour.description\`.
- Backfill setting \`legacy_imported = TRUE\` for rows created before a migration cutoff (needs the cutoff date confirmed).
- Drop dead columns: \`Website\` on \`profiles\`, \`GP Properties\` / \`UCH Dept Properties\` on cost codes.

Once those are authorized, they can ship as a separate PR that closes #99 fully. This PR intentionally does **not** close #99.