### PR TITLE
fix(po): searchable vendor picker with inline create in Create PO dialog (#68)

### DIFF
--- a/frontend/src/components/forms/ProfileForm.tsx
+++ b/frontend/src/components/forms/ProfileForm.tsx
@@ -36,7 +36,7 @@ interface ContactFormData {
 interface ProfileFormProps {
   profile?: Profile // If provided, we're editing; otherwise creating
   defaultType?: ProfileType
-  onSuccess?: () => void
+  onSuccess?: (profile?: Profile) => void
   onCancel?: () => void
 }
 
@@ -224,7 +224,9 @@ export function ProfileForm({ profile, defaultType = "customer", onSuccess, onCa
           default_discount_percent: defaultDiscountPercent ? parseFloat(defaultDiscountPercent) : undefined,
           contacts: contacts.map(buildContactCreate)
         }
-        await api.profiles.create(profileData)
+        const created = await api.profiles.create(profileData)
+        onSuccess?.(created)
+        return
       }
       onSuccess?.()
     } catch (err) {

--- a/frontend/src/pages/ProjectDetailsPage.tsx
+++ b/frontend/src/pages/ProjectDetailsPage.tsx
@@ -23,13 +23,9 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import { SearchableSelect } from "@/components/ui/searchable-select"
+import type { SearchableSelectOption } from "@/components/ui/searchable-select"
+import { ProfileForm } from "@/components/forms/ProfileForm"
 import { Label } from "@/components/ui/label"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import {
@@ -754,29 +750,30 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
           <div className="space-y-4 pt-4">
             <div className="space-y-2">
               <Label>Vendor</Label>
-              {vendors.length === 0 ? (
-                <p className="text-sm text-muted-foreground">
-                  No vendors found. Please create a vendor first.
-                </p>
-              ) : (
-                <Select value={selectedVendorId} onValueChange={setSelectedVendorId}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select a vendor" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {vendors.map((vendor) => (
-                      <SelectItem key={vendor.id} value={vendor.id.toString()}>
-                        {vendor.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              )}
+              <SearchableSelect<Profile>
+                options={vendors.map((vendor): SearchableSelectOption => ({
+                  value: vendor.id.toString(),
+                  label: vendor.name,
+                }))}
+                value={selectedVendorId}
+                onChange={setSelectedVendorId}
+                placeholder="Select a vendor"
+                searchPlaceholder="Search vendors..."
+                emptyMessage="No vendors found."
+                allowCreate={true}
+                createLabel="Create New Vendor"
+                createDialogTitle="Create New Vendor"
+                createForm={<ProfileForm defaultType="vendor" />}
+                onCreateSuccess={(newVendor) => {
+                  setVendors([...vendors, newVendor])
+                  setSelectedVendorId(newVendor.id.toString())
+                }}
+              />
             </div>
             <Button
               onClick={handleCreatePO}
               className="w-full"
-              disabled={!selectedVendorId || vendors.length === 0}
+              disabled={!selectedVendorId}
             >
               Create Purchase Order
             </Button>


### PR DESCRIPTION
## Summary

Fixes #68 — vendor picker in the Create PO dialog could not be searched or mouse-wheel scrolled.

## Root cause

The vendor picker at `ProjectDetailsPage.tsx:746` used the Radix `<Select>` primitive, which:

1. **Has no search input by design** — explaining "cannot search". Every other picker in the app (parts, labour, miscellaneous, customer) uses `SearchableSelect` for exactly this reason; vendor was the odd one out.
2. **Cannot be wheel-scrolled inside a Radix Dialog** — same `react-remove-scroll` interaction documented in #69, but on Radix Select's portaled content instead of cmdk's `CommandList`. The #69 fix is component-specific and does not apply.

## Fix

- **`ProjectDetailsPage.tsx`** — replace the Radix `<Select>` vendor picker with `<SearchableSelect>`, mirroring the customer picker pattern in `ProjectForm.tsx`. Inherits the wheel-scroll fix from #69 (via `CommandList onWheel stopPropagation`). Includes inline "Create New Vendor" via `<ProfileForm defaultType="vendor" />`, matching the inline-create-customer pattern.

- **`ProfileForm.tsx`** — fix a latent bug: `onSuccess` was called with no args, so `SearchableSelect.onCreateSuccess` consumers received `undefined` as the newly-created profile (the existing inline-create-customer flow in `ProjectForm` had this bug too, just untested in practice). Capture the result of `api.profiles.create` and pass it through `onSuccess(created)`. The signature change `() => void` → `(profile?: Profile) => void` is backward-compatible: the arg is optional, so existing callers like `ProfilesPage` continue to work unchanged.