### PR TITLE
fix(searchable-select): allow mouse wheel scroll inside dialog-wrapped popovers (#69)

### DIFF
--- a/frontend/src/components/ui/searchable-multi-select.tsx
+++ b/frontend/src/components/ui/searchable-multi-select.tsx
@@ -139,7 +139,7 @@ export function SearchableMultiSelect<T>({
               value={searchQuery}
               onValueChange={setSearchQuery}
             />
-            <CommandList>
+            <CommandList onWheel={(e) => e.stopPropagation()}>
               {filteredOptions.length === 0 && (
                 <CommandEmpty>{emptyMessage}</CommandEmpty>
               )}

--- a/frontend/src/components/ui/searchable-select.tsx
+++ b/frontend/src/components/ui/searchable-select.tsx
@@ -115,7 +115,7 @@ export function SearchableSelect<T>({
               value={searchQuery}
               onValueChange={setSearchQuery}
             />
-            <CommandList>
+            <CommandList onWheel={(e) => e.stopPropagation()}>
               {filteredOptions.length === 0 && (
                 <CommandEmpty>{emptyMessage}</CommandEmpty>
               )}

--- a/frontend/src/test/searchable-select-wheel.test.tsx
+++ b/frontend/src/test/searchable-select-wheel.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import { SearchableSelect } from '@/components/ui/searchable-select'
+
+// jsdom is missing several browser APIs that cmdk + Radix Popover rely on.
+// Stub them so the dropdown can render and the wheel event can fire.
+beforeAll(() => {
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  ;(globalThis as unknown as { ResizeObserver: typeof ResizeObserverMock }).ResizeObserver = ResizeObserverMock
+
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {}
+  }
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {}
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => {}
+  }
+})
+
+// Regression test for issue #69. When SearchableSelect is rendered inside a
+// Radix Dialog, react-remove-scroll cancels wheel events on the portaled
+// Popover content. The fix is `onWheel={e => e.stopPropagation()}` on the
+// CommandList — this test asserts that wheel events on the list do not bubble
+// past the SearchableSelect's React tree, which is the only contract we can
+// verify in jsdom (jsdom does not perform real scroll).
+describe('SearchableSelect — wheel propagation (issue #69)', () => {
+  it('stops wheel events from propagating past the dropdown list', async () => {
+    const onWheelOutside = vi.fn()
+    const { getByRole } = render(
+      <div onWheel={onWheelOutside}>
+        <SearchableSelect
+          options={[
+            { value: '1', label: 'Option 1' },
+            { value: '2', label: 'Option 2' },
+            { value: '3', label: 'Option 3' },
+          ]}
+          value={undefined}
+          onChange={() => {}}
+        />
+      </div>
+    )
+
+    fireEvent.click(getByRole('combobox'))
+
+    const list = await waitFor(() => {
+      const el = document.querySelector('[cmdk-list]')
+      if (!el) throw new Error('CommandList not yet rendered')
+      return el as HTMLElement
+    })
+
+    fireEvent.wheel(list, { deltaY: 100 })
+
+    expect(onWheelOutside).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #69 — mouse wheel scroll did nothing when adding a part to a Purchase Order (and in several other dropdowns that share the same primitive).

## Root cause

The shared `SearchableSelect` (and `SearchableMultiSelect`) renders its options list inside a Radix `Popover`, whose content is portaled to `document.body`. When the component is used inside a Radix `Dialog` — which the PO/Quote/Project add-item flows all do — Radix Dialog uses `react-remove-scroll` to lock body scrolling. That library attaches a document-level `wheel` listener that calls `preventDefault()` on any wheel event outside the Dialog's scroll-allowed subtree. Because the portaled popover content lives outside that subtree, every wheel event on the parts list was cancelled.

Scrollbar drag still worked because it uses pointer events, not wheel events — exactly the asymmetry the bug report described.

## Fix

`onWheel={(e) => e.stopPropagation()}` on `<CommandList>` in both `searchable-select.tsx` and `searchable-multi-select.tsx`. Native scroll happens in the overflow container before the React event bubbles, so the only thing being suppressed is the Dialog's wheel-lock `preventDefault`. The change is a no-op outside a Dialog (e.g. `ReportsPage`'s project filter).

## Affected dropdowns (all benefit from the shared-component fix)

- `POEditor` Add Part picker (the reported issue)
- `QuoteEditor` Add Labour picker
- `QuoteEditor` Add Misc picker
- `ProjectForm` Customer picker
- Any future `SearchableSelect` / `SearchableMultiSelect` rendered inside a Dialog