### PR TITLE
feat(quotes): hardware schedule version field; sidebar list sub-data

### DIFF
--- a/backend/alembic/versions/20260527_020_add_hardware_schedule_version.py
+++ b/backend/alembic/versions/20260527_020_add_hardware_schedule_version.py
@@ -4,7 +4,11 @@ Adds a nullable free-text field on `quotes` modeled after `work_description`.
 The value is surfaced in the Quote editor (#52) and in the project sidebar
 quote list sub-data (#53).
 
-Revision ID: 020_add_hardware_schedule_version
+Note: revision id is intentionally short — alembic_version.version_num is
+VARCHAR(32) by default, so the full "020_add_hardware_schedule_version" name
+would overflow on insert.
+
+Revision ID: 020_hardware_schedule_ver
 Revises: 019_destructive_data_hygiene
 Create Date: 2026-05-27
 """
@@ -12,7 +16,7 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision = '020_add_hardware_schedule_version'
+revision = '020_hardware_schedule_ver'
 down_revision = '019_destructive_data_hygiene'
 branch_labels = None
 depends_on = None

--- a/backend/alembic/versions/20260527_020_add_hardware_schedule_version.py
+++ b/backend/alembic/versions/20260527_020_add_hardware_schedule_version.py
@@ -1,0 +1,29 @@
+"""Add hardware_schedule_version column to quotes
+
+Adds a nullable free-text field on `quotes` modeled after `work_description`.
+The value is surfaced in the Quote editor (#52) and in the project sidebar
+quote list sub-data (#53).
+
+Revision ID: 020_add_hardware_schedule_version
+Revises: 019_destructive_data_hygiene
+Create Date: 2026-05-27
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '020_add_hardware_schedule_version'
+down_revision = '019_destructive_data_hygiene'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute(sa.text(
+        "ALTER TABLE quotes ADD COLUMN IF NOT EXISTS hardware_schedule_version VARCHAR"
+    ))
+
+
+def downgrade():
+    op.drop_column('quotes', 'hardware_schedule_version')

--- a/backend/models.py
+++ b/backend/models.py
@@ -174,6 +174,7 @@ class Quote(Base):
     current_version = Column(Integer, default=0)  # Current snapshot version
     client_po_number = Column(String, nullable=True)  # Client's PO number (required for invoicing)
     work_description = Column(String, nullable=True)  # Optional work description
+    hardware_schedule_version = Column(String, nullable=True)  # Optional hardware schedule version identifier
     markup_control_enabled = Column(Boolean, default=False)  # Markup Discount Control toggle
     parts_markup_percent = Column(Float, nullable=True)  # Section-level markup for parts
     labor_markup_percent = Column(Float, nullable=True)  # Section-level markup for labor

--- a/backend/routes/quotes.py
+++ b/backend/routes/quotes.py
@@ -383,6 +383,9 @@ def update_quote(quote_id: int, quote_data: QuoteUpdate, db: Session = Depends(g
     if quote_data.work_description is not None:
         db_quote.work_description = quote_data.work_description.strip() or None
 
+    if quote_data.hardware_schedule_version is not None:
+        db_quote.hardware_schedule_version = quote_data.hardware_schedule_version.strip() or None
+
     if quote_data.cost_code_id is not None:
         db_quote.cost_code_id = quote_data.cost_code_id
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -491,6 +491,7 @@ class QuoteBase(BaseModel):
     status: str = "Draft"  # "Draft", "Work Order", "Invoiced", "Closed" — computed by system
     client_po_number: Optional[str] = None
     work_description: Optional[str] = None
+    hardware_schedule_version: Optional[str] = None
     markup_control_enabled: bool = False  # Markup Discount Control toggle
     parts_markup_percent: Optional[float] = None  # Section-level markup for parts
     labor_markup_percent: Optional[float] = None  # Section-level markup for labor
@@ -501,12 +502,14 @@ class QuoteCreate(BaseModel):
     project_id: int
     client_po_number: Optional[str] = None
     work_description: Optional[str] = None
+    hardware_schedule_version: Optional[str] = None
     cost_code_id: Optional[int] = None
 
 
 class QuoteUpdate(BaseModel):
     client_po_number: Optional[str] = None
     work_description: Optional[str] = None
+    hardware_schedule_version: Optional[str] = None
     cost_code_id: Optional[int] = None
 
 

--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -142,6 +142,11 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
   const [isEditingWorkDescription, setIsEditingWorkDescription] = useState(false)
   const [savingWorkDescription, setSavingWorkDescription] = useState(false)
 
+  // Hardware Schedule Version editing
+  const [hardwareScheduleVersion, setHardwareScheduleVersion] = useState("")
+  const [isEditingHardwareScheduleVersion, setIsEditingHardwareScheduleVersion] = useState(false)
+  const [savingHardwareScheduleVersion, setSavingHardwareScheduleVersion] = useState(false)
+
   // PMS (Project Management Services) dialog states
   const [pmsDialogOpen, setPmsDialogOpen] = useState(false)
   const [pmsType, setPmsType] = useState<"percent" | "dollar">("dollar")
@@ -244,6 +249,7 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
       setQuote(data)
       setClientPoNumber(data.client_po_number || "")
       setWorkDescription(data.work_description || "")
+      setHardwareScheduleVersion(data.hardware_schedule_version || "")
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to fetch quote")
     } finally {
@@ -724,6 +730,7 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
           setQuote(freshQuote)
           setClientPoNumber(freshQuote.client_po_number || "")
           setWorkDescription(freshQuote.work_description || "")
+          setHardwareScheduleVersion(freshQuote.hardware_schedule_version || "")
           setEditModeStartVersion(freshQuote.current_version)
           setQuoteChangedDialogOpen(true)
           setIsCommitting(false)
@@ -828,6 +835,20 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
       alert(err instanceof Error ? err.message : "Failed to update Work Description")
     } finally {
       setSavingWorkDescription(false)
+    }
+  }
+
+  const handleSaveHardwareScheduleVersion = async () => {
+    setSavingHardwareScheduleVersion(true)
+    try {
+      await api.quotes.update(quoteId, { hardware_schedule_version: hardwareScheduleVersion.trim() || null })
+      setIsEditingHardwareScheduleVersion(false)
+      fetchQuote()
+      onUpdate?.()
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to update Hardware Schedule Version")
+    } finally {
+      setSavingHardwareScheduleVersion(false)
     }
   }
 
@@ -1780,6 +1801,7 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
           setQuote(freshQuote)
           setClientPoNumber(freshQuote.client_po_number || "")
           setWorkDescription(freshQuote.work_description || "")
+          setHardwareScheduleVersion(freshQuote.hardware_schedule_version || "")
           setInitialQuoteVersion(freshQuote.current_version)
           setQuoteChangedDialogOpen(true)
           setIsCreatingInvoice(false)
@@ -2898,6 +2920,59 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
               {/* Edit button only visible in Edit mode */}
               {editorMode === "edit" && (
                 <Button size="sm" variant="ghost" onClick={() => setIsEditingWorkDescription(true)}>
+                  <Pencil className="h-4 w-4" />
+                </Button>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Hardware Schedule Version */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2">
+            <FileText className="h-4 w-4" />
+            Hardware Schedule Version
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isEditingHardwareScheduleVersion ? (
+            <div className="space-y-2">
+              <Input
+                value={hardwareScheduleVersion}
+                onChange={(e) => setHardwareScheduleVersion(e.target.value)}
+                placeholder="e.g. Rev A"
+              />
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  onClick={handleSaveHardwareScheduleVersion}
+                  disabled={savingHardwareScheduleVersion}
+                >
+                  {savingHardwareScheduleVersion ? "Saving..." : "Save"}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    setHardwareScheduleVersion(quote.hardware_schedule_version || "")
+                    setIsEditingHardwareScheduleVersion(false)
+                  }}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="flex items-start gap-2">
+              {quote.hardware_schedule_version ? (
+                <p className="whitespace-pre-wrap">{quote.hardware_schedule_version}</p>
+              ) : (
+                <span className="text-muted-foreground" title={editorMode === "edit" ? "Click pencil to set" : undefined}>—</span>
+              )}
+              {editorMode === "edit" && (
+                <Button size="sm" variant="ghost" onClick={() => setIsEditingHardwareScheduleVersion(true)}>
                   <Pencil className="h-4 w-4" />
                 </Button>
               )}

--- a/frontend/src/pages/ProjectDetailsPage.tsx
+++ b/frontend/src/pages/ProjectDetailsPage.tsx
@@ -399,7 +399,8 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
       const hay = [
         q.quote_number,
         q.status,
-        new Date(q.created_at).toLocaleDateString(),
+        q.client_po_number ?? "",
+        q.hardware_schedule_version ?? "",
       ].join(" ").toLowerCase()
       return hay.includes(n)
     })
@@ -841,7 +842,7 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
               {project.quotes.map((q) => (
                 <CommandItem
                   key={`q-${q.id}`}
-                  value={`quote ${q.quote_number} ${q.status} ${formatDate(q.created_at)}`}
+                  value={`quote ${q.quote_number} ${q.status} ${q.client_po_number ?? ""} ${q.hardware_schedule_version ?? ""}`}
                   onSelect={() => {
                     setCmdOpen(false)
                     openDoc("quote", q.id)
@@ -931,8 +932,11 @@ function QuoteRow({ quote, isSelected, isHighlighted, onSelect, onDelete }: Quot
           <span className="truncate">{quote.quote_number}</span>
           <StatusBadge status={quote.status} className="text-[10px] px-1.5 py-0" />
         </div>
-        <div className="text-xs text-muted-foreground">
-          {formatDate(quote.created_at)}
+        <div className="text-xs text-muted-foreground truncate">
+          PO# {quote.client_po_number || "—"}
+        </div>
+        <div className="text-xs text-muted-foreground truncate">
+          HW Schedule {quote.hardware_schedule_version || "—"}
         </div>
       </div>
       <Button

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -405,6 +405,7 @@ export interface Quote {
   current_version: number;
   client_po_number?: string | null;
   work_description?: string | null;
+  hardware_schedule_version?: string | null;
   markup_control_enabled: boolean;  // Markup Control toggle
   parts_markup_percent?: number | null;  // Section-level markup for parts
   labor_markup_percent?: number | null;  // Section-level markup for labor
@@ -419,12 +420,14 @@ export interface QuoteCreate {
   project_id: number;
   client_po_number?: string;
   work_description?: string;
+  hardware_schedule_version?: string;
   cost_code_id?: number;
 }
 
 export interface QuoteUpdate {
   client_po_number?: string | null;
   work_description?: string | null;
+  hardware_schedule_version?: string | null;
   cost_code_id?: number | null;
 }
 


### PR DESCRIPTION
## Summary
- Adds a `hardware_schedule_version` nullable text column on `quotes`, mirroring the `work_description` pattern end-to-end (model, schemas, route, types, editor card with immediate-save).
- Updates the project sidebar quote list (`QuoteRow` in `ProjectDetailsPage.tsx`) to remove the creation date and show **Client PO Number** and **Hardware Schedule Version** on separate lines. Filter hay and ⌘K command-palette search values updated to match.
- Migration `020_add_hardware_schedule_version` uses `ADD COLUMN IF NOT EXISTS` for safety; matching downgrade drops the column.

Fixes #52
Fixes #53

## Deploy note
This PR contains a schema change. Set `ALEMBIC_AUTO_UPGRADE=1` on the Railway backend service for this deploy so the migration actually runs against the live database — without it the column is never created and any read/write touching `hardware_schedule_version` will 500.