### PR TITLE
ops(deploy): auto-apply alembic migrations via Railway preDeployCommand

### DIFF
--- a/backend/alembic/README
+++ b/backend/alembic/README
@@ -21,5 +21,11 @@ Show migration history:
 
 ## Production
 
-Migrations run automatically on Railway deploy via the releaseCommand
-in railway.toml. No manual intervention needed.
+Migrations run automatically on Railway deploy via the preDeployCommand
+in backend/railway.toml. The preDeployCommand executes in a one-off container
+before any Gunicorn worker boots - if `alembic upgrade head` fails, the deploy
+fails before serving traffic. No manual intervention needed.
+
+For local development, run `alembic upgrade head` yourself, or set
+ALEMBIC_AUTO_UPGRADE=1 in backend/.env to have main.py migrate on each
+uvicorn --reload boot.

--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -16,6 +16,11 @@
 builder = "nixpacks"
 
 [deploy]
+# Run pending Alembic migrations exactly once per deploy, before any worker
+# accepts traffic. If this exits non-zero the deploy fails before workers boot,
+# so a schema/code drift can never silently ship. This replaces the previous
+# per-worker ALEMBIC_AUTO_UPGRADE=1 dance, which was fail-open and easy to forget.
+preDeployCommand = "python -m alembic upgrade head"
 startCommand = "gunicorn main:app -w 2 -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT --timeout 300"
 healthcheckPath = "/health"
 healthcheckTimeout = 100


### PR DESCRIPTION
## Summary

- Adds `preDeployCommand = \"python -m alembic upgrade head\"` to `backend/railway.toml` so migrations run once per deploy, before any Gunicorn worker boots.
- Fail-closed: if `alembic upgrade head` returns non-zero, the deploy fails before serving traffic. No more silently-shipped schema/code drift.
- Updates the stale `backend/alembic/README` claim about a `releaseCommand` (which never existed in `railway.toml`).
- The per-worker `ALEMBIC_AUTO_UPGRADE=1` gate in `backend/main.py` stays for local-dev convenience but becomes unnecessary on Railway.

## Background

Today the end user clicked a project row and saw `Failed to fetch`. Root cause:

- `backend/models.py` declares `Quote.legacy_imported` and `PurchaseOrder.legacy_imported`.
- Migrations `018_legacy_imported_flag` and `019_destructive_data_hygiene` add those columns and ship to master with PRs #109 and #110.
- `ALEMBIC_AUTO_UPGRADE` was unset on Railway, so both deploys silently skipped the migrations.
- `GET /projects/{id}` uses `joinedload(Project.quotes)` + `joinedload(Project.purchase_orders)`, which forces SQLAlchemy to SELECT every model column - including the missing `legacy_imported`.
- The 500 from psycopg2 was replaced by `railway-edge` with its own plain-text response (no CORS headers), surfacing in the browser as `TypeError: Failed to fetch`.

This PR makes that failure mode structurally impossible going forward.