### PR TITLE
feat(po): printable received PO PDF + receiving history + notes

### DIFF
--- a/frontend/src/components/editors/POEditor.tsx
+++ b/frontend/src/components/editors/POEditor.tsx
@@ -53,12 +53,13 @@ import { api } from "@/api/client"
 import type {
   PurchaseOrder, POLineItem, POLineItemCreate, POLineItemType, POStatus, Part, CostCode,
   POEditorMode, StagedPOEdit, StagedPOAdd,
-  StagedPOLineItemChange, POCommitEditsRequest, POReceivingCreate, POReceivingLineItemCreate,
+  StagedPOLineItemChange, POCommitEditsRequest, POReceiving, POReceivingCreate, POReceivingLineItemCreate,
   CompanySettings, Project
 } from "@/types"
 import {
   Plus, Minus, Trash2, Package, FileText, Building, Pencil, Copy,
-  X, GitCommit, Eye, AlertTriangle, Check, Calendar, Loader2, Hash, Printer
+  X, GitCommit, Eye, AlertTriangle, Check, Calendar, Loader2, Hash, Printer,
+  History, ChevronDown, ChevronRight, Receipt
 } from "lucide-react"
 import { StatusBadge } from "@/components/ui/status-badge"
 import { formatDate } from "@/lib/format"
@@ -148,8 +149,14 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
     actual_unit_price?: number;
   }>>(new Map())
   const [receivedDate, setReceivedDate] = useState<string>(new Date().toISOString().split('T')[0])
+  const [receivingNotes, setReceivingNotes] = useState<string>("")
   const [receivingDialogOpen, setReceivingDialogOpen] = useState(false)
   const [isSubmittingReceiving, setIsSubmittingReceiving] = useState(false)
+
+  // ===== Receiving History State =====
+  const [receivings, setReceivings] = useState<POReceiving[]>([])
+  const [expandedReceivings, setExpandedReceivings] = useState<Set<number>>(new Set())
+  const [isPrintingReceived, setIsPrintingReceived] = useState(false)
 
   // ===== Computed Values =====
   const hasBeenReceived = po?.line_items.some(item => item.qty_received > 0) ?? false
@@ -196,9 +203,19 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
     }
   }
 
+  const fetchReceivings = async () => {
+    try {
+      const data = await api.purchaseOrders.getReceivings(poId)
+      setReceivings(data)
+    } catch (err) {
+      console.error("Failed to fetch receivings", err)
+    }
+  }
+
   useEffect(() => {
     fetchPO()
     fetchParts()
+    fetchReceivings()
     api.companySettings.get().then(setCompanySettings).catch(() => {})
     api.costCodes.getAll().then(setCostCodes).catch(() => {})
   }, [poId])
@@ -656,12 +673,41 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
     }
   }
 
+  const handlePrintReceivedPO = async () => {
+    if (!po) return
+    setIsPrintingReceived(true)
+    try {
+      const [project, companySettings, freshReceivings, { pdf }, { ReceivedPurchaseOrderPDF }] = await Promise.all([
+        api.projects.get(po.project_id) as Promise<Project>,
+        api.companySettings.get(),
+        api.purchaseOrders.getReceivings(po.id),
+        import('@react-pdf/renderer'),
+        import('@/components/pdf/ReceivedPurchaseOrderPDF'),
+      ])
+      const blob = await pdf(
+        <ReceivedPurchaseOrderPDF
+          po={po}
+          receivings={freshReceivings}
+          project={project}
+          companySettings={companySettings}
+        />
+      ).toBlob()
+      const url = URL.createObjectURL(blob)
+      window.open(url, '_blank')
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to generate received PO PDF")
+    } finally {
+      setIsPrintingReceived(false)
+    }
+  }
+
   // ===== Receiving Mode Handlers =====
 
   const enterReceivingMode = () => {
     if (!canReceive) return
     setStagedReceivings(new Map())
     setReceivedDate(new Date().toISOString().split('T')[0])
+    setReceivingNotes("")
     setReceivingDialogOpen(true)
     setEditorMode("receiving")
   }
@@ -669,6 +715,7 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
   const exitReceivingMode = () => {
     setStagedReceivings(new Map())
     setReceivedDate(new Date().toISOString().split('T')[0])
+    setReceivingNotes("")
     setReceivingDialogOpen(false)
     setEditorMode("view")
   }
@@ -707,15 +754,18 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
 
     setIsSubmittingReceiving(true)
     try {
+      const trimmedNotes = receivingNotes.trim()
       const payload: POReceivingCreate = {
         received_date: `${receivedDate}T00:00:00`,
         line_items: receivingLineItems,
+        ...(trimmedNotes ? { notes: trimmedNotes } : {}),
       }
       await api.purchaseOrders.createReceiving(poId, payload)
 
       // Exit receiving mode and refresh
       exitReceivingMode()
       await fetchPO()
+      await fetchReceivings()
       onUpdate?.()
 
       // Check if all items are now received - auto-transition to "Received"
@@ -731,6 +781,13 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
     } finally {
       setIsSubmittingReceiving(false)
     }
+  }
+
+  const toggleExpandReceiving = (id: number) => {
+    const next = new Set(expandedReceivings)
+    if (next.has(id)) next.delete(id)
+    else next.add(id)
+    setExpandedReceivings(next)
   }
 
   // ===== Calculation Functions =====
@@ -1506,6 +1563,116 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
         </CardContent>
       </Card>
 
+      {/* Receiving History */}
+      {editorMode !== "edit" && receivings.length > 0 && (() => {
+        const activeReceivings = receivings.filter(r => !r.voided_at)
+        const sorted = [...receivings].sort(
+          (a, b) => new Date(b.received_date).getTime() - new Date(a.received_date).getTime()
+        )
+        return (
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <History className="h-4 w-4" />
+                Receiving History
+                <Badge variant="secondary" className="ml-2">
+                  {activeReceivings.length} receipt{activeReceivings.length !== 1 ? "s" : ""}
+                </Badge>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-2">
+                {sorted.map((rcv) => {
+                  const isExpanded = expandedReceivings.has(rcv.id)
+                  const isVoided = !!rcv.voided_at
+                  const totalQty = rcv.line_items.reduce(
+                    (s, l) => s + (l.qty_received_this_receiving ?? 0), 0
+                  )
+                  const totalValue = rcv.line_items.reduce((s, l) => {
+                    const price = l.actual_unit_price ?? l.unit_price ?? 0
+                    const qty = l.qty_received_this_receiving ?? 0
+                    return s + price * qty
+                  }, 0)
+
+                  return (
+                    <div
+                      key={rcv.id}
+                      className={`border rounded-md ${isVoided ? "opacity-60" : ""}`}
+                    >
+                      <button
+                        type="button"
+                        className="w-full flex items-center justify-between p-3 hover:bg-muted/50 text-left"
+                        onClick={() => toggleExpandReceiving(rcv.id)}
+                      >
+                        <div className="flex items-center gap-3">
+                          {isExpanded
+                            ? <ChevronDown className="h-4 w-4 shrink-0" />
+                            : <ChevronRight className="h-4 w-4 shrink-0" />}
+                          <div>
+                            <div className={`font-medium ${isVoided ? "line-through" : ""}`}>
+                              {formatDate(rcv.received_date)}
+                              {isVoided && (
+                                <span className="ml-2 text-xs font-normal text-muted-foreground no-underline">
+                                  (voided)
+                                </span>
+                              )}
+                            </div>
+                            {rcv.notes && (
+                              <div className="text-xs text-muted-foreground mt-0.5 truncate max-w-md">
+                                {rcv.notes}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-4 text-sm">
+                          <span className="text-muted-foreground">
+                            {totalQty} item{totalQty !== 1 ? "s" : ""}
+                          </span>
+                          <span className="font-medium">{formatCurrency(totalValue)}</span>
+                        </div>
+                      </button>
+
+                      {isExpanded && (
+                        <div className="border-t bg-muted/30 px-3 py-2">
+                          <Table>
+                            <TableHeader>
+                              <TableRow>
+                                <TableHead>Description</TableHead>
+                                <TableHead className="text-center">Qty Received</TableHead>
+                                <TableHead className="text-right">Actual Unit Price</TableHead>
+                                <TableHead className="text-right">Line Total</TableHead>
+                              </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                              {rcv.line_items.map((line) => {
+                                const match = po.line_items.find(li => li.id === line.po_line_item_id)
+                                const description = match
+                                  ? getLineItemDescription(match)
+                                  : (line.description || "Unknown item")
+                                const price = line.actual_unit_price ?? line.unit_price ?? 0
+                                const qty = line.qty_received_this_receiving ?? 0
+                                return (
+                                  <TableRow key={line.id}>
+                                    <TableCell>{description}</TableCell>
+                                    <TableCell className="text-center">{qty}</TableCell>
+                                    <TableCell className="text-right">{formatCurrency(price)}</TableCell>
+                                    <TableCell className="text-right">{formatCurrency(price * qty)}</TableCell>
+                                  </TableRow>
+                                )
+                              })}
+                            </TableBody>
+                          </Table>
+                        </div>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            </CardContent>
+          </Card>
+        )
+      })()}
+
       {/* Audit Trail */}
       {editorMode !== "edit" && (
         <POAuditTrail
@@ -1521,7 +1688,7 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
       {/* ===== Floating Action Buttons ===== */}
       <div className="fixed bottom-6 right-6 z-50">
         <div className="flex flex-col items-end gap-2">
-          {/* Secondary actions (Print / Clone) always reachable in view mode */}
+          {/* Secondary actions (Print / Print Received / Clone) always reachable in view mode */}
           {editorMode === "view" && (
             <div className="flex gap-2">
               <Button
@@ -1534,6 +1701,18 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
                 {isPrinting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Printer className="h-4 w-4" />}
                 {isPrinting ? "Generating..." : "Print"}
               </Button>
+              {hasBeenReceived && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handlePrintReceivedPO}
+                  disabled={isPrintingReceived}
+                  className="shadow-md gap-2 bg-background"
+                >
+                  {isPrintingReceived ? <Loader2 className="h-4 w-4 animate-spin" /> : <Receipt className="h-4 w-4" />}
+                  {isPrintingReceived ? "Generating..." : "Print Received"}
+                </Button>
+              )}
               <Button
                 variant="outline"
                 size="sm"
@@ -2007,6 +2186,21 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
                 value={receivedDate}
                 onChange={(e) => setReceivedDate(e.target.value)}
                 className="max-w-xs"
+              />
+            </div>
+
+            {/* Receiving Notes — optional context (packing slip #, condition, etc.) */}
+            <div className="space-y-2">
+              <Label className="flex items-center gap-1">
+                <FileText className="h-3 w-3" />
+                Notes <span className="text-xs text-muted-foreground">(optional)</span>
+              </Label>
+              <Textarea
+                value={receivingNotes}
+                onChange={(e) => setReceivingNotes(e.target.value)}
+                placeholder="Packing slip #, condition on arrival, delivered by, etc."
+                rows={2}
+                disabled={isSubmittingReceiving}
               />
             </div>
 

--- a/frontend/src/components/pdf/ReceivedPurchaseOrderPDF.tsx
+++ b/frontend/src/components/pdf/ReceivedPurchaseOrderPDF.tsx
@@ -1,0 +1,257 @@
+import { Document, Page, View, Text } from '@react-pdf/renderer'
+import { styles, BORDER_COLOR, HEADER_BG } from './styles'
+import { PDFHeader } from './PDFHeader'
+import { PDFFooter } from './PDFFooter'
+import { formatCurrency } from '@/lib/pricing'
+import type {
+  PurchaseOrder, POLineItem, POReceiving, Project, CompanySettings,
+} from '@/types'
+
+interface ReceivedPurchaseOrderPDFProps {
+  po: PurchaseOrder
+  receivings: POReceiving[]
+  project: Project
+  companySettings: CompanySettings
+}
+
+// Number of (qty, date) receipt pairs shown inline on each line item row.
+// Matches the legacy Vision-style PO layout; extras collapse to a "+N" hint.
+const INLINE_RECEIPT_SLOTS = 3
+
+function formatShortDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('en-CA', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
+function getItemDescription(item: POLineItem): string {
+  if (item.item_type === 'part' && item.part)
+    return `${item.part.part_number} - ${item.part.description}`
+  return item.description || 'Unknown item'
+}
+
+interface ReceiptEntry {
+  qty: number
+  date: string
+}
+
+// Build a chronologically-ordered list of receipts per line item.
+// Voided receivings are excluded so the PDF reflects the live ledger.
+function buildReceiptIndex(receivings: POReceiving[]): Map<number, ReceiptEntry[]> {
+  const index = new Map<number, ReceiptEntry[]>()
+  const active = receivings.filter(r => !r.voided_at)
+  const sorted = [...active].sort(
+    (a, b) => new Date(a.received_date).getTime() - new Date(b.received_date).getTime()
+  )
+  for (const receiving of sorted) {
+    for (const line of receiving.line_items) {
+      if (line.po_line_item_id == null) continue
+      const qty = line.qty_received_this_receiving ?? 0
+      if (qty <= 0) continue
+      const list = index.get(line.po_line_item_id) ?? []
+      list.push({ qty, date: receiving.received_date })
+      index.set(line.po_line_item_id, list)
+    }
+  }
+  return index
+}
+
+// Column widths for the receiving table (sums to 100%). Designed for landscape LETTER.
+const rcvCol = {
+  partNo: { width: '8%', fontSize: 7 } as const,
+  description: { width: '32%', fontSize: 7 } as const,
+  qtyOrd: { width: '5%', textAlign: 'center' as const, fontSize: 7 },
+  bo: { width: '5%', textAlign: 'center' as const, color: '#C00000', fontSize: 7 },
+  qtyRec: { width: '5%', textAlign: 'center' as const, fontSize: 7 },
+  date: { width: '8%', textAlign: 'center' as const, fontSize: 7 },
+  unitPrice: { width: '9%', textAlign: 'right' as const, fontSize: 7 },
+}
+
+function ReceivingTableHeader() {
+  return (
+    <View
+      style={[styles.tableHeader, { backgroundColor: HEADER_BG, borderColor: BORDER_COLOR }]}
+      fixed
+    >
+      <Text style={[styles.colHeaderText, rcvCol.partNo]}>Manuf. Part #</Text>
+      <Text style={[styles.colHeaderText, rcvCol.description]}>Product Description</Text>
+      <Text style={[styles.colHeaderText, rcvCol.qtyOrd]}>Qty.Ord.</Text>
+      <Text style={[styles.colHeaderText, rcvCol.bo, { color: '#333333' }]}>B.O.</Text>
+      <Text style={[styles.colHeaderText, rcvCol.qtyRec]}>Qty.Rec.</Text>
+      <Text style={[styles.colHeaderText, rcvCol.date]}>Date</Text>
+      <Text style={[styles.colHeaderText, rcvCol.qtyRec]}>Qty.Rec.</Text>
+      <Text style={[styles.colHeaderText, rcvCol.date]}>Date</Text>
+      <Text style={[styles.colHeaderText, rcvCol.qtyRec]}>Qty.Rec.</Text>
+      <Text style={[styles.colHeaderText, rcvCol.date]}>Date</Text>
+      <Text style={[styles.colHeaderText, rcvCol.unitPrice]}>Unit Price</Text>
+    </View>
+  )
+}
+
+function ReceivingLineRow({
+  item, receipts, alt,
+}: {
+  item: POLineItem
+  receipts: ReceiptEntry[]
+  alt: boolean
+}) {
+  const partNo = item.item_type === 'part' && item.part ? item.part.part_number : ''
+  const description = getItemDescription(item)
+  const unitPrice = item.unit_price ?? 0
+  const visible = receipts.slice(0, INLINE_RECEIPT_SLOTS)
+  const overflow = receipts.length - INLINE_RECEIPT_SLOTS
+
+  const slot = (i: number) => {
+    const r = visible[i]
+    const isLast = i === INLINE_RECEIPT_SLOTS - 1
+    const dateText = r ? formatShortDate(r.date) : ''
+    const overflowSuffix = isLast && overflow > 0 ? ` +${overflow}` : ''
+    return (
+      <>
+        <Text style={rcvCol.qtyRec}>{r ? r.qty : ''}</Text>
+        <Text style={rcvCol.date}>{`${dateText}${overflowSuffix}`}</Text>
+      </>
+    )
+  }
+
+  return (
+    <View style={[styles.tableRow, alt ? styles.tableRowAlt : {}]} wrap={false}>
+      <Text style={rcvCol.partNo}>{partNo}</Text>
+      <Text style={rcvCol.description}>{description}</Text>
+      <Text style={rcvCol.qtyOrd}>{item.quantity}</Text>
+      <Text style={rcvCol.bo}>{item.qty_pending}</Text>
+      {slot(0)}
+      {slot(1)}
+      {slot(2)}
+      <Text style={rcvCol.unitPrice}>{formatCurrency(unitPrice)}</Text>
+    </View>
+  )
+}
+
+export function ReceivedPurchaseOrderPDF({
+  po, receivings, project, companySettings,
+}: ReceivedPurchaseOrderPDFProps) {
+  const receiptIndex = buildReceiptIndex(receivings)
+
+  const orderedSubtotal = po.line_items.reduce(
+    (sum, item) => sum + (item.unit_price ?? 0) * item.quantity, 0
+  )
+  // Use actual price where captured by a receipt, otherwise fall back to PO unit price.
+  const receivedSubtotal = po.line_items.reduce((sum, item) => {
+    const effectivePrice = item.actual_unit_price ?? item.unit_price ?? 0
+    return sum + effectivePrice * item.qty_received
+  }, 0)
+  const hstRate = companySettings.hst_rate ?? 13.0
+  const receivedHst = receivedSubtotal * (hstRate / 100)
+  const receivedTotal = receivedSubtotal + receivedHst
+
+  const orderDate = new Date(po.created_at).toLocaleDateString('en-CA', {
+    day: '2-digit', month: 'short', year: 'numeric',
+  })
+  const expectedDelivery = po.expected_delivery_date
+    ? new Date(po.expected_delivery_date).toLocaleDateString('en-CA', {
+        day: '2-digit', month: 'short', year: 'numeric',
+      })
+    : null
+
+  return (
+    <Document>
+      <Page size="LETTER" orientation="landscape" style={styles.pageLandscape}>
+        {/* Header — full version on page 1 */}
+        <PDFHeader companySettings={companySettings} title="RECEIVED PO">
+          <View>
+            <View style={styles.metaRow}>
+              <Text style={styles.metaLabel}>PO #:</Text>
+              <Text style={styles.metaValue}>{po.po_number}</Text>
+            </View>
+            {po.vendor_po_number && (
+              <View style={styles.metaRow}>
+                <Text style={styles.metaLabel}>Vendor PO #:</Text>
+                <Text style={styles.metaValue}>{po.vendor_po_number}</Text>
+              </View>
+            )}
+            <View style={styles.metaRow}>
+              <Text style={styles.metaLabel}>Order Date:</Text>
+              <Text style={styles.metaValue}>{orderDate}</Text>
+            </View>
+            {expectedDelivery && (
+              <View style={styles.metaRow}>
+                <Text style={styles.metaLabel}>Date Required:</Text>
+                <Text style={styles.metaValue}>{expectedDelivery}</Text>
+              </View>
+            )}
+            <View style={styles.metaRow}>
+              <Text style={styles.metaLabel}>Status:</Text>
+              <Text style={styles.metaValue}>{po.status}</Text>
+            </View>
+          </View>
+        </PDFHeader>
+
+        {/* Vendor */}
+        <View style={styles.customerSection}>
+          <Text style={styles.customerLabel}>VENDOR:</Text>
+          <Text style={styles.customerName}>{po.vendor.name}</Text>
+          {po.vendor.address && <Text style={styles.customerAddress}>{po.vendor.address}</Text>}
+          {po.vendor.postal_code && <Text style={styles.customerAddress}>{po.vendor.postal_code}</Text>}
+        </View>
+
+        {/* Project Info */}
+        <View style={styles.projectRow}>
+          <View style={styles.projectField}>
+            <Text style={styles.bold}>UCA #:</Text>
+            <Text>{project.uca_project_number}</Text>
+          </View>
+          <View style={styles.projectField}>
+            <Text style={styles.bold}>Project:</Text>
+            <Text>{project.name}</Text>
+          </View>
+        </View>
+
+        {/* Work Description */}
+        {po.work_description && (
+          <View style={styles.workDescription}>
+            <Text style={[styles.bold, { marginBottom: 2 }]}>Work Description:</Text>
+            <Text>{po.work_description}</Text>
+          </View>
+        )}
+
+        {/* Receiving Table */}
+        <ReceivingTableHeader />
+        {po.line_items.map((item, idx) => (
+          <ReceivingLineRow
+            key={item.id}
+            item={item}
+            receipts={receiptIndex.get(item.id) ?? []}
+            alt={idx % 2 === 1}
+          />
+        ))}
+
+        {/* Totals */}
+        <View style={styles.totalsBlock}>
+          <View style={styles.totalsRow}>
+            <Text style={styles.totalsLabel}>Ordered Subtotal:</Text>
+            <Text style={styles.totalsValue}>{formatCurrency(orderedSubtotal)}</Text>
+          </View>
+          <View style={styles.totalsRow}>
+            <Text style={[styles.totalsLabel, styles.bold]}>Received Subtotal:</Text>
+            <Text style={styles.totalsValue}>{formatCurrency(receivedSubtotal)}</Text>
+          </View>
+          {hstRate > 0 && (
+            <View style={styles.totalsRow}>
+              <Text style={styles.totalsLabel}>HST ({hstRate}%):</Text>
+              <Text style={styles.totalsValue}>{formatCurrency(receivedHst)}</Text>
+            </View>
+          )}
+          <View style={styles.grandTotalRow}>
+            <Text style={[styles.totalsLabel, styles.bold]}>Received Total:</Text>
+            <Text style={[styles.totalsValue, styles.bold]}>{formatCurrency(receivedTotal)}</Text>
+          </View>
+        </View>
+
+        <PDFFooter leftText={`PO ${po.po_number} — Receiving Document`} />
+      </Page>
+    </Document>
+  )
+}


### PR DESCRIPTION
## Summary
- New `ReceivedPurchaseOrderPDF` (landscape) matching the legacy Vision-style layout the team prints today, with inline `(Qty.Rec, Date)` x3 columns per line item and a "+N" overflow hint when a line has more than 3 receipts.
- "Print Received" floating action button on `POEditor`, shown only when the PO has at least one non-zero receipt — sits next to the existing "Print" / "Clone" buttons.
- Receiving History card on the PO page that surfaces each receipt event (date, total qty, total value, optional notes) and expands to a per-line breakdown with actual unit prices and line totals. Voided receipts render struck-through.
- Notes textarea in the Receiving Dialog. The backend schema (`POReceivingCreate.notes`) already accepted notes; the only gap was the UI surface.

## Notes
- No backend, schema, or migration changes — the receiving model, endpoints, and aggregation logic were already complete; this PR fills in the UI/PDF surface.
- Bundle impact: a 5.8 KB code-split chunk that loads only when "Print Received" is clicked.

Fixes #79