### PR TITLE
feat(reports): project filter on Invoice Summary Report

### DIFF
--- a/backend/routes/invoices.py
+++ b/backend/routes/invoices.py
@@ -24,6 +24,7 @@ router = APIRouter(prefix="/invoices", tags=["invoices"])
 def list_invoices(
     start_date: date = Query(..., description="Start date (inclusive)"),
     end_date: date = Query(..., description="End date (inclusive)"),
+    project_id: Optional[int] = Query(None, description="Optional: filter to a single project"),
     db: Session = Depends(get_db)
 ):
     """List invoices within a date range with project/customer info for the summary report."""
@@ -32,7 +33,7 @@ def list_invoices(
     hst_rate = settings.hst_rate if settings and settings.hst_rate is not None else 13.0
 
     # Query invoices with joined quote -> project -> customer
-    invoices = (
+    query = (
         db.query(Invoice)
         .join(Quote, Invoice.quote_id == Quote.id)
         .join(Project, Quote.project_id == Project.id)
@@ -46,9 +47,10 @@ def list_invoices(
             Invoice.created_at <= datetime.combine(end_date, datetime.max.time()),
             Invoice.status != "Voided",
         )
-        .order_by(Invoice.created_at)
-        .all()
     )
+    if project_id is not None:
+        query = query.filter(Project.id == project_id)
+    invoices = query.order_by(Invoice.created_at).all()
 
     results = []
     for inv in invoices:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -14,4 +14,4 @@ def _pg_reachable():
 # This prevents the ImportError from `from main import app` when
 # there's no local Postgres — while CI (which has Postgres) is unaffected.
 if not _pg_reachable():
-    collect_ignore = ["test_smoke.py", "test_backlog_report.py"]
+    collect_ignore = ["test_smoke.py", "test_backlog_report.py", "test_invoice_summary.py"]

--- a/backend/tests/test_invoice_summary.py
+++ b/backend/tests/test_invoice_summary.py
@@ -1,0 +1,65 @@
+"""Tests for the invoice summary report endpoint."""
+from datetime import date
+
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+# A wide date range that should capture all existing test data
+WIDE_START = "2000-01-01"
+WIDE_END = "2099-12-31"
+
+
+def test_invoice_summary_returns_200():
+    """GET /invoices/ with a date range returns 200 with a list."""
+    r = client.get(f"/invoices/?start_date={WIDE_START}&end_date={WIDE_END}")
+    assert r.status_code == 200
+    assert isinstance(r.json(), list)
+
+
+def test_invoice_summary_rows_carry_project_fields():
+    """Every row must have UCA project number, project name, and customer name."""
+    r = client.get(f"/invoices/?start_date={WIDE_START}&end_date={WIDE_END}")
+    assert r.status_code == 200
+    for item in r.json():
+        assert item["uca_project_number"]
+        assert item["project_name"]
+        assert item["customer_name"]
+
+
+def test_invoice_summary_project_filter_narrows_results():
+    """Passing project_id must return only invoices for that project."""
+    all_rows = client.get(
+        f"/invoices/?start_date={WIDE_START}&end_date={WIDE_END}"
+    ).json()
+    if not all_rows:
+        return  # nothing to test against — environment has no invoices
+
+    # Pick a project that actually has an invoice
+    first = all_rows[0]
+    # The summary doesn't expose project_id directly, so we look it up via /projects/list-view
+    projects = client.get("/projects/list-view").json()
+    target = next(
+        (p for p in projects if p["uca_project_number"] == first["uca_project_number"]),
+        None,
+    )
+    assert target is not None, "Could not resolve project_id for first invoice"
+
+    filtered = client.get(
+        f"/invoices/?start_date={WIDE_START}&end_date={WIDE_END}&project_id={target['id']}"
+    ).json()
+
+    assert len(filtered) <= len(all_rows)
+    assert len(filtered) > 0, "Expected at least one row for the picked project"
+    for row in filtered:
+        assert row["uca_project_number"] == target["uca_project_number"]
+
+
+def test_invoice_summary_unknown_project_returns_empty():
+    """An invalid project_id should return an empty list, not an error."""
+    r = client.get(
+        f"/invoices/?start_date={WIDE_START}&end_date={WIDE_END}&project_id=999999999"
+    )
+    assert r.status_code == 200
+    assert r.json() == []

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -227,8 +227,11 @@ export const api = {
     get: (id: number) => request<Invoice>(`/invoices/${id}`),
     updateStatus: (id: number, data: InvoiceStatusUpdate) =>
       request<Invoice>(`/invoices/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
-    getSummary: (startDate: string, endDate: string) =>
-      request<InvoiceSummaryItem[]>(`/invoices/?start_date=${startDate}&end_date=${endDate}`),
+    getSummary: (startDate: string, endDate: string, projectId?: number) => {
+      const qs = new URLSearchParams({ start_date: startDate, end_date: endDate })
+      if (projectId !== undefined) qs.set('project_id', String(projectId))
+      return request<InvoiceSummaryItem[]>(`/invoices/?${qs.toString()}`)
+    },
   },
 
   // ===== Company Settings =====

--- a/frontend/src/components/pdf/InvoiceSummaryPDF.tsx
+++ b/frontend/src/components/pdf/InvoiceSummaryPDF.tsx
@@ -2,12 +2,13 @@ import { Document, Page, View, Text } from '@react-pdf/renderer'
 import { styles } from './styles'
 import { PDFFooter } from './PDFFooter'
 import { formatCurrency } from '@/lib/pricing'
-import type { InvoiceSummaryItem, CompanySettings } from '@/types'
+import type { InvoiceSummaryItem, CompanySettings, ProjectListView } from '@/types'
 
 interface InvoiceSummaryPDFProps {
   invoices: InvoiceSummaryItem[]
   dateRange: { start: string; end: string }
   companySettings: CompanySettings
+  project?: ProjectListView | null
 }
 
 // Column widths for the summary table
@@ -22,7 +23,7 @@ const col = {
   total: { width: '11%', textAlign: 'right' as const },
 }
 
-export function InvoiceSummaryPDF({ invoices, dateRange, companySettings }: InvoiceSummaryPDFProps) {
+export function InvoiceSummaryPDF({ invoices, dateRange, companySettings, project }: InvoiceSummaryPDFProps) {
   const totals = invoices.reduce(
     (acc, inv) => ({
       netSales: acc.netSales + inv.net_sales,
@@ -45,7 +46,9 @@ export function InvoiceSummaryPDF({ invoices, dateRange, companySettings }: Invo
         {/* Title */}
         <Text style={styles.reportTitle}>WorkOrder Invoice Report</Text>
         <Text style={styles.reportSubtitle}>
-          {companySettings.name} — Invoice Report — {formatDate(dateRange.start)} to {formatDate(dateRange.end)}
+          {companySettings.name} — Invoice Report
+          {project ? ` — ${project.uca_project_number} ${project.name}` : ''}
+          {' — '}{formatDate(dateRange.start)} to {formatDate(dateRange.end)}
         </Text>
 
         <View style={styles.divider} />

--- a/frontend/src/pages/ReportsPage.tsx
+++ b/frontend/src/pages/ReportsPage.tsx
@@ -1,12 +1,13 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
+import { SearchableSelect } from '@/components/ui/searchable-select'
 import { api } from '@/api/client'
 import { formatCurrency } from '@/lib/pricing'
 import { formatDate } from '@/lib/format'
-import type { InvoiceSummaryItem, CompanySettings, BacklogQuoteItem, InventoryHealthReport, InventoryHealthIssueCode } from '@/types'
+import type { InvoiceSummaryItem, CompanySettings, BacklogQuoteItem, InventoryHealthReport, InventoryHealthIssueCode, ProjectListView } from '@/types'
 import { FileText, Download, Loader2, ChevronRight, ChevronDown, FileSpreadsheet, ShieldAlert } from 'lucide-react'
 
 export function ReportsPage() {
@@ -17,6 +18,33 @@ export function ReportsPage() {
   const [error, setError] = useState<string | null>(null)
   const [invoices, setInvoices] = useState<InvoiceSummaryItem[] | null>(null)
   const [companySettings, setCompanySettings] = useState<CompanySettings | null>(null)
+
+  // Project picker for Invoice Summary ('' = All Projects)
+  const [projects, setProjects] = useState<ProjectListView[]>([])
+  const [selectedProjectId, setSelectedProjectId] = useState<string>('')
+
+  useEffect(() => {
+    api.projects.getListView().then(setProjects).catch(() => {
+      // Picker stays empty; report still works in "All Projects" mode
+    })
+  }, [])
+
+  const projectOptions = useMemo(
+    () => [
+      { value: '', label: 'All Projects' },
+      ...projects.map((p) => ({
+        value: String(p.id),
+        label: `${p.uca_project_number} — ${p.name}`,
+        description: p.customer_name,
+      })),
+    ],
+    [projects],
+  )
+
+  const selectedProject = useMemo(
+    () => projects.find((p) => String(p.id) === selectedProjectId) ?? null,
+    [projects, selectedProjectId],
+  )
 
   // Backlog Quotes state
   const [backlogLoading, setBacklogLoading] = useState(false)
@@ -55,8 +83,9 @@ export function ReportsPage() {
     setInvoices(null)
 
     try {
+      const projectIdNum = selectedProjectId ? Number(selectedProjectId) : undefined
       const [data, settings] = await Promise.all([
-        api.invoices.getSummary(startDate, endDate),
+        api.invoices.getSummary(startDate, endDate, projectIdNum),
         api.companySettings.get(),
       ])
       setInvoices(data)
@@ -82,13 +111,15 @@ export function ReportsPage() {
           invoices={invoices}
           dateRange={{ start: startDate, end: endDate }}
           companySettings={companySettings}
+          project={selectedProject}
         />
       ).toBlob()
 
+      const projectTag = selectedProject ? `_${selectedProject.uca_project_number}` : ''
       const url = URL.createObjectURL(blob)
       const link = document.createElement('a')
       link.href = url
-      link.download = `Invoice_Report_${startDate}_to_${endDate}.pdf`
+      link.download = `Invoice_Report${projectTag}_${startDate}_to_${endDate}.pdf`
       link.click()
       URL.revokeObjectURL(url)
     } catch (err) {
@@ -112,6 +143,7 @@ export function ReportsPage() {
           invoices={invoices}
           dateRange={{ start: startDate, end: endDate }}
           companySettings={companySettings}
+          project={selectedProject}
         />
       ).toBlob()
 
@@ -185,8 +217,20 @@ export function ReportsPage() {
         </div>
 
         <div className="p-4 space-y-4">
-          {/* Date range inputs */}
-          <div className="flex gap-4 items-end">
+          {/* Filters: project + date range */}
+          <div className="flex flex-wrap gap-4 items-end">
+            <div className="space-y-2">
+              <Label>Project</Label>
+              <SearchableSelect
+                options={projectOptions}
+                value={selectedProjectId}
+                onChange={setSelectedProjectId}
+                placeholder="All Projects"
+                searchPlaceholder="Search by UCA #, name, or customer..."
+                emptyMessage="No projects found."
+                className="w-72"
+              />
+            </div>
             <div className="space-y-2">
               <Label htmlFor="start-date">Start Date</Label>
               <Input


### PR DESCRIPTION
## Summary
- Adds an optional project picker to the Invoice Summary Report on the Reports page. Default ("All Projects") preserves existing behavior.
- Backend `GET /invoices/` accepts a new optional `project_id` query param; the query builder applies the filter conditionally.
- Frontend reuses the existing `SearchableSelect` and `api.projects.getListView()` so no new component or endpoint is needed.
- PDF subtitle and download filename reflect the selected project when one is chosen.

## Files changed
- `backend/routes/invoices.py` — optional `project_id` filter
- `backend/tests/test_invoice_summary.py` (new) — 4 shape tests for the endpoint and filter
- `backend/tests/conftest.py` — register new test for the no-Postgres skip list
- `frontend/src/api/client.ts` — `getSummary(startDate, endDate, projectId?)` via `URLSearchParams`
- `frontend/src/components/pdf/InvoiceSummaryPDF.tsx` — optional `project` prop, included in the subtitle
- `frontend/src/pages/ReportsPage.tsx` — project picker, loaded on mount, threaded into the API call and both PDF call sites

## Out of scope
Group-by-project subtotals (the issue title mentions filter *or* group-by; the comment narrowed the requirement to a single-project filter). Group-by would need redesigning the preview table and the `@react-pdf` table to support header/subtotal rows — left for a follow-up issue if needed.

Fixes #81