### PR TITLE
fix(pdf): quantities-only print mode lists items without pricing (#55)

### DIFF
--- a/frontend/src/components/editors/POEditor.tsx
+++ b/frontend/src/components/editors/POEditor.tsx
@@ -2176,9 +2176,9 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
               onClick={() => runPrintPO(false)}
               className="w-full text-left p-4 rounded-md border bg-background hover:bg-accent transition-colors"
             >
-              <div className="font-medium">Section totals only</div>
+              <div className="font-medium">Quantities only</div>
               <div className="text-sm text-muted-foreground mt-1">
-                Hide per-item rows and show only the Parts and Miscellaneous subtotals.
+                Show each item's description and quantity, but hide all unit prices, line totals, and section subtotals. Only the final Subtotal, HST, and Total are shown.
               </div>
             </button>
           </div>

--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -3809,9 +3809,9 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
               onClick={() => runPrintQuote(false)}
               className="w-full text-left p-4 rounded-md border bg-background hover:bg-accent transition-colors"
             >
-              <div className="font-medium">Section totals only</div>
+              <div className="font-medium">Quantities only</div>
               <div className="text-sm text-muted-foreground mt-1">
-                Hide per-item rows and show only the Parts, Labour, and Miscellaneous subtotals.
+                Show each item's description and quantity, but hide all unit prices, line totals, and section subtotals. Only the final Subtotal, HST, and Total are shown.
               </div>
             </button>
           </div>

--- a/frontend/src/components/pdf/PurchaseOrderPDF.tsx
+++ b/frontend/src/components/pdf/PurchaseOrderPDF.tsx
@@ -23,6 +23,30 @@ function LineItemTable({
 }) {
   if (items.length === 0) return null
 
+  // Quantities-only mode: list each item's description + qty, with no pricing
+  // and no section subtotal (only the final Subtotal/HST/Total appear at the bottom).
+  if (!showLineDetails) {
+    return (
+      <>
+        <Text style={styles.sectionTitle}>{title}</Text>
+        <View style={styles.tableHeader}>
+          <Text style={[styles.colHeaderText, styles.colDescriptionWide]}>Description</Text>
+          <Text style={[styles.colHeaderText, styles.colQtyWide]}>Qty</Text>
+        </View>
+        {items.map((item, idx) => (
+          <View
+            key={item.id}
+            style={[styles.tableRow, idx % 2 === 1 ? styles.tableRowAlt : {}]}
+            wrap={false}
+          >
+            <Text style={styles.colDescriptionWide}>{getItemDescription(item)}</Text>
+            <Text style={styles.colQtyWide}>{item.quantity}</Text>
+          </View>
+        ))}
+      </>
+    )
+  }
+
   const sectionTotal = items.reduce(
     (sum, item) => sum + (item.unit_price ?? 0) * item.quantity,
     0
@@ -32,37 +56,33 @@ function LineItemTable({
     <>
       <Text style={styles.sectionTitle}>{title}</Text>
 
-      {showLineDetails && (
-        <>
-          {/* Table header */}
-          <View style={styles.tableHeader}>
-            <Text style={[styles.colHeaderText, styles.colDescription]}>Description</Text>
-            <Text style={[styles.colHeaderText, styles.colQty]}>Qty</Text>
-            <Text style={[styles.colHeaderText, styles.colUnitPrice]}>Unit Price</Text>
-            <Text style={[styles.colHeaderText, styles.colTotal]}>Total</Text>
+      {/* Table header */}
+      <View style={styles.tableHeader}>
+        <Text style={[styles.colHeaderText, styles.colDescription]}>Description</Text>
+        <Text style={[styles.colHeaderText, styles.colQty]}>Qty</Text>
+        <Text style={[styles.colHeaderText, styles.colUnitPrice]}>Unit Price</Text>
+        <Text style={[styles.colHeaderText, styles.colTotal]}>Total</Text>
+      </View>
+
+      {/* Table rows */}
+      {items.map((item, idx) => {
+        const description = getItemDescription(item)
+        const unitPrice = item.unit_price ?? 0
+        const total = unitPrice * item.quantity
+
+        return (
+          <View
+            key={item.id}
+            style={[styles.tableRow, idx % 2 === 1 ? styles.tableRowAlt : {}]}
+            wrap={false}
+          >
+            <Text style={styles.colDescription}>{description}</Text>
+            <Text style={styles.colQty}>{item.quantity}</Text>
+            <Text style={styles.colUnitPrice}>{formatCurrency(unitPrice)}</Text>
+            <Text style={styles.colTotal}>{formatCurrency(total)}</Text>
           </View>
-
-          {/* Table rows */}
-          {items.map((item, idx) => {
-            const description = getItemDescription(item)
-            const unitPrice = item.unit_price ?? 0
-            const total = unitPrice * item.quantity
-
-            return (
-              <View
-                key={item.id}
-                style={[styles.tableRow, idx % 2 === 1 ? styles.tableRowAlt : {}]}
-                wrap={false}
-              >
-                <Text style={styles.colDescription}>{description}</Text>
-                <Text style={styles.colQty}>{item.quantity}</Text>
-                <Text style={styles.colUnitPrice}>{formatCurrency(unitPrice)}</Text>
-                <Text style={styles.colTotal}>{formatCurrency(total)}</Text>
-              </View>
-            )
-          })}
-        </>
-      )}
+        )
+      })}
 
       {/* Section subtotal */}
       <View style={styles.tableFooterRow}>

--- a/frontend/src/components/pdf/QuotePDF.tsx
+++ b/frontend/src/components/pdf/QuotePDF.tsx
@@ -34,6 +34,30 @@ function LineItemTable({
 }) {
   if (items.length === 0) return null
 
+  // Quantities-only mode: list each item's description + qty, with no pricing
+  // and no section subtotal (only the final Subtotal/HST/Total appear at the bottom).
+  if (!showLineDetails) {
+    return (
+      <>
+        <Text style={styles.sectionTitle}>{title}</Text>
+        <View style={styles.tableHeader}>
+          <Text style={[styles.colHeaderText, styles.colDescriptionWide]}>Description</Text>
+          <Text style={[styles.colHeaderText, styles.colQtyWide]}>Qty</Text>
+        </View>
+        {items.map((item, idx) => (
+          <View
+            key={item.id}
+            style={[styles.tableRow, idx % 2 === 1 ? styles.tableRowAlt : {}]}
+            wrap={false}
+          >
+            <Text style={styles.colDescriptionWide}>{getItemDescription(item)}</Text>
+            <Text style={styles.colQtyWide}>{item.quantity}</Text>
+          </View>
+        ))}
+      </>
+    )
+  }
+
   const sectionTotal = items.reduce(
     (sum, item) =>
       sum + (useEffective ? getEffectiveLineItemTotal(item, nonPmsTotal) : getLineItemTotal(item)),
@@ -44,44 +68,40 @@ function LineItemTable({
     <>
       <Text style={styles.sectionTitle}>{title}</Text>
 
-      {showLineDetails && (
-        <>
-          {/* Table header */}
-          <View style={styles.tableHeader}>
-            <Text style={[styles.colHeaderText, styles.colDescription]}>Description</Text>
-            <Text style={[styles.colHeaderText, styles.colQty]}>Qty</Text>
-            <Text style={[styles.colHeaderText, styles.colUnitPrice]}>Unit Price</Text>
-            <Text style={[styles.colHeaderText, styles.colTotal]}>Total</Text>
+      {/* Table header */}
+      <View style={styles.tableHeader}>
+        <Text style={[styles.colHeaderText, styles.colDescription]}>Description</Text>
+        <Text style={[styles.colHeaderText, styles.colQty]}>Qty</Text>
+        <Text style={[styles.colHeaderText, styles.colUnitPrice]}>Unit Price</Text>
+        <Text style={[styles.colHeaderText, styles.colTotal]}>Total</Text>
+      </View>
+
+      {/* Table rows */}
+      {items.map((item, idx) => {
+        const description = getItemDescription(item)
+        const unitPrice = useEffective && item.is_pms && item.pms_percent != null
+          ? nonPmsTotal * item.pms_percent / 100
+          : getLineItemUnitPrice(item)
+        const total = useEffective
+          ? getEffectiveLineItemTotal(item, nonPmsTotal)
+          : getLineItemTotal(item)
+
+        return (
+          <View
+            key={item.id}
+            style={[styles.tableRow, idx % 2 === 1 ? styles.tableRowAlt : {}]}
+            wrap={false}
+          >
+            <Text style={styles.colDescription}>
+              {description}
+              {item.is_pms && item.pms_percent != null ? ` (PMS ${item.pms_percent}%)` : ''}
+            </Text>
+            <Text style={styles.colQty}>{item.quantity}</Text>
+            <Text style={styles.colUnitPrice}>{formatCurrency(unitPrice)}</Text>
+            <Text style={styles.colTotal}>{formatCurrency(total)}</Text>
           </View>
-
-          {/* Table rows */}
-          {items.map((item, idx) => {
-            const description = getItemDescription(item)
-            const unitPrice = useEffective && item.is_pms && item.pms_percent != null
-              ? nonPmsTotal * item.pms_percent / 100
-              : getLineItemUnitPrice(item)
-            const total = useEffective
-              ? getEffectiveLineItemTotal(item, nonPmsTotal)
-              : getLineItemTotal(item)
-
-            return (
-              <View
-                key={item.id}
-                style={[styles.tableRow, idx % 2 === 1 ? styles.tableRowAlt : {}]}
-                wrap={false}
-              >
-                <Text style={styles.colDescription}>
-                  {description}
-                  {item.is_pms && item.pms_percent != null ? ` (PMS ${item.pms_percent}%)` : ''}
-                </Text>
-                <Text style={styles.colQty}>{item.quantity}</Text>
-                <Text style={styles.colUnitPrice}>{formatCurrency(unitPrice)}</Text>
-                <Text style={styles.colTotal}>{formatCurrency(total)}</Text>
-              </View>
-            )
-          })}
-        </>
-      )}
+        )
+      })}
 
       {/* Section subtotal */}
       <View style={styles.tableFooterRow}>

--- a/frontend/src/components/pdf/styles.ts
+++ b/frontend/src/components/pdf/styles.ts
@@ -179,6 +179,9 @@ export const styles = StyleSheet.create({
   colQty: { width: '10%', textAlign: 'right' },
   colUnitPrice: { width: '20%', textAlign: 'right' },
   colTotal: { width: '20%', textAlign: 'right' },
+  // Column widths for quantities-only (no-pricing) layout
+  colDescriptionWide: { width: '85%' },
+  colQtyWide: { width: '15%', textAlign: 'right' },
   // Column header text
   colHeaderText: {
     fontFamily: 'Helvetica-Bold',


### PR DESCRIPTION
## Summary
- Reworks the "no breakdown" print option for quote and PO PDFs to match the reopened spec on #55.
- The option is renamed from **"Section totals only"** to **"Quantities only"**: each line item is still listed (description + quantity), but all unit prices, line totals, and section subtotals are hidden. Only the final Subtotal, HST, and Total remain at the bottom.
- Applies to both quote and PO PDFs (answers the issue's "check if applies to POs too").

## Changes
- `QuotePDF.tsx` / `PurchaseOrderPDF.tsx`: `LineItemTable` branches into a quantities-only layout (description + qty columns, no section subtotal) when `includeBreakdown` is false.
- `styles.ts`: add `colDescriptionWide` / `colQtyWide` for the no-pricing column layout.
- `QuoteEditor.tsx` / `POEditor.tsx`: rename the print-dialog option and correct its description.

Fixes #55