### PR TITLE
feat(pdf): print options dialog to include or hide line-item breakdown

### DIFF
--- a/frontend/src/components/editors/POEditor.tsx
+++ b/frontend/src/components/editors/POEditor.tsx
@@ -138,6 +138,7 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
 
   // Print PDF state
   const [isPrinting, setIsPrinting] = useState(false)
+  const [printDialogOpen, setPrintDialogOpen] = useState(false)
 
   // ===== Cost Codes =====
   const [costCodes, setCostCodes] = useState<CostCode[]>([])
@@ -651,8 +652,9 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
 
   // ===== Print PO Handler =====
 
-  const handlePrintPO = async () => {
+  const runPrintPO = async (includeBreakdown: boolean) => {
     if (!po) return
+    setPrintDialogOpen(false)
     setIsPrinting(true)
     try {
       const [project, companySettings, { pdf }, { PurchaseOrderPDF }] = await Promise.all([
@@ -662,7 +664,12 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
         import('@/components/pdf/PurchaseOrderPDF'),
       ])
       const blob = await pdf(
-        <PurchaseOrderPDF po={po} project={project} companySettings={companySettings} />
+        <PurchaseOrderPDF
+          po={po}
+          project={project}
+          companySettings={companySettings}
+          includeBreakdown={includeBreakdown}
+        />
       ).toBlob()
       const url = URL.createObjectURL(blob)
       window.open(url, '_blank')
@@ -1694,7 +1701,7 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
               <Button
                 variant="outline"
                 size="sm"
-                onClick={handlePrintPO}
+                onClick={() => setPrintDialogOpen(true)}
                 disabled={isPrinting}
                 className="shadow-md gap-2 bg-background"
               >
@@ -2140,6 +2147,48 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* Print Options Dialog */}
+      <Dialog open={printDialogOpen} onOpenChange={setPrintDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Printer className="h-4 w-4" />
+              Print Purchase Order
+            </DialogTitle>
+            <DialogDescription>
+              Choose how line items appear in the printout.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 pt-2">
+            <button
+              type="button"
+              onClick={() => runPrintPO(true)}
+              className="w-full text-left p-4 rounded-md border bg-background hover:bg-accent transition-colors"
+            >
+              <div className="font-medium">Include line-item breakdown</div>
+              <div className="text-sm text-muted-foreground mt-1">
+                Show each item's description, quantity, unit price, and per-item total, along with section subtotals.
+              </div>
+            </button>
+            <button
+              type="button"
+              onClick={() => runPrintPO(false)}
+              className="w-full text-left p-4 rounded-md border bg-background hover:bg-accent transition-colors"
+            >
+              <div className="font-medium">Section totals only</div>
+              <div className="text-sm text-muted-foreground mt-1">
+                Hide per-item rows and show only the Parts and Miscellaneous subtotals.
+              </div>
+            </button>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPrintDialogOpen(false)}>
+              Cancel
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Clone Confirmation Dialog */}
       <AlertDialog open={cloneConfirmOpen} onOpenChange={setCloneConfirmOpen}>

--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -176,6 +176,7 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
 
   // Print PDF state
   const [isPrinting, setIsPrinting] = useState(false)
+  const [printDialogOpen, setPrintDialogOpen] = useState(false)
 
   // Company settings (for HST rate display)
   const [companySettings, setCompanySettings] = useState<CompanySettings | null>(null)
@@ -1943,8 +1944,9 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
     }
   }
 
-  const handlePrintQuote = async () => {
+  const runPrintQuote = async (includeBreakdown: boolean) => {
     if (!quote) return
+    setPrintDialogOpen(false)
     setIsPrinting(true)
     try {
       const [project, companySettings, { pdf }, { QuotePDF }] = await Promise.all([
@@ -1954,7 +1956,12 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
         import('@/components/pdf/QuotePDF'),
       ])
       const blob = await pdf(
-        <QuotePDF quote={quote} project={project} companySettings={companySettings} />
+        <QuotePDF
+          quote={quote}
+          project={project}
+          companySettings={companySettings}
+          includeBreakdown={includeBreakdown}
+        />
       ).toBlob()
       const url = URL.createObjectURL(blob)
       window.open(url, '_blank')
@@ -3172,7 +3179,7 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
               <Button
                 variant="outline"
                 size="sm"
-                onClick={handlePrintQuote}
+                onClick={() => setPrintDialogOpen(true)}
                 disabled={isPrinting}
                 className="shadow-md gap-2 bg-background"
               >
@@ -3478,6 +3485,48 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
             </Button>
             <Button onClick={handleConfirmAutoAddLabor}>
               Add Part + Labour
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Print Options Dialog */}
+      <Dialog open={printDialogOpen} onOpenChange={setPrintDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Printer className="h-4 w-4" />
+              Print Quote
+            </DialogTitle>
+            <DialogDescription>
+              Choose how line items appear in the printout.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 pt-2">
+            <button
+              type="button"
+              onClick={() => runPrintQuote(true)}
+              className="w-full text-left p-4 rounded-md border bg-background hover:bg-accent transition-colors"
+            >
+              <div className="font-medium">Include line-item breakdown</div>
+              <div className="text-sm text-muted-foreground mt-1">
+                Show each item's description, quantity, unit price, and per-item total, along with section subtotals.
+              </div>
+            </button>
+            <button
+              type="button"
+              onClick={() => runPrintQuote(false)}
+              className="w-full text-left p-4 rounded-md border bg-background hover:bg-accent transition-colors"
+            >
+              <div className="font-medium">Section totals only</div>
+              <div className="text-sm text-muted-foreground mt-1">
+                Hide per-item rows and show only the Parts, Labour, and Miscellaneous subtotals.
+              </div>
+            </button>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPrintDialogOpen(false)}>
+              Cancel
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/components/pdf/PurchaseOrderPDF.tsx
+++ b/frontend/src/components/pdf/PurchaseOrderPDF.tsx
@@ -9,14 +9,17 @@ interface PurchaseOrderPDFProps {
   po: PurchaseOrder
   project: Project
   companySettings: CompanySettings
+  includeBreakdown?: boolean
 }
 
 function LineItemTable({
   title,
   items,
+  showLineDetails,
 }: {
   title: string
   items: POLineItem[]
+  showLineDetails: boolean
 }) {
   if (items.length === 0) return null
 
@@ -29,33 +32,37 @@ function LineItemTable({
     <>
       <Text style={styles.sectionTitle}>{title}</Text>
 
-      {/* Table header */}
-      <View style={styles.tableHeader}>
-        <Text style={[styles.colHeaderText, styles.colDescription]}>Description</Text>
-        <Text style={[styles.colHeaderText, styles.colQty]}>Qty</Text>
-        <Text style={[styles.colHeaderText, styles.colUnitPrice]}>Unit Price</Text>
-        <Text style={[styles.colHeaderText, styles.colTotal]}>Total</Text>
-      </View>
-
-      {/* Table rows */}
-      {items.map((item, idx) => {
-        const description = getItemDescription(item)
-        const unitPrice = item.unit_price ?? 0
-        const total = unitPrice * item.quantity
-
-        return (
-          <View
-            key={item.id}
-            style={[styles.tableRow, idx % 2 === 1 ? styles.tableRowAlt : {}]}
-            wrap={false}
-          >
-            <Text style={styles.colDescription}>{description}</Text>
-            <Text style={styles.colQty}>{item.quantity}</Text>
-            <Text style={styles.colUnitPrice}>{formatCurrency(unitPrice)}</Text>
-            <Text style={styles.colTotal}>{formatCurrency(total)}</Text>
+      {showLineDetails && (
+        <>
+          {/* Table header */}
+          <View style={styles.tableHeader}>
+            <Text style={[styles.colHeaderText, styles.colDescription]}>Description</Text>
+            <Text style={[styles.colHeaderText, styles.colQty]}>Qty</Text>
+            <Text style={[styles.colHeaderText, styles.colUnitPrice]}>Unit Price</Text>
+            <Text style={[styles.colHeaderText, styles.colTotal]}>Total</Text>
           </View>
-        )
-      })}
+
+          {/* Table rows */}
+          {items.map((item, idx) => {
+            const description = getItemDescription(item)
+            const unitPrice = item.unit_price ?? 0
+            const total = unitPrice * item.quantity
+
+            return (
+              <View
+                key={item.id}
+                style={[styles.tableRow, idx % 2 === 1 ? styles.tableRowAlt : {}]}
+                wrap={false}
+              >
+                <Text style={styles.colDescription}>{description}</Text>
+                <Text style={styles.colQty}>{item.quantity}</Text>
+                <Text style={styles.colUnitPrice}>{formatCurrency(unitPrice)}</Text>
+                <Text style={styles.colTotal}>{formatCurrency(total)}</Text>
+              </View>
+            )
+          })}
+        </>
+      )}
 
       {/* Section subtotal */}
       <View style={styles.tableFooterRow}>
@@ -74,7 +81,7 @@ function getItemDescription(item: POLineItem): string {
   return item.description || 'Unknown item'
 }
 
-export function PurchaseOrderPDF({ po, project, companySettings }: PurchaseOrderPDFProps) {
+export function PurchaseOrderPDF({ po, project, companySettings, includeBreakdown = true }: PurchaseOrderPDFProps) {
   const partItems = po.line_items.filter(i => i.item_type === 'part')
   const miscItems = po.line_items.filter(i => i.item_type === 'misc')
 
@@ -166,8 +173,8 @@ export function PurchaseOrderPDF({ po, project, companySettings }: PurchaseOrder
         )}
 
         {/* Line Items by Section */}
-        <LineItemTable title="Parts" items={partItems} />
-        <LineItemTable title="Miscellaneous" items={miscItems} />
+        <LineItemTable title="Parts" items={partItems} showLineDetails={includeBreakdown} />
+        <LineItemTable title="Miscellaneous" items={miscItems} showLineDetails={includeBreakdown} />
 
         {/* Totals */}
         <View style={styles.totalsBlock}>

--- a/frontend/src/components/pdf/QuotePDF.tsx
+++ b/frontend/src/components/pdf/QuotePDF.tsx
@@ -16,6 +16,7 @@ interface QuotePDFProps {
   quote: Quote
   project: Project
   companySettings: CompanySettings
+  includeBreakdown?: boolean
 }
 
 function LineItemTable({
@@ -23,11 +24,13 @@ function LineItemTable({
   items,
   nonPmsTotal,
   useEffective,
+  showLineDetails,
 }: {
   title: string
   items: QuoteLineItem[]
   nonPmsTotal: number
   useEffective?: boolean
+  showLineDetails: boolean
 }) {
   if (items.length === 0) return null
 
@@ -41,40 +44,44 @@ function LineItemTable({
     <>
       <Text style={styles.sectionTitle}>{title}</Text>
 
-      {/* Table header */}
-      <View style={styles.tableHeader}>
-        <Text style={[styles.colHeaderText, styles.colDescription]}>Description</Text>
-        <Text style={[styles.colHeaderText, styles.colQty]}>Qty</Text>
-        <Text style={[styles.colHeaderText, styles.colUnitPrice]}>Unit Price</Text>
-        <Text style={[styles.colHeaderText, styles.colTotal]}>Total</Text>
-      </View>
-
-      {/* Table rows */}
-      {items.map((item, idx) => {
-        const description = getItemDescription(item)
-        const unitPrice = useEffective && item.is_pms && item.pms_percent != null
-          ? nonPmsTotal * item.pms_percent / 100
-          : getLineItemUnitPrice(item)
-        const total = useEffective
-          ? getEffectiveLineItemTotal(item, nonPmsTotal)
-          : getLineItemTotal(item)
-
-        return (
-          <View
-            key={item.id}
-            style={[styles.tableRow, idx % 2 === 1 ? styles.tableRowAlt : {}]}
-            wrap={false}
-          >
-            <Text style={styles.colDescription}>
-              {description}
-              {item.is_pms && item.pms_percent != null ? ` (PMS ${item.pms_percent}%)` : ''}
-            </Text>
-            <Text style={styles.colQty}>{item.quantity}</Text>
-            <Text style={styles.colUnitPrice}>{formatCurrency(unitPrice)}</Text>
-            <Text style={styles.colTotal}>{formatCurrency(total)}</Text>
+      {showLineDetails && (
+        <>
+          {/* Table header */}
+          <View style={styles.tableHeader}>
+            <Text style={[styles.colHeaderText, styles.colDescription]}>Description</Text>
+            <Text style={[styles.colHeaderText, styles.colQty]}>Qty</Text>
+            <Text style={[styles.colHeaderText, styles.colUnitPrice]}>Unit Price</Text>
+            <Text style={[styles.colHeaderText, styles.colTotal]}>Total</Text>
           </View>
-        )
-      })}
+
+          {/* Table rows */}
+          {items.map((item, idx) => {
+            const description = getItemDescription(item)
+            const unitPrice = useEffective && item.is_pms && item.pms_percent != null
+              ? nonPmsTotal * item.pms_percent / 100
+              : getLineItemUnitPrice(item)
+            const total = useEffective
+              ? getEffectiveLineItemTotal(item, nonPmsTotal)
+              : getLineItemTotal(item)
+
+            return (
+              <View
+                key={item.id}
+                style={[styles.tableRow, idx % 2 === 1 ? styles.tableRowAlt : {}]}
+                wrap={false}
+              >
+                <Text style={styles.colDescription}>
+                  {description}
+                  {item.is_pms && item.pms_percent != null ? ` (PMS ${item.pms_percent}%)` : ''}
+                </Text>
+                <Text style={styles.colQty}>{item.quantity}</Text>
+                <Text style={styles.colUnitPrice}>{formatCurrency(unitPrice)}</Text>
+                <Text style={styles.colTotal}>{formatCurrency(total)}</Text>
+              </View>
+            )
+          })}
+        </>
+      )}
 
       {/* Section subtotal */}
       <View style={styles.tableFooterRow}>
@@ -95,7 +102,7 @@ function getItemDescription(item: QuoteLineItem): string {
   return item.description || 'Unknown item'
 }
 
-export function QuotePDF({ quote, project, companySettings }: QuotePDFProps) {
+export function QuotePDF({ quote, project, companySettings, includeBreakdown = true }: QuotePDFProps) {
   const partItems = quote.line_items.filter(i => i.item_type === 'part')
   const laborItems = quote.line_items.filter(i => i.item_type === 'labor')
   const miscItems = quote.line_items.filter(i => i.item_type === 'misc')
@@ -166,9 +173,9 @@ export function QuotePDF({ quote, project, companySettings }: QuotePDFProps) {
         )}
 
         {/* Line Items by Section */}
-        <LineItemTable title="Parts" items={partItems} nonPmsTotal={nonPmsTotal} />
-        <LineItemTable title="Labour" items={laborItems} nonPmsTotal={nonPmsTotal} useEffective />
-        <LineItemTable title="Miscellaneous" items={miscItems} nonPmsTotal={nonPmsTotal} />
+        <LineItemTable title="Parts" items={partItems} nonPmsTotal={nonPmsTotal} showLineDetails={includeBreakdown} />
+        <LineItemTable title="Labour" items={laborItems} nonPmsTotal={nonPmsTotal} useEffective showLineDetails={includeBreakdown} />
+        <LineItemTable title="Miscellaneous" items={miscItems} nonPmsTotal={nonPmsTotal} showLineDetails={includeBreakdown} />
 
         {/* Totals */}
         <View style={styles.totalsBlock}>


### PR DESCRIPTION
## Summary
- Adds `includeBreakdown` prop to `QuotePDF` and `PurchaseOrderPDF`. When `true` (default), table renders unit prices and per-item totals as today. When `false`, table renders section title + subtotal only, hiding all per-item rows.
- Adds a print options dialog in `QuoteEditor` and `POEditor` — clicking Print now opens a dialog with two big choice buttons ("Include line-item breakdown" / "Section totals only") that immediately trigger the PDF.
- Section subtotals, work description, header, customer/vendor block, and final SUBTOTAL/HST/TOTAL block are unchanged in both modes.
- `ReceivedPurchaseOrderPDF` is intentionally untouched — it's a receiving audit trail, not a quote/PO presentation.

Fixes #55