### PR TITLE
fix(pdf): logo aspect ratio, always-show client PO #, HST label

### DIFF
--- a/frontend/src/components/pdf/InvoicePDF.tsx
+++ b/frontend/src/components/pdf/InvoicePDF.tsx
@@ -130,12 +130,10 @@ export function InvoicePDF({ invoice, quote, project, companySettings }: Invoice
               <Text style={styles.metaLabel}>Invoice Date:</Text>
               <Text style={styles.metaValue}>{invoiceDate}</Text>
             </View>
-            {quote.client_po_number && (
-              <View style={styles.metaRow}>
-                <Text style={styles.metaLabel}>Client PO #:</Text>
-                <Text style={styles.metaValue}>{quote.client_po_number}</Text>
-              </View>
-            )}
+            <View style={styles.metaRow}>
+              <Text style={styles.metaLabel}>Client PO #:</Text>
+              <Text style={styles.metaValue}>{quote.client_po_number || '—'}</Text>
+            </View>
           </View>
         </PDFHeader>
 
@@ -172,7 +170,7 @@ export function InvoicePDF({ invoice, quote, project, companySettings }: Invoice
           </View>
           {hstRate > 0 && (
             <View style={styles.totalsRow}>
-              <Text style={styles.totalsLabel}>HST ({hstRate}%):</Text>
+              <Text style={styles.totalsLabel}>HST (Extra):</Text>
               <Text style={styles.totalsValue}>{formatCurrency(hstAmount)}</Text>
             </View>
           )}

--- a/frontend/src/components/pdf/PDFHeader.tsx
+++ b/frontend/src/components/pdf/PDFHeader.tsx
@@ -16,7 +16,9 @@ export function PDFHeader({ companySettings, title, children }: PDFHeaderProps) 
       <View style={styles.headerRow}>
         {/* Left: Logo + Company Info */}
         <View style={styles.headerLeft}>
-          <Image src={companySettings.logo_data_url || logo} style={styles.logo} />
+          <View style={styles.logoBox}>
+            <Image src={companySettings.logo_data_url || logo} style={styles.logo} />
+          </View>
           <View style={styles.companyInfo}>
             <Text style={styles.companyName}>{companySettings.name}</Text>
             {companySettings.address && <Text>{companySettings.address}</Text>}

--- a/frontend/src/components/pdf/QuotePDF.tsx
+++ b/frontend/src/components/pdf/QuotePDF.tsx
@@ -122,12 +122,10 @@ export function QuotePDF({ quote, project, companySettings }: QuotePDFProps) {
               <Text style={styles.metaLabel}>Quotation #:</Text>
               <Text style={styles.metaValue}>{quote.quote_number}</Text>
             </View>
-            {quote.client_po_number && (
-              <View style={styles.metaRow}>
-                <Text style={styles.metaLabel}>Client PO #:</Text>
-                <Text style={styles.metaValue}>{quote.client_po_number}</Text>
-              </View>
-            )}
+            <View style={styles.metaRow}>
+              <Text style={styles.metaLabel}>Client PO #:</Text>
+              <Text style={styles.metaValue}>{quote.client_po_number || '—'}</Text>
+            </View>
             <View style={styles.metaRow}>
               <Text style={styles.metaLabel}>Date:</Text>
               <Text style={styles.metaValue}>{formattedDate}</Text>
@@ -180,7 +178,7 @@ export function QuotePDF({ quote, project, companySettings }: QuotePDFProps) {
           </View>
           {hstRate > 0 && (
             <View style={styles.totalsRow}>
-              <Text style={styles.totalsLabel}>HST ({hstRate}%):</Text>
+              <Text style={styles.totalsLabel}>HST (Extra):</Text>
               <Text style={styles.totalsValue}>{formatCurrency(hstAmount)}</Text>
             </View>
           )}

--- a/frontend/src/components/pdf/styles.ts
+++ b/frontend/src/components/pdf/styles.ts
@@ -32,9 +32,16 @@ export const styles = StyleSheet.create({
     alignItems: 'flex-start',
     gap: 10,
   },
+  logoBox: {
+    width: 120,
+    height: 50,
+    justifyContent: 'center',
+    alignItems: 'flex-start',
+  },
   logo: {
-    width: 60,
-    height: 60,
+    width: '100%',
+    height: '100%',
+    objectFit: 'contain',
   },
   companyInfo: {
     fontSize: 7,


### PR DESCRIPTION
Fixes #80.

## Summary
Three post-optimization polish fixes to the quote and invoice PDF templates:

- **Logo aspect ratio.** Logo was forced into a fixed `60x60` square in `styles.ts`, squeezing the default 650x418 wordmark by ~36% horizontally. Wrap the `<Image>` in a 120x50 `logoBox` `<View>` and apply `objectFit: 'contain'` so any uploaded company logo (wide wordmark, square mark, tall portrait) letterboxes inside the reserved area without stretching. Reserved bounds keep the header rhythm stable across documents.
- **Client PO # missing on printout.** The row was gated on `quote.client_po_number` being truthy, so empty values produced no row at all — diverging from the editor UI which shows `—`. Now renders unconditionally with the same `—` fallback on both `QuotePDF` and `InvoicePDF`.
- **HST label.** `HST (13%):` → `HST (Extra):` on both `QuotePDF` and `InvoicePDF` (label-only change; tax math unchanged).