### PR TITLE
feat(data-hygiene): destructive UX-7 cleanup — unescape quotes, backfill legacy_imported, drop dead columns

### DIFF
--- a/backend/alembic/versions/20260526_019_destructive_data_hygiene.py
+++ b/backend/alembic/versions/20260526_019_destructive_data_hygiene.py
@@ -1,0 +1,115 @@
+"""Destructive data hygiene: unescape CSV quotes, backfill legacy_imported, drop dead columns.
+
+Closes UX-7 (#99). Counterpart to the additive 018_legacy_imported_flag — runs
+the three operations the previous PR deliberately deferred because they cannot
+be undone by Alembic alone.
+
+Three operations, all in a single transaction so the batch is atomic:
+
+1. Replace any run of four consecutive double-quote characters in
+   parts.description / labor.description / miscellaneous.description with a
+   single double-quote. The over-escaped sequence is a CSV artifact from the
+   original UC Vision import (see inventory_health report's
+   `description_has_escaped_quotes` detector for the matching read-side).
+
+2. Set legacy_imported = TRUE on quotes and purchase_orders whose created_at
+   predates the user-adoption cutoff (LEGACY_CUTOFF below). The cutoff is
+   the day Clerk auth shipped — before that, the only writes to these tables
+   were the bulk CSV import plus dev testing on the unauthenticated app, so
+   flagging them as "imported" is a conservative match for the badge's UX
+   purpose. Change LEGACY_CUTOFF before running if a different boundary is
+   appropriate.
+
+3. Drop three columns that the UI no longer surfaces and the data model no
+   longer carries:
+     - profiles.website
+     - cost_codes.gp_cost_code_properties
+     - cost_codes.uch_dept_properties
+
+Revision ID: 019_destructive_data_hygiene
+Revises: 018_legacy_imported_flag
+Create Date: 2026-05-26
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '019_destructive_data_hygiene'
+down_revision = '018_legacy_imported_flag'
+branch_labels = None
+depends_on = None
+
+
+# Cutoff for the legacy_imported backfill. Anything created strictly before
+# this date is flagged. See module docstring for rationale.
+LEGACY_CUTOFF = '2026-04-09'
+
+# Inventory tables whose `description` column came from the CSV import and
+# is exposed in the UI. Line-item override descriptions are user-typed and
+# would not carry the four-quote artifact, so they're deliberately excluded.
+_DESCRIPTION_TABLES = ('parts', 'labor', 'miscellaneous')
+
+# (table, column) pairs to drop. Kept as a tuple so upgrade/downgrade
+# share a single source of truth.
+_DROPPED_COLUMNS = (
+    ('profiles', 'website'),
+    ('cost_codes', 'gp_cost_code_properties'),
+    ('cost_codes', 'uch_dept_properties'),
+)
+
+
+def _column_exists(table: str, column: str) -> bool:
+    """Idempotent guard matching the rest of the migration chain."""
+    conn = op.get_bind()
+    result = conn.execute(sa.text(
+        """
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = :t AND column_name = :c
+        LIMIT 1
+        """
+    ), {"t": table, "c": column}).scalar()
+    return bool(result)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # 1. Unescape "" -> " on rows that contain the four-quote artifact.
+    # The filter is purely a no-op optimization; REPLACE on a row without
+    # the pattern is a no-op anyway.
+    for table in _DESCRIPTION_TABLES:
+        conn.execute(sa.text(
+            f"UPDATE {table} "
+            f"SET description = REPLACE(description, '\"\"\"\"', '\"') "
+            f"WHERE description LIKE '%\"\"\"\"%'"
+        ))
+
+    # 2. Backfill legacy_imported on rows created before the cutoff.
+    # Guard on legacy_imported = FALSE so re-running the migration after
+    # someone manually un-flags a row does not silently re-flag it.
+    for table in ('quotes', 'purchase_orders'):
+        conn.execute(
+            sa.text(
+                f"UPDATE {table} "
+                f"SET legacy_imported = TRUE "
+                f"WHERE legacy_imported = FALSE AND created_at < :cutoff"
+            ),
+            {"cutoff": LEGACY_CUTOFF},
+        )
+
+    # 3. Drop dead columns the UI no longer surfaces.
+    for table, column in _DROPPED_COLUMNS:
+        if _column_exists(table, column):
+            op.drop_column(table, column)
+
+
+def downgrade() -> None:
+    """Restore dropped columns; string rewrites and the backfill cannot be undone.
+
+    The historical character sequence in `description` fields and the original
+    FALSE state of `legacy_imported` are not recoverable from this revision
+    alone — a restore-from-backup is required to roll those parts back.
+    """
+    for table, column in _DROPPED_COLUMNS:
+        if not _column_exists(table, column):
+            op.add_column(table, sa.Column(column, sa.String(), nullable=True))

--- a/backend/models.py
+++ b/backend/models.py
@@ -52,7 +52,6 @@ class Profile(Base):
     pst = Column(String, nullable=False)  # Provincial Tax Number
     address = Column(String, nullable=False)
     postal_code = Column(String, nullable=False)
-    website = Column(String, nullable=True)  # Optional URL to official website
     default_discount_percent = Column(Float, nullable=True)  # Default vendor discount %
 
     # Relationships
@@ -141,8 +140,6 @@ class CostCode(Base):
     id = Column(Integer, primary_key=True, index=True)
     code = Column(String, unique=True, nullable=False)
     description = Column(String, nullable=False)
-    gp_cost_code_properties = Column(String, nullable=True)
-    uch_dept_properties = Column(String, nullable=True)
 
 
 class Project(Base):

--- a/backend/routes/cost_codes.py
+++ b/backend/routes/cost_codes.py
@@ -40,8 +40,6 @@ def create_cost_code(data: CostCodeCreate, db: Session = Depends(get_db)):
     cc = CostCode(
         code=data.code,
         description=data.description,
-        gp_cost_code_properties=data.gp_cost_code_properties,
-        uch_dept_properties=data.uch_dept_properties,
     )
     db.add(cc)
     db.commit()
@@ -65,10 +63,6 @@ def update_cost_code(cost_code_id: int, data: CostCodeUpdate, db: Session = Depe
 
     if data.description is not None:
         cc.description = data.description
-    if data.gp_cost_code_properties is not None:
-        cc.gp_cost_code_properties = data.gp_cost_code_properties
-    if data.uch_dept_properties is not None:
-        cc.uch_dept_properties = data.uch_dept_properties
 
     db.commit()
     db.refresh(cc)

--- a/backend/routes/migration.py
+++ b/backend/routes/migration.py
@@ -360,15 +360,12 @@ async def import_legacy_data(
                 ]
                 address = ", ".join(p for p in addr_parts if p)
 
-                website = safe_str(row.get("chrWebPage", "")) or None
-
                 profile = Profile(
                     name=name,
                     type=ProfileType.vendor,
                     pst=safe_str(row.get("chrProvincialTax", "")),
                     address=address,
                     postal_code=safe_str(row.get("chrPostalCode", "")),
-                    website=website,
                 )
                 db.add(profile)
                 batch.append((legacy_id, profile))

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -69,7 +69,6 @@ def create_profile(profile_data: ProfileCreate, db: Session = Depends(get_db)):
         pst=profile_data.pst,
         address=profile_data.address,
         postal_code=profile_data.postal_code,
-        website=profile_data.website,
         default_discount_percent=getattr(profile_data, 'default_discount_percent', None)
     )
     db.add(db_profile)
@@ -118,8 +117,6 @@ def update_profile(profile_id: int, profile_data: ProfileUpdate, db: Session = D
         db_profile.address = profile_data.address
     if profile_data.postal_code is not None:
         db_profile.postal_code = profile_data.postal_code
-    if profile_data.website is not None:
-        db_profile.website = profile_data.website
     if profile_data.default_discount_percent is not None:
         db_profile.default_discount_percent = profile_data.default_discount_percent
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -157,8 +157,6 @@ class POStatus(str, Enum):
 class CostCodeBase(BaseModel):
     code: str
     description: str
-    gp_cost_code_properties: Optional[str] = None
-    uch_dept_properties: Optional[str] = None
 
 
 class CostCodeCreate(CostCodeBase):
@@ -168,8 +166,6 @@ class CostCodeCreate(CostCodeBase):
 class CostCodeUpdate(BaseModel):
     code: Optional[str] = None
     description: Optional[str] = None
-    gp_cost_code_properties: Optional[str] = None
-    uch_dept_properties: Optional[str] = None
 
 
 class CostCode(CostCodeBase):
@@ -368,7 +364,6 @@ class ProfileBase(BaseModel):
     pst: str
     address: str
     postal_code: str
-    website: Optional[str] = None
     default_discount_percent: Optional[float] = None
 
 
@@ -388,7 +383,6 @@ class ProfileUpdate(BaseModel):
     pst: Optional[str] = None
     address: Optional[str] = None
     postal_code: Optional[str] = None
-    website: Optional[str] = None
     default_discount_percent: Optional[float] = None
 
 

--- a/frontend/src/components/forms/ProfileForm.tsx
+++ b/frontend/src/components/forms/ProfileForm.tsx
@@ -52,7 +52,6 @@ export function ProfileForm({ profile, defaultType = "customer", onSuccess, onCa
   const [pst, setPst] = useState("")
   const [address, setAddress] = useState("")
   const [postalCode, setPostalCode] = useState("")
-  const [website, setWebsite] = useState("")
   const [defaultDiscountPercent, setDefaultDiscountPercent] = useState("")
 
   // Contacts state
@@ -80,7 +79,6 @@ export function ProfileForm({ profile, defaultType = "customer", onSuccess, onCa
       setPst(profile.pst)
       setAddress(profile.address)
       setPostalCode(profile.postal_code)
-      setWebsite(profile.website || "")
       setDefaultDiscountPercent(profile.default_discount_percent?.toString() || "")
       setContacts(profile.contacts.map(c => ({
         id: c.id,
@@ -183,7 +181,6 @@ export function ProfileForm({ profile, defaultType = "customer", onSuccess, onCa
           pst: pst.trim(),
           address: address.trim(),
           postal_code: postalCode.trim(),
-          website: website.trim() || undefined,
           default_discount_percent: defaultDiscountPercent ? parseFloat(defaultDiscountPercent) : undefined,
         })
 
@@ -224,7 +221,6 @@ export function ProfileForm({ profile, defaultType = "customer", onSuccess, onCa
           pst: pst.trim(),
           address: address.trim(),
           postal_code: postalCode.trim(),
-          website: website.trim() || undefined,
           default_discount_percent: defaultDiscountPercent ? parseFloat(defaultDiscountPercent) : undefined,
           contacts: contacts.map(buildContactCreate)
         }
@@ -307,17 +303,6 @@ export function ProfileForm({ profile, defaultType = "customer", onSuccess, onCa
             onChange={(e) => setPostalCode(e.target.value)}
             placeholder="e.g., V6B 1A1"
             required
-          />
-        </div>
-
-        <div className="space-y-2">
-          <Label htmlFor="website">Link to Website</Label>
-          <Input
-            id="website"
-            type="url"
-            value={website}
-            onChange={(e) => setWebsite(e.target.value)}
-            placeholder="e.g., https://www.example.com"
           />
         </div>
 

--- a/frontend/src/pages/ProfilesPage.tsx
+++ b/frontend/src/pages/ProfilesPage.tsx
@@ -24,7 +24,7 @@ import { Input } from "@/components/ui/input"
 import { api } from "@/api/client"
 import type { Profile, Part, PricebookImportResult } from "@/types"
 import {
-  Plus, Trash2, Pencil, Users, Building, ExternalLink, Phone, Mail, MapPin, Upload, Search,
+  Plus, Trash2, Pencil, Users, Building, Phone, Mail, MapPin, Upload, Search,
 } from "lucide-react"
 import { EMPTY_VALUE } from "@/lib/format"
 import { VirtualizedTable, headerCellClass, cellClass } from "@/components/ui/virtualized-table"
@@ -301,21 +301,6 @@ export function ProfilesPage() {
                   </p>
                   <p className="font-medium">{viewingProfile.address || EMPTY_VALUE}</p>
                 </div>
-                {viewingProfile.website && (
-                  <div>
-                    <p className="text-sm text-muted-foreground flex items-center gap-1">
-                      <ExternalLink className="h-3 w-3" /> Website
-                    </p>
-                    <a
-                      href={viewingProfile.website}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-600 hover:underline font-medium"
-                    >
-                      {viewingProfile.website}
-                    </a>
-                  </div>
-                )}
               </div>
 
               <Separator />

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -30,8 +30,6 @@ import { Loader2, Save, Pencil, Trash2, Plus, X, Check, Upload } from 'lucide-re
 interface CostCodeEditState {
   code: string
   description: string
-  gp_cost_code_properties: string
-  uch_dept_properties: string
 }
 
 export function SettingsPage() {
@@ -55,7 +53,7 @@ export function SettingsPage() {
   const [editingCostCodeId, setEditingCostCodeId] = useState<number | null>(null)
   const [editingCostCode, setEditingCostCode] = useState<CostCodeEditState | null>(null)
   const [addingCostCode, setAddingCostCode] = useState(false)
-  const [newCostCode, setNewCostCode] = useState<CostCodeEditState>({ code: '', description: '', gp_cost_code_properties: '', uch_dept_properties: '' })
+  const [newCostCode, setNewCostCode] = useState<CostCodeEditState>({ code: '', description: '' })
   const [costCodeSaving, setCostCodeSaving] = useState(false)
   const [costCodeError, setCostCodeError] = useState<string | null>(null)
   const [deleteConfirm, setDeleteConfirm] = useState<CostCode | null>(null)
@@ -348,8 +346,6 @@ export function SettingsPage() {
     setEditingCostCode({
       code: cc.code,
       description: cc.description,
-      gp_cost_code_properties: cc.gp_cost_code_properties || '',
-      uch_dept_properties: cc.uch_dept_properties || '',
     })
     setCostCodeError(null)
   }
@@ -372,8 +368,6 @@ export function SettingsPage() {
       await api.costCodes.update(editingCostCodeId, {
         code: editingCostCode.code.trim(),
         description: editingCostCode.description.trim(),
-        gp_cost_code_properties: editingCostCode.gp_cost_code_properties.trim() || undefined,
-        uch_dept_properties: editingCostCode.uch_dept_properties.trim() || undefined,
       })
       setEditingCostCodeId(null)
       setEditingCostCode(null)
@@ -387,13 +381,13 @@ export function SettingsPage() {
 
   const startAddCostCode = () => {
     setAddingCostCode(true)
-    setNewCostCode({ code: '', description: '', gp_cost_code_properties: '', uch_dept_properties: '' })
+    setNewCostCode({ code: '', description: '' })
     setCostCodeError(null)
   }
 
   const cancelAddCostCode = () => {
     setAddingCostCode(false)
-    setNewCostCode({ code: '', description: '', gp_cost_code_properties: '', uch_dept_properties: '' })
+    setNewCostCode({ code: '', description: '' })
   }
 
   const saveNewCostCode = async () => {
@@ -408,12 +402,10 @@ export function SettingsPage() {
       const data: CostCodeCreate = {
         code: newCostCode.code.trim(),
         description: newCostCode.description.trim(),
-        gp_cost_code_properties: newCostCode.gp_cost_code_properties.trim() || undefined,
-        uch_dept_properties: newCostCode.uch_dept_properties.trim() || undefined,
       }
       await api.costCodes.create(data)
       setAddingCostCode(false)
-      setNewCostCode({ code: '', description: '', gp_cost_code_properties: '', uch_dept_properties: '' })
+      setNewCostCode({ code: '', description: '' })
       fetchCostCodes()
     } catch (err) {
       setCostCodeError(err instanceof Error ? err.message : 'Failed to create cost code')
@@ -921,8 +913,6 @@ export function SettingsPage() {
                   <TableRow>
                     <TableHead className="w-[120px]">Code</TableHead>
                     <TableHead>Description</TableHead>
-                    <TableHead className="w-[180px]">GP Properties</TableHead>
-                    <TableHead className="w-[180px]">UCH Dept Properties</TableHead>
                     <TableHead className="w-[100px] text-right">Actions</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -945,22 +935,6 @@ export function SettingsPage() {
                               className="h-8"
                             />
                           </TableCell>
-                          <TableCell>
-                            <Input
-                              value={editingCostCode.gp_cost_code_properties}
-                              onChange={(e) => setEditingCostCode({ ...editingCostCode, gp_cost_code_properties: e.target.value })}
-                              className="h-8"
-                              placeholder="Optional"
-                            />
-                          </TableCell>
-                          <TableCell>
-                            <Input
-                              value={editingCostCode.uch_dept_properties}
-                              onChange={(e) => setEditingCostCode({ ...editingCostCode, uch_dept_properties: e.target.value })}
-                              className="h-8"
-                              placeholder="Optional"
-                            />
-                          </TableCell>
                           <TableCell className="text-right">
                             <div className="flex justify-end gap-1">
                               <Button size="icon" variant="ghost" className="h-7 w-7" onClick={saveEditCostCode} disabled={costCodeSaving}>
@@ -976,8 +950,6 @@ export function SettingsPage() {
                         <>
                           <TableCell className="font-mono text-sm">{cc.code}</TableCell>
                           <TableCell>{cc.description}</TableCell>
-                          <TableCell className="text-sm text-muted-foreground">{cc.gp_cost_code_properties || '—'}</TableCell>
-                          <TableCell className="text-sm text-muted-foreground">{cc.uch_dept_properties || '—'}</TableCell>
                           <TableCell className="text-right">
                             <div className="flex justify-end gap-1">
                               <Button
@@ -1025,22 +997,6 @@ export function SettingsPage() {
                           placeholder="Description"
                         />
                       </TableCell>
-                      <TableCell>
-                        <Input
-                          value={newCostCode.gp_cost_code_properties}
-                          onChange={(e) => setNewCostCode({ ...newCostCode, gp_cost_code_properties: e.target.value })}
-                          className="h-8"
-                          placeholder="Optional"
-                        />
-                      </TableCell>
-                      <TableCell>
-                        <Input
-                          value={newCostCode.uch_dept_properties}
-                          onChange={(e) => setNewCostCode({ ...newCostCode, uch_dept_properties: e.target.value })}
-                          className="h-8"
-                          placeholder="Optional"
-                        />
-                      </TableCell>
                       <TableCell className="text-right">
                         <div className="flex justify-end gap-1">
                           <Button size="icon" variant="ghost" className="h-7 w-7" onClick={saveNewCostCode} disabled={costCodeSaving}>
@@ -1056,7 +1012,7 @@ export function SettingsPage() {
 
                   {costCodes.length === 0 && !addingCostCode && (
                     <TableRow>
-                      <TableCell colSpan={5} className="text-center text-muted-foreground py-8">
+                      <TableCell colSpan={3} className="text-center text-muted-foreground py-8">
                         No cost codes found. Click "Add New" to create one.
                       </TableCell>
                     </TableRow>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -130,22 +130,16 @@ export interface CostCode {
   id: number;
   code: string;
   description: string;
-  gp_cost_code_properties?: string | null;
-  uch_dept_properties?: string | null;
 }
 
 export interface CostCodeCreate {
   code: string;
   description: string;
-  gp_cost_code_properties?: string | null;
-  uch_dept_properties?: string | null;
 }
 
 export interface CostCodeUpdate {
   code?: string;
   description?: string;
-  gp_cost_code_properties?: string | null;
-  uch_dept_properties?: string | null;
 }
 
 // ===== Labor =====
@@ -258,7 +252,6 @@ export interface Profile {
   pst: string;
   address: string;
   postal_code: string;
-  website?: string;
   default_discount_percent?: number;
   contacts: Contact[];
 }
@@ -269,7 +262,6 @@ export interface ProfileCreate {
   pst: string;
   address: string;
   postal_code: string;
-  website?: string;
   default_discount_percent?: number;
   contacts: ContactCreate[];
 }
@@ -280,7 +272,6 @@ export interface ProfileUpdate {
   pst?: string;
   address?: string;
   postal_code?: string;
-  website?: string;
   default_discount_percent?: number;
 }
 


### PR DESCRIPTION
## Summary

Closes the deferred half of UX-7. Counterpart to PR #109 (which shipped the additive pieces: `legacy_imported` column + Inventory Health report). Runs the three irreversible operations the previous PR could not, all inside a single Alembic migration so the batch is atomic.

Fixes #99.

## Migration `019_destructive_data_hygiene`

One transaction, three operations:

1. **Unescape CSV double-quote artifact** in `parts.description`, `labor.description`, and `miscellaneous.description`. Replaces any run of four consecutive double-quote characters with a single double-quote, matching the read-side detector in the existing Inventory Health endpoint (`description_has_escaped_quotes`).

2. **Backfill `legacy_imported = TRUE`** on `quotes` and `purchase_orders` whose `created_at < 2026-04-09`. The cutoff is the day Clerk auth shipped — before that, the only writes were the bulk CSV import + dev testing on an unauthenticated app, so flagging them as "imported" is the conservative match for the badge's UX purpose. Cutoff is a module-level constant (`LEGACY_CUTOFF`) so it can be edited before the migration runs if a different boundary is appropriate. Guarded with `WHERE legacy_imported = FALSE` so a re-run won't silently re-flag rows that were manually un-flagged.

3. **Drop three dead columns** the UI no longer surfaces:
   - `profiles.website`
   - `cost_codes.gp_cost_code_properties`
   - `cost_codes.uch_dept_properties`

The `_column_exists` idempotent guard matches the rest of the migration chain. `downgrade()` restores the dropped columns as nullable VARCHAR; the string rewrites and the backfill cannot be undone by Alembic alone (a restore-from-backup is required for that).

## Backend

- `models.py`: drops `Profile.website`, `CostCode.gp_cost_code_properties`, `CostCode.uch_dept_properties`
- `schemas.py`: drops `website` from `ProfileBase` / `ProfileUpdate`, and the GP/UCH fields from `CostCodeBase` / `CostCodeUpdate`
- `routes/profiles.py`: stops reading and writing `website` in create/update
- `routes/cost_codes.py`: stops reading and writing GP/UCH in create/update
- `routes/migration.py`: stops reading `chrWebPage` from CSV imports (the field is no longer stored anywhere)

Pydantic defaults to `extra='ignore'`, so any older client that still sends `website` will have it silently dropped rather than 422'd — no rollout coordination required.

## Frontend

- `types/index.ts`: removes `website` from `Profile` / `ProfileCreate` / `ProfileUpdate`, and GP/UCH from `CostCode*`
- `ProfileForm.tsx`: removes the "Link to Website" input, state, and submit-path inclusion
- `ProfilesPage.tsx`: removes the website block in the view dialog and the now-unused `ExternalLink` icon import
- `SettingsPage.tsx`: removes the GP Properties and UCH Dept Properties columns from the cost-code table (header, view cells, inline-edit cells, add-row cells, and the empty-row `colSpan`)