### PR TITLE
Invoice numbering + Clerk audit actor + deep-link fix + Quote/PO QoL

### DIFF
--- a/backend/alembic/versions/20260528_021_add_invoice_numbering.py
+++ b/backend/alembic/versions/20260528_021_add_invoice_numbering.py
@@ -1,0 +1,69 @@
+"""Add invoice_sequence and quote_version to invoices
+
+Enables structured invoice numbers of the form
+    {invoice_sequence}-{quote_number}
+where quote_number is {UCA}-{quote_sequence:04d}-{quote_version} captured at
+invoice-creation time (the quote version is snapshotted when the invoice is
+created). invoice_sequence is a per-quote running number (1, 2, 3...).
+
+Existing rows are backfilled:
+  - invoice_sequence via ROW_NUMBER() per quote ordered by creation
+  - quote_version from the linked "invoice" snapshot (quote_snapshots.invoice_id),
+    falling back to 0 when no snapshot is found.
+
+Note: revision id kept short — alembic_version.version_num is VARCHAR(32).
+
+Revision ID: 021_invoice_numbering
+Revises: 020_hardware_schedule_ver
+Create Date: 2026-05-28
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '021_invoice_numbering'
+down_revision = '020_hardware_schedule_ver'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # 1. Add columns (nullable first so existing rows can be backfilled)
+    conn.execute(sa.text("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS invoice_sequence INTEGER"))
+    conn.execute(sa.text("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS quote_version INTEGER"))
+
+    # 2. Backfill invoice_sequence: per-quote running number ordered by creation
+    conn.execute(sa.text("""
+        UPDATE invoices SET invoice_sequence = sub.seq
+        FROM (
+            SELECT id,
+                   ROW_NUMBER() OVER (PARTITION BY quote_id ORDER BY created_at ASC, id ASC) AS seq
+            FROM invoices
+        ) AS sub
+        WHERE invoices.id = sub.id
+    """))
+
+    # 3. Backfill quote_version from the linked invoice snapshot; default 0
+    conn.execute(sa.text("""
+        UPDATE invoices SET quote_version = COALESCE(
+            (SELECT qs.version FROM quote_snapshots qs
+             WHERE qs.invoice_id = invoices.id
+             ORDER BY qs.version DESC LIMIT 1),
+            0
+        )
+    """))
+
+    # 4. Defaults (safety net for future inserts) + enforce NOT NULL
+    conn.execute(sa.text("UPDATE invoices SET invoice_sequence = 1 WHERE invoice_sequence IS NULL"))
+    conn.execute(sa.text("UPDATE invoices SET quote_version = 0 WHERE quote_version IS NULL"))
+    conn.execute(sa.text("ALTER TABLE invoices ALTER COLUMN invoice_sequence SET DEFAULT 1"))
+    conn.execute(sa.text("ALTER TABLE invoices ALTER COLUMN quote_version SET DEFAULT 0"))
+    conn.execute(sa.text("ALTER TABLE invoices ALTER COLUMN invoice_sequence SET NOT NULL"))
+    conn.execute(sa.text("ALTER TABLE invoices ALTER COLUMN quote_version SET NOT NULL"))
+
+
+def downgrade():
+    op.drop_column('invoices', 'quote_version')
+    op.drop_column('invoices', 'invoice_sequence')

--- a/backend/alembic/versions/20260528_022_add_snapshot_actor.py
+++ b/backend/alembic/versions/20260528_022_add_snapshot_actor.py
@@ -1,0 +1,39 @@
+"""Add actor columns to quote_snapshots and po_snapshots (audit trail)
+
+Records who performed each action:
+  - actor_user_id: the verified Clerk user id (JWT ``sub``)
+  - actor_email:   resolved email, for display
+
+Both are nullable — pre-existing snapshots and any unauthenticated writes simply
+have no actor. Every quote/PO/invoice/receiving/revert action funnels through
+create_snapshot / create_po_snapshot, so these two tables cover the whole trail.
+
+Note: revision id kept short — alembic_version.version_num is VARCHAR(32).
+
+Revision ID: 022_snapshot_actor
+Revises: 021_invoice_numbering
+Create Date: 2026-05-28
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '022_snapshot_actor'
+down_revision = '021_invoice_numbering'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute(sa.text("ALTER TABLE quote_snapshots ADD COLUMN IF NOT EXISTS actor_user_id VARCHAR"))
+    conn.execute(sa.text("ALTER TABLE quote_snapshots ADD COLUMN IF NOT EXISTS actor_email VARCHAR"))
+    conn.execute(sa.text("ALTER TABLE po_snapshots ADD COLUMN IF NOT EXISTS actor_user_id VARCHAR"))
+    conn.execute(sa.text("ALTER TABLE po_snapshots ADD COLUMN IF NOT EXISTS actor_email VARCHAR"))
+
+
+def downgrade():
+    op.drop_column('po_snapshots', 'actor_email')
+    op.drop_column('po_snapshots', 'actor_user_id')
+    op.drop_column('quote_snapshots', 'actor_email')
+    op.drop_column('quote_snapshots', 'actor_user_id')

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,124 @@
+"""Best-effort Clerk JWT verification for the audit trail.
+
+A pure-ASGI middleware verifies the incoming Clerk session token
+(``Authorization: Bearer ...``) against the issuer's JWKS and stashes the acting
+user's id/email in a request-scoped contextvar. The snapshot helpers
+(``create_snapshot`` / ``create_po_snapshot``) read that contextvar to record
+*who* performed each action.
+
+Verification is intentionally best-effort: a missing or invalid token simply
+yields no actor and never blocks the request, so the audit trail is purely
+additive and cannot break existing functionality.
+"""
+import contextvars
+import os
+from typing import Optional
+
+import httpx
+import jwt
+from jwt import PyJWKClient
+from starlette.concurrency import run_in_threadpool
+
+# Request-scoped acting user: {"user_id": str, "email": Optional[str]} or None.
+current_actor: contextvars.ContextVar[Optional[dict]] = contextvars.ContextVar(
+    "current_actor", default=None
+)
+
+# Caches: JWKS client per issuer, and resolved email per Clerk user id.
+_jwks_clients: dict[str, PyJWKClient] = {}
+_email_cache: dict[str, Optional[str]] = {}
+
+
+def _jwks_client_for(issuer: str) -> PyJWKClient:
+    url = f"{issuer.rstrip('/')}/.well-known/jwks.json"
+    client = _jwks_clients.get(url)
+    if client is None:
+        client = PyJWKClient(url)
+        _jwks_clients[url] = client
+    return client
+
+
+def _resolve_email(user_id: str) -> Optional[str]:
+    """Look up a Clerk user's primary email via the Admin API (cached per user)."""
+    if user_id in _email_cache:
+        return _email_cache[user_id]
+    secret = os.getenv("CLERK_SECRET_KEY")
+    if not secret:
+        return None
+    email: Optional[str] = None
+    try:
+        with httpx.Client(timeout=5.0, headers={"Authorization": f"Bearer {secret}"}) as client:
+            r = client.get(f"https://api.clerk.com/v1/users/{user_id}")
+            if r.status_code == 200:
+                data = r.json()
+                primary_id = data.get("primary_email_address_id")
+                addresses = data.get("email_addresses", []) or []
+                for addr in addresses:
+                    if addr.get("id") == primary_id:
+                        email = addr.get("email_address")
+                        break
+                if email is None and addresses:
+                    email = addresses[0].get("email_address")
+    except Exception:
+        return None
+    _email_cache[user_id] = email
+    return email
+
+
+def extract_actor(authorization: Optional[str]) -> Optional[dict]:
+    """Verify a Clerk session JWT and return {"user_id", "email"}, or None."""
+    if not authorization or not authorization.lower().startswith("bearer "):
+        return None
+    token = authorization[7:].strip()
+    if not token:
+        return None
+    try:
+        unverified = jwt.decode(token, options={"verify_signature": False})
+        issuer = unverified.get("iss")
+        if not issuer:
+            return None
+        expected = os.getenv("CLERK_ISSUER")
+        if expected and issuer.rstrip("/") != expected.rstrip("/"):
+            return None
+        signing_key = _jwks_client_for(issuer).get_signing_key_from_jwt(token)
+        claims = jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=["RS256"],
+            options={"verify_aud": False},
+        )
+    except Exception:
+        return None
+    user_id = claims.get("sub")
+    if not user_id:
+        return None
+    email = claims.get("email") or _resolve_email(user_id)
+    return {"user_id": user_id, "email": email}
+
+
+class ActorMiddleware:
+    """Pure-ASGI middleware that sets ``current_actor`` for the request's duration.
+
+    Implemented as pure ASGI (not Starlette ``BaseHTTPMiddleware``) so the
+    contextvar set here propagates into the sync route handler — which Starlette
+    runs in a threadpool that copies the current context.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+        auth_value: Optional[str] = None
+        for key, value in scope.get("headers", []):
+            if key == b"authorization":
+                auth_value = value.decode("latin-1")
+                break
+        actor = await run_in_threadpool(extract_actor, auth_value)
+        token = current_actor.set(actor)
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            current_actor.reset(token)

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from database import engine, Base, SessionLocal
 from routes import parts, labor, profiles, projects, quotes, purchase_orders, miscellaneous, invoices, company_settings, reports, cost_codes, vendor_pricebook, migration, system_rates, testing
 from seed import seed_system_items
+from auth import ActorMiddleware
 
 
 def run_migrations():
@@ -100,6 +101,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Capture the acting Clerk user (best-effort, never blocks) for the audit trail
+app.add_middleware(ActorMiddleware)
 
 # Include routers
 app.include_router(parts.router)

--- a/backend/models.py
+++ b/backend/models.py
@@ -312,6 +312,8 @@ class POSnapshot(Base):
     action_description = Column(String, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     receiving_id = Column(Integer, ForeignKey('po_receivings.id'), nullable=True)
+    actor_user_id = Column(String, nullable=True)  # Clerk user id (sub) who performed the action
+    actor_email = Column(String, nullable=True)  # Resolved email, for display
 
     # Relationships
     purchase_order = relationship("PurchaseOrder", back_populates="snapshots")
@@ -395,6 +397,8 @@ class QuoteSnapshot(Base):
     action_description = Column(String)
     created_at = Column(DateTime, default=datetime.utcnow)
     invoice_id = Column(Integer)  # If action_type="invoice", link to Invoice
+    actor_user_id = Column(String, nullable=True)  # Clerk user id (sub) who performed the action
+    actor_email = Column(String, nullable=True)  # Resolved email, for display
 
     # Relationships
     quote = relationship("Quote", back_populates="snapshots")

--- a/backend/models.py
+++ b/backend/models.py
@@ -348,6 +348,8 @@ class Invoice(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
     status = Column(String, default="Sent")  # "Sent", "Paid", "Voided"
     notes = Column(String)  # Optional notes for this invoice
+    invoice_sequence = Column(Integer, default=1)  # Per-quote sequence (1, 2, 3...)
+    quote_version = Column(Integer, default=0)  # Quote version captured at invoice time
     voided_at = Column(DateTime)  # When voided (if applicable)
     voided_by_snapshot_id = Column(Integer)  # Which revert voided this
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ python-dotenv==1.0.0
 gunicorn==21.2.0
 alembic==1.13.1
 httpx==0.25.2
+PyJWT[crypto]==2.8.0

--- a/backend/routes/invoices.py
+++ b/backend/routes/invoices.py
@@ -16,6 +16,7 @@ from schemas import (
     LineItemFulfillment,
     InvoiceSummaryItem
 )
+from routes.quotes import populate_invoice_number
 
 router = APIRouter(prefix="/invoices", tags=["invoices"])
 
@@ -98,13 +99,16 @@ def get_invoice(invoice_id: int, db: Session = Depends(get_db)):
     """Get a single invoice with all line items."""
     invoice = (
         db.query(Invoice)
-        .options(joinedload(Invoice.line_items))
+        .options(
+            joinedload(Invoice.line_items),
+            joinedload(Invoice.quote).joinedload(Quote.project),
+        )
         .filter(Invoice.id == invoice_id)
         .first()
     )
     if not invoice:
         raise HTTPException(status_code=404, detail="Invoice not found")
-    return invoice
+    return populate_invoice_number(invoice, db)
 
 
 @router.put("/{invoice_id}", response_model=InvoiceSchema)
@@ -141,11 +145,14 @@ def update_invoice_status(
     # Reload with relationships
     invoice = (
         db.query(Invoice)
-        .options(joinedload(Invoice.line_items))
+        .options(
+            joinedload(Invoice.line_items),
+            joinedload(Invoice.quote).joinedload(Quote.project),
+        )
         .filter(Invoice.id == invoice_id)
         .first()
     )
-    return invoice
+    return populate_invoice_number(invoice, db)
 
 
 # Invoice creation endpoint on quotes router (will be added to quotes.py)

--- a/backend/routes/purchase_orders.py
+++ b/backend/routes/purchase_orders.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 from datetime import datetime
 
 from database import get_db
+from auth import current_actor
 from models import (
     PurchaseOrder, POLineItem, Project, Profile, ProfileType, Part,
     POReceiving, POReceivingLineItem, POSnapshot, POLineItemSnapshot, POStatus, CostCode
@@ -56,13 +57,16 @@ def create_po_snapshot(
         new_version = po.current_version + 1
         po.current_version = new_version
 
-    # Create the snapshot
+    # Create the snapshot (record the acting user from the request context)
+    actor = current_actor.get()
     snapshot = POSnapshot(
         purchase_order_id=po.id,
         version=new_version,
         action_type=action_type,
         action_description=action_description,
-        receiving_id=receiving_id
+        receiving_id=receiving_id,
+        actor_user_id=actor["user_id"] if actor else None,
+        actor_email=actor.get("email") if actor else None,
     )
     db.add(snapshot)
     db.flush()  # Get the snapshot ID

--- a/backend/routes/quotes.py
+++ b/backend/routes/quotes.py
@@ -277,6 +277,33 @@ def populate_quote_number(quote: Quote, uca_project_number: str) -> QuoteSchema:
     return response
 
 
+def format_invoice_number(invoice_sequence: int, uca_project_number: str, quote_sequence: int, quote_version: int) -> str:
+    """
+    Format the full invoice number string.
+
+    Pattern: {invoice_sequence}-{quote_number}, where quote_number is the quote's
+    number as it stood at invoice time: {UCA}-{quote_sequence:04d}-{quote_version}.
+    Example: 1-A2132-0001-3
+    """
+    return f"{invoice_sequence}-{uca_project_number}-{quote_sequence:04d}-{quote_version}"
+
+
+def populate_invoice_number(invoice: Invoice, db: Session) -> InvoiceSchema:
+    """Convert an Invoice ORM object to an InvoiceSchema with a computed invoice_number."""
+    response = InvoiceSchema.model_validate(invoice)
+    quote = invoice.quote or db.query(Quote).filter(Quote.id == invoice.quote_id).first()
+    if quote is not None:
+        project = quote.project or db.query(Project).filter(Project.id == quote.project_id).first()
+        if project is not None:
+            response.invoice_number = format_invoice_number(
+                invoice.invoice_sequence,
+                project.uca_project_number,
+                quote.quote_sequence,
+                invoice.quote_version,
+            )
+    return response
+
+
 router = APIRouter(prefix="/quotes", tags=["quotes"])
 
 
@@ -1228,12 +1255,15 @@ def get_quote_invoices(quote_id: int, db: Session = Depends(get_db)):
 
     invoices = (
         db.query(Invoice)
-        .options(joinedload(Invoice.line_items))
+        .options(
+            joinedload(Invoice.line_items),
+            joinedload(Invoice.quote).joinedload(Quote.project),
+        )
         .filter(Invoice.quote_id == quote_id)
         .order_by(Invoice.created_at.desc())
         .all()
     )
-    return invoices
+    return [populate_invoice_number(inv, db) for inv in invoices]
 
 
 @router.post("/{quote_id}/invoices", response_model=InvoiceSchema)
@@ -1289,11 +1319,19 @@ def create_invoice(
             )
         line_items_to_fulfill.append((line_item, fulfillment.quantity))
 
+    # Per-quote invoice sequence (1, 2, 3...) for the structured invoice number
+    next_invoice_seq = (
+        db.query(func.max(Invoice.invoice_sequence))
+        .filter(Invoice.quote_id == quote_id)
+        .scalar() or 0
+    ) + 1
+
     # Create the invoice
     invoice = Invoice(
         quote_id=quote_id,
         status="Sent",
-        notes=invoice_data.notes
+        notes=invoice_data.notes,
+        invoice_sequence=next_invoice_seq,
     )
     db.add(invoice)
     db.flush()  # Get invoice ID
@@ -1326,7 +1364,7 @@ def create_invoice(
         line_item.qty_fulfilled += fulfill_qty
         line_item.qty_pending -= fulfill_qty
 
-    # Create snapshot for this invoice action
+    # Create snapshot for this invoice action (bumps quote.current_version)
     create_snapshot(
         db=db,
         quote=quote,
@@ -1335,17 +1373,23 @@ def create_invoice(
         invoice_id=invoice.id
     )
 
+    # Capture the quote version at invoice time for the structured invoice number
+    invoice.quote_version = quote.current_version
+
     db.commit()
     db.refresh(invoice)
 
-    # Reload with relationships
+    # Reload with relationships (quote + project needed for the computed invoice_number)
     invoice = (
         db.query(Invoice)
-        .options(joinedload(Invoice.line_items))
+        .options(
+            joinedload(Invoice.line_items),
+            joinedload(Invoice.quote).joinedload(Quote.project),
+        )
         .filter(Invoice.id == invoice.id)
         .first()
     )
-    return invoice
+    return populate_invoice_number(invoice, db)
 
 
 # ==================== Snapshots (Audit Trail) ====================

--- a/backend/routes/quotes.py
+++ b/backend/routes/quotes.py
@@ -4,6 +4,7 @@ from sqlalchemy import func
 from typing import List, Optional
 
 from database import get_db
+from auth import current_actor
 from models import (
     Quote, QuoteLineItem, Project, Labor, Part, Miscellaneous,
     QuoteSnapshot, QuoteLineItemSnapshot, Invoice, InvoiceLineItem, CostCode
@@ -48,13 +49,16 @@ def create_snapshot(
     new_version = quote.current_version + 1
     quote.current_version = new_version
 
-    # Create the snapshot
+    # Create the snapshot (record the acting user from the request context)
+    actor = current_actor.get()
     snapshot = QuoteSnapshot(
         quote_id=quote.id,
         version=new_version,
         action_type=action_type,
         action_description=action_description,
-        invoice_id=invoice_id
+        invoice_id=invoice_id,
+        actor_user_id=actor["user_id"] if actor else None,
+        actor_email=actor.get("email") if actor else None,
     )
     db.add(snapshot)
     db.flush()  # Get the snapshot ID

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -713,6 +713,8 @@ class POSnapshotBase(BaseModel):
 class POSnapshot(POSnapshotBase):
     id: int
     created_at: datetime
+    actor_user_id: Optional[str] = None
+    actor_email: Optional[str] = None
     line_item_states: List[POLineItemSnapshot] = []
 
     class Config:
@@ -953,6 +955,8 @@ class QuoteSnapshotBase(BaseModel):
 class QuoteSnapshot(QuoteSnapshotBase):
     id: int
     created_at: datetime
+    actor_user_id: Optional[str] = None
+    actor_email: Optional[str] = None
     line_item_states: List[QuoteLineItemSnapshot] = []
 
     class Config:

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -893,6 +893,9 @@ class InvoiceStatusUpdate(BaseModel):
 
 class Invoice(InvoiceBase):
     id: int
+    invoice_sequence: int = 1
+    quote_version: int = 0
+    invoice_number: Optional[str] = None  # Computed: "{invoice_sequence}-{UCA}-{quote_seq:04d}-{quote_version}"
     created_at: datetime
     status: str
     voided_at: Optional[datetime] = None

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,7 +68,7 @@ type ParsedRoute =
   | {
       view: "project-details"
       projectId: number
-      initialDoc: { type: "quote" | "po"; id: number } | null
+      initialDoc: { type: "quote" | "po" | "invoice"; id: number } | null
     }
 
 function parseRoute(pathname: string): ParsedRoute {
@@ -83,13 +83,11 @@ function parseRoute(pathname: string): ParsedRoute {
     const projectId = parseInt(projMatch[1], 10)
     const docSeg = projMatch[2]
     const docId = projMatch[3] ? parseInt(projMatch[3], 10) : null
-    let initialDoc: { type: "quote" | "po"; id: number } | null = null
+    let initialDoc: { type: "quote" | "po" | "invoice"; id: number } | null = null
     if (docId !== null) {
       if (docSeg === "quotes") initialDoc = { type: "quote", id: docId }
       else if (docSeg === "pos") initialDoc = { type: "po", id: docId }
-      // /invoices/:id deep-links open the project details and the invoice subview;
-      // the editor handles invoice selection via its initialDoc-like flow.
-      else if (docSeg === "invoices") initialDoc = { type: "quote", id: docId } // editor surfaces invoice through quote anyway
+      else if (docSeg === "invoices") initialDoc = { type: "invoice", id: docId }
     }
     return { view: "project-details", projectId, initialDoc }
   }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -27,10 +27,21 @@ async function request<T>(
   endpoint: string,
   options: RequestInit = {}
 ): Promise<T> {
+  // Attach the Clerk session token so the backend can attribute audit-trail actions.
+  let authHeaders: Record<string, string> = {};
+  try {
+    const clerk = (window as unknown as { Clerk?: { session?: { getToken?: () => Promise<string | null> } } }).Clerk;
+    const token = await clerk?.session?.getToken?.();
+    if (token) authHeaders = { Authorization: `Bearer ${token}` };
+  } catch {
+    // Best-effort: if Clerk isn't ready yet, proceed without a token.
+  }
+
   const response = await fetch(`${API_BASE}${endpoint}`, {
     ...options,
     headers: {
       'Content-Type': 'application/json',
+      ...authHeaders,
       ...options.headers,
     },
   });

--- a/frontend/src/components/editors/InvoiceEditor.tsx
+++ b/frontend/src/components/editors/InvoiceEditor.tsx
@@ -141,7 +141,7 @@ export function InvoiceEditor({ invoiceId, onUpdate }: InvoiceEditorProps) {
         <div>
           <div className="flex items-center gap-3">
             <Receipt className="h-6 w-6" />
-            <h2 className="text-xl font-semibold">Invoice #{invoice.id}</h2>
+            <h2 className="text-xl font-semibold">Invoice #{invoice.invoice_number ?? invoice.id}</h2>
             <Badge variant={getStatusBadgeVariant(invoice.status)}>
               {invoice.status}
             </Badge>

--- a/frontend/src/components/editors/POAuditTrail.tsx
+++ b/frontend/src/components/editors/POAuditTrail.tsx
@@ -256,6 +256,9 @@ export function POAuditTrail({ purchaseOrderId, currentVersion, onRevert }: POAu
                           </div>
                           <p className="text-xs text-muted-foreground">
                             {formatDate(snapshot.created_at)}
+                            {snapshot.actor_email && (
+                              <span className="ml-2">· by {snapshot.actor_email}</span>
+                            )}
                             {snapshot.action_description && (
                               <span className="ml-2">
                                 - {snapshot.action_description}

--- a/frontend/src/components/editors/POEditor.tsx
+++ b/frontend/src/components/editors/POEditor.tsx
@@ -758,6 +758,22 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
     setStagedReceivings(newMap)
   }
 
+  /** Stage the full pending quantity for every line item with items outstanding. */
+  const stageReceiveAll = () => {
+    if (!po) return
+    const newMap = new Map(stagedReceivings)
+    for (const item of po.line_items) {
+      if (item.qty_pending > 0) {
+        const existing = newMap.get(item.id)
+        newMap.set(item.id, {
+          qty_received: item.qty_pending,
+          actual_unit_price: existing?.actual_unit_price,
+        })
+      }
+    }
+    setStagedReceivings(newMap)
+  }
+
   /** Submit staged receiving quantities and actual prices to the backend. */
   const handleSubmitReceiving = async () => {
     if (!po) return
@@ -2375,7 +2391,20 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
               }
 
               return (
-                <Table>
+                <div className="space-y-2">
+                  <div className="flex justify-end">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={stageReceiveAll}
+                      disabled={isSubmittingReceiving}
+                      className="gap-2"
+                    >
+                      <Check className="h-3.5 w-3.5" />
+                      Receive All Pending
+                    </Button>
+                  </div>
+                  <Table>
                   <TableHeader>
                     <TableRow>
                       <TableHead>Description</TableHead>
@@ -2463,6 +2492,7 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
                     })}
                   </TableBody>
                 </Table>
+                </div>
               )
             })()}
           </div>

--- a/frontend/src/components/editors/POEditor.tsx
+++ b/frontend/src/components/editors/POEditor.tsx
@@ -59,7 +59,7 @@ import type {
 import {
   Plus, Minus, Trash2, Package, FileText, Building, Pencil, Copy,
   X, GitCommit, Eye, AlertTriangle, Check, Calendar, Loader2, Hash, Printer,
-  History, ChevronDown, ChevronRight, Receipt
+  History, ChevronDown, ChevronRight, Receipt, Info, ArrowLeft
 } from "lucide-react"
 import { StatusBadge } from "@/components/ui/status-badge"
 import { formatDate } from "@/lib/format"
@@ -82,6 +82,8 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
   // ===== Dialog States =====
   const [addDialogOpen, setAddDialogOpen] = useState(false)
   const [addDialogType, setAddDialogType] = useState<POLineItemType>("part")
+  // "select" shows the picker + inventory details; "edit-inventory" swaps in PartForm
+  const [addDialogMode, setAddDialogMode] = useState<"select" | "edit-inventory">("select")
 
   // Edit dialog states
   const [editDialogOpen, setEditDialogOpen] = useState(false)
@@ -417,11 +419,26 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
 
   const openAddDialog = (type: POLineItemType) => {
     setAddDialogType(type)
+    setAddDialogMode("select")
     setSelectedPartId("")
     setMiscDescription("")
     setQuantity("1")
     setUnitPrice("")
     setAddDialogOpen(true)
+  }
+
+  const selectedPart =
+    addDialogType === "part" && selectedPartId
+      ? parts.find((p) => p.id === parseInt(selectedPartId)) ?? null
+      : null
+
+  // After editing the part master inline, refresh the local cache so the details
+  // panel + add-pricing reflect the new values, then return to the picker.
+  const handlePartUpdateSuccess = (updated?: Part) => {
+    if (updated) {
+      setParts((prev) => prev.map((p) => (p.id === updated.id ? updated : p)))
+    }
+    setAddDialogMode("select")
   }
 
   const openEditDialog = (item: POLineItem) => {
@@ -1813,91 +1830,181 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
       {/* ===== Dialogs ===== */}
 
       {/* Add Line Item Dialog */}
-      <Dialog open={addDialogOpen} onOpenChange={setAddDialogOpen}>
-        <DialogContent className="max-w-2xl">
+      <Dialog
+        open={addDialogOpen}
+        onOpenChange={(open) => {
+          setAddDialogOpen(open)
+          if (!open) setAddDialogMode("select")
+        }}
+      >
+        <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
-              {getTypeIcon(addDialogType)}
-              Add {addDialogType.charAt(0).toUpperCase() + addDialogType.slice(1)}
+              {addDialogMode === "edit-inventory" ? (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => setAddDialogMode("select")}
+                    className="p-1 -ml-1 rounded hover:bg-muted"
+                    title="Back to selection"
+                    aria-label="Back to selection"
+                  >
+                    <ArrowLeft className="h-4 w-4" />
+                  </button>
+                  <Pencil className="h-5 w-5" />
+                  Edit Part Details
+                </>
+              ) : (
+                <>
+                  {getTypeIcon(addDialogType)}
+                  Add {addDialogType.charAt(0).toUpperCase() + addDialogType.slice(1)}
+                </>
+              )}
             </DialogTitle>
             <DialogDescription>
-              Add a {addDialogType} line item to this purchase order.
+              {addDialogMode === "edit-inventory"
+                ? "Updates apply to the inventory master record. Future selections will use these values; previously committed line items are unaffected."
+                : `Add a ${addDialogType} line item to this purchase order.`}
             </DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-4 pt-4">
-            {addDialogType === "part" && (
+          {addDialogMode === "select" && (
+            <div className="space-y-4 pt-4">
+              {addDialogType === "part" && (
+                <div className="space-y-2">
+                  <Label>Part</Label>
+                  <SearchableSelect<Part>
+                    options={parts.map((part): SearchableSelectOption => ({
+                      value: part.id.toString(),
+                      label: `${part.part_number} - ${part.description}`,
+                      description: `$${(part.cost ?? 0).toFixed(2)}`,
+                    }))}
+                    value={selectedPartId}
+                    onChange={setSelectedPartId}
+                    placeholder="Select part"
+                    searchPlaceholder="Search parts..."
+                    emptyMessage="No parts found."
+                    allowCreate={true}
+                    createLabel="Create New Part"
+                    createDialogTitle="Create New Part"
+                    createForm={<PartForm />}
+                    onCreateSuccess={(newPart) => {
+                      setParts([...parts, newPart])
+                      setSelectedPartId(newPart.id.toString())
+                    }}
+                  />
+                </div>
+              )}
+
+              {/* Inventory details panel — shown after a part is selected. */}
+              {addDialogType === "part" && selectedPart && (
+                <div className="rounded-lg border bg-muted/30 p-4 space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h4 className="text-sm font-semibold flex items-center gap-2">
+                      <Info className="h-4 w-4" />
+                      Inventory Details
+                    </h4>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setAddDialogMode("edit-inventory")}
+                      className="h-7 gap-2"
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                      Edit details
+                    </Button>
+                  </div>
+                  <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+                    <div>
+                      <dt className="text-muted-foreground">Part Number</dt>
+                      <dd className="font-medium">{selectedPart.part_number}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-muted-foreground">Description</dt>
+                      <dd className="font-medium">{selectedPart.description}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-muted-foreground">Base Cost</dt>
+                      <dd className="font-medium">${selectedPart.cost.toFixed(2)}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-muted-foreground">Markup</dt>
+                      <dd className="font-medium">{(selectedPart.markup_percent ?? 0).toFixed(2)}%</dd>
+                    </div>
+                    {selectedPart.list_price != null && (
+                      <div>
+                        <dt className="text-muted-foreground">List Price</dt>
+                        <dd className="font-medium">${selectedPart.list_price.toFixed(2)}</dd>
+                      </div>
+                    )}
+                    {selectedPart.discount_percent != null && (
+                      <div>
+                        <dt className="text-muted-foreground">Discount</dt>
+                        <dd className="font-medium">{selectedPart.discount_percent.toFixed(2)}%</dd>
+                      </div>
+                    )}
+                  </dl>
+                  <p className="text-xs text-muted-foreground">PO line items use the base cost.</p>
+                </div>
+              )}
+
+              {addDialogType === "misc" && (
+                <>
+                  <div className="space-y-2">
+                    <Label>Description</Label>
+                    <Input
+                      value={miscDescription}
+                      onChange={(e) => setMiscDescription(e.target.value)}
+                      placeholder="e.g., Shipping fee"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Unit Price</Label>
+                    <Input
+                      type="number"
+                      step="0.01"
+                      value={unitPrice}
+                      onChange={(e) => setUnitPrice(e.target.value)}
+                      placeholder="0.00"
+                    />
+                  </div>
+                </>
+              )}
+
               <div className="space-y-2">
-                <Label>Part</Label>
-                <SearchableSelect<Part>
-                  options={parts.map((part): SearchableSelectOption => ({
-                    value: part.id.toString(),
-                    label: `${part.part_number} - ${part.description}`,
-                    description: `$${(part.cost ?? 0).toFixed(2)}`,
-                  }))}
-                  value={selectedPartId}
-                  onChange={setSelectedPartId}
-                  placeholder="Select part"
-                  searchPlaceholder="Search parts..."
-                  emptyMessage="No parts found."
-                  allowCreate={true}
-                  createLabel="Create New Part"
-                  createDialogTitle="Create New Part"
-                  createForm={<PartForm />}
-                  onCreateSuccess={(newPart) => {
-                    setParts([...parts, newPart])
-                    setSelectedPartId(newPart.id.toString())
-                  }}
+                <Label>Quantity</Label>
+                <Input
+                  type="number"
+                  step="1"
+                  min="1"
+                  value={quantity}
+                  onChange={(e) => setQuantity(e.target.value)}
                 />
               </div>
-            )}
 
-            {addDialogType === "misc" && (
-              <>
-                <div className="space-y-2">
-                  <Label>Description</Label>
-                  <Input
-                    value={miscDescription}
-                    onChange={(e) => setMiscDescription(e.target.value)}
-                    placeholder="e.g., Shipping fee"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label>Unit Price</Label>
-                  <Input
-                    type="number"
-                    step="0.01"
-                    value={unitPrice}
-                    onChange={(e) => setUnitPrice(e.target.value)}
-                    placeholder="0.00"
-                  />
-                </div>
-              </>
-            )}
+              <Button
+                onClick={handleAddLineItem}
+                className="w-full"
+                disabled={
+                  (addDialogType === "part" && (!selectedPartId || parts.length === 0)) ||
+                  (addDialogType === "misc" && !miscDescription)
+                }
+              >
+                <Plus className="h-4 w-4 mr-2" />
+                Add Line Item
+              </Button>
+            </div>
+          )}
 
-            <div className="space-y-2">
-              <Label>Quantity</Label>
-              <Input
-                type="number"
-                step="1"
-                min="1"
-                value={quantity}
-                onChange={(e) => setQuantity(e.target.value)}
+          {addDialogMode === "edit-inventory" && addDialogType === "part" && selectedPart && (
+            <div className="pt-4">
+              <PartForm
+                part={selectedPart}
+                onSuccess={handlePartUpdateSuccess}
+                onCancel={() => setAddDialogMode("select")}
               />
             </div>
-
-            <Button
-              onClick={handleAddLineItem}
-              className="w-full"
-              disabled={
-                (addDialogType === "part" && (!selectedPartId || parts.length === 0)) ||
-                (addDialogType === "misc" && !miscDescription)
-              }
-            >
-              <Plus className="h-4 w-4 mr-2" />
-              Add Line Item
-            </Button>
-          </div>
+          )}
         </DialogContent>
       </Dialog>
 

--- a/frontend/src/components/editors/QuoteAuditTrail.tsx
+++ b/frontend/src/components/editors/QuoteAuditTrail.tsx
@@ -227,6 +227,9 @@ export function QuoteAuditTrail({ quoteId, currentVersion, onRevert }: QuoteAudi
                           </div>
                           <p className="text-xs text-muted-foreground">
                             {formatDate(snapshot.created_at)}
+                            {snapshot.actor_email && (
+                              <span className="ml-2">· by {snapshot.actor_email}</span>
+                            )}
                             {snapshot.action_description && (
                               <span className="ml-2">
                                 - {snapshot.action_description}

--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -131,17 +131,14 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
   // Client PO Number editing
   const [clientPoNumber, setClientPoNumber] = useState("")
   const [isEditingClientPo, setIsEditingClientPo] = useState(false)
-  const [savingClientPo, setSavingClientPo] = useState(false)
 
   // Work Description editing
   const [workDescription, setWorkDescription] = useState("")
   const [isEditingWorkDescription, setIsEditingWorkDescription] = useState(false)
-  const [savingWorkDescription, setSavingWorkDescription] = useState(false)
 
   // Hardware Schedule Version editing
   const [hardwareScheduleVersion, setHardwareScheduleVersion] = useState("")
   const [isEditingHardwareScheduleVersion, setIsEditingHardwareScheduleVersion] = useState(false)
-  const [savingHardwareScheduleVersion, setSavingHardwareScheduleVersion] = useState(false)
 
   // PMS (Project Management Services) dialog states
   const [pmsDialogOpen, setPmsDialogOpen] = useState(false)
@@ -212,8 +209,17 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
   // Computed: Is quote frozen (has been invoiced)?
   const hasBeenInvoiced = quote?.line_items.some(item => item.qty_fulfilled > 0) ?? false
 
+  // Metadata (client PO / work description / hardware schedule) is staged in edit
+  // mode and persisted on Commit — never eager-saved by the per-field Save button.
+  const metadataDirty =
+    editorMode === "edit" && !!quote && (
+      clientPoNumber.trim() !== (quote.client_po_number || "") ||
+      workDescription.trim() !== (quote.work_description || "") ||
+      hardwareScheduleVersion.trim() !== (quote.hardware_schedule_version || "")
+    )
+
   // Computed: Are there any staged changes?
-  const hasStagedChanges = stagedEdits.size > 0 || stagedAdds.length > 0 || stagedDeletes.size > 0
+  const hasStagedChanges = stagedEdits.size > 0 || stagedAdds.length > 0 || stagedDeletes.size > 0 || metadataDirty
 
   // Computed: Total count of staged changes
   const stagedChangesCount = stagedEdits.size + stagedAdds.length + stagedDeletes.size
@@ -592,6 +598,13 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
     setStagedAdds([])
     setStagedDeletes(new Set())
     setEditModeStartVersion(null)
+    // Revert any staged metadata edits back to the persisted values
+    setClientPoNumber(quote?.client_po_number || "")
+    setWorkDescription(quote?.work_description || "")
+    setHardwareScheduleVersion(quote?.hardware_schedule_version || "")
+    setIsEditingClientPo(false)
+    setIsEditingWorkDescription(false)
+    setIsEditingHardwareScheduleVersion(false)
     setEditorMode("view")
     setDiscardConfirmOpen(false)
   }
@@ -770,13 +783,29 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
         })
       }
 
-      const request: CommitEditsRequest = { changes }
-      await api.quotes.commitEdits(quoteId, request)
+      // Persist staged metadata edits (deferred from the per-field Save to Commit
+      // so editing a text field no longer eager-writes or leaves edit mode).
+      if (metadataDirty) {
+        await api.quotes.update(quoteId, {
+          client_po_number: clientPoNumber.trim() || null,
+          work_description: workDescription.trim() || null,
+          hardware_schedule_version: hardwareScheduleVersion.trim() || null,
+        })
+      }
+
+      // Commit line-item changes (skipped when only metadata changed)
+      if (changes.length > 0) {
+        const request: CommitEditsRequest = { changes }
+        await api.quotes.commitEdits(quoteId, request)
+      }
 
       // Clear staged changes and exit edit mode
       setStagedEdits(new Map())
       setStagedAdds([])
       setStagedDeletes(new Set())
+      setIsEditingClientPo(false)
+      setIsEditingWorkDescription(false)
+      setIsEditingHardwareScheduleVersion(false)
       setEditorMode("view")
 
       // Refresh quote data
@@ -803,47 +832,11 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
   // Check if controls should be enabled based on mode
   const canEdit = editorMode === "edit" && !hasBeenInvoiced
 
-  const handleSaveClientPoNumber = async () => {
-    setSavingClientPo(true)
-    try {
-      await api.quotes.update(quoteId, { client_po_number: clientPoNumber.trim() || null })
-      setIsEditingClientPo(false)
-      fetchQuote()
-      onUpdate?.()
-    } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to update Client PO Number")
-    } finally {
-      setSavingClientPo(false)
-    }
-  }
-
-  const handleSaveWorkDescription = async () => {
-    setSavingWorkDescription(true)
-    try {
-      await api.quotes.update(quoteId, { work_description: workDescription.trim() || null })
-      setIsEditingWorkDescription(false)
-      fetchQuote()
-      onUpdate?.()
-    } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to update Work Description")
-    } finally {
-      setSavingWorkDescription(false)
-    }
-  }
-
-  const handleSaveHardwareScheduleVersion = async () => {
-    setSavingHardwareScheduleVersion(true)
-    try {
-      await api.quotes.update(quoteId, { hardware_schedule_version: hardwareScheduleVersion.trim() || null })
-      setIsEditingHardwareScheduleVersion(false)
-      fetchQuote()
-      onUpdate?.()
-    } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to update Hardware Schedule Version")
-    } finally {
-      setSavingHardwareScheduleVersion(false)
-    }
-  }
+  // These per-field "Save" buttons only close the inline editor; the value is held
+  // in local state and persisted together on Commit (see handleCommitChanges).
+  const handleSaveClientPoNumber = () => setIsEditingClientPo(false)
+  const handleSaveWorkDescription = () => setIsEditingWorkDescription(false)
+  const handleSaveHardwareScheduleVersion = () => setIsEditingHardwareScheduleVersion(false)
 
   const handleCostCodeChange = async (value: string) => {
     const costCodeId = parseInt(value)
@@ -2806,9 +2799,8 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
               <Button
                 size="sm"
                 onClick={handleSaveClientPoNumber}
-                disabled={savingClientPo}
               >
-                {savingClientPo ? "Saving..." : "Save"}
+                Save
               </Button>
               <Button
                 size="sm"
@@ -2823,10 +2815,13 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
             </div>
           ) : (
             <div className="flex items-center gap-2">
-              {quote.client_po_number ? (
-                <span className="font-medium">{quote.client_po_number}</span>
+              {clientPoNumber.trim() ? (
+                <span className="font-medium">{clientPoNumber}</span>
               ) : (
                 <span className="text-muted-foreground" title={editorMode === "edit" ? "Click pencil to set" : undefined}>—</span>
+              )}
+              {editorMode === "edit" && clientPoNumber.trim() !== (quote.client_po_number || "") && (
+                <Badge variant="outline" className="text-xs bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 border-blue-300">Pending</Badge>
               )}
               {/* Edit button only visible in Edit mode */}
               {editorMode === "edit" && (
@@ -2836,7 +2831,7 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
               )}
             </div>
           )}
-          {!quote.client_po_number && (
+          {!clientPoNumber.trim() && (
             <p className="text-sm text-amber-600 mt-2">
               A Client PO Number is required before you can create an invoice.
             </p>
@@ -2890,9 +2885,8 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
                 <Button
                   size="sm"
                   onClick={handleSaveWorkDescription}
-                  disabled={savingWorkDescription}
                 >
-                  {savingWorkDescription ? "Saving..." : "Save"}
+                  Save
                 </Button>
                 <Button
                   size="sm"
@@ -2908,10 +2902,13 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
             </div>
           ) : (
             <div className="flex items-start gap-2">
-              {quote.work_description ? (
-                <p className="whitespace-pre-wrap">{quote.work_description}</p>
+              {workDescription.trim() ? (
+                <p className="whitespace-pre-wrap">{workDescription}</p>
               ) : (
                 <span className="text-muted-foreground" title={editorMode === "edit" ? "Click pencil to set" : undefined}>—</span>
+              )}
+              {editorMode === "edit" && workDescription.trim() !== (quote.work_description || "") && (
+                <Badge variant="outline" className="text-xs bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 border-blue-300 self-start">Pending</Badge>
               )}
               {/* Edit button only visible in Edit mode */}
               {editorMode === "edit" && (
@@ -2944,9 +2941,8 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
                 <Button
                   size="sm"
                   onClick={handleSaveHardwareScheduleVersion}
-                  disabled={savingHardwareScheduleVersion}
                 >
-                  {savingHardwareScheduleVersion ? "Saving..." : "Save"}
+                  Save
                 </Button>
                 <Button
                   size="sm"
@@ -2962,11 +2958,15 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
             </div>
           ) : (
             <div className="flex items-start gap-2">
-              {quote.hardware_schedule_version ? (
-                <p className="whitespace-pre-wrap">{quote.hardware_schedule_version}</p>
+              {hardwareScheduleVersion.trim() ? (
+                <p className="whitespace-pre-wrap">{hardwareScheduleVersion}</p>
               ) : (
                 <span className="text-muted-foreground" title={editorMode === "edit" ? "Click pencil to set" : undefined}>—</span>
               )}
+              {editorMode === "edit" && hardwareScheduleVersion.trim() !== (quote.hardware_schedule_version || "") && (
+                <Badge variant="outline" className="text-xs bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 border-blue-300 self-start">Pending</Badge>
+              )}
+              {/* Edit button only visible in Edit mode */}
               {editorMode === "edit" && (
                 <Button size="sm" variant="ghost" onClick={() => setIsEditingHardwareScheduleVersion(true)}>
                   <Pencil className="h-4 w-4" />

--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -50,7 +50,7 @@ import {
 import type { SearchableSelectOption } from "@/components/ui/searchable-select"
 import { api } from "@/api/client"
 import type {
-  Quote, QuoteLineItem, QuoteLineItemCreate, QuoteLineItemUpdate,
+  Quote, QuoteLineItem, QuoteLineItemCreate,
   LineItemType, Part, Labor, Miscellaneous, CostCode,
   StagedFulfillment, InvoiceCreate, QuoteEditorMode, StagedEdit, StagedAdd,
   StagedLineItemChange, CommitEditsRequest
@@ -95,10 +95,6 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
   // inventory edit form so the user can update the master record without leaving the quote.
   const [addDialogMode, setAddDialogMode] = useState<"select" | "edit-inventory">("select")
 
-  // Edit dialog states
-  const [editDialogOpen, setEditDialogOpen] = useState(false)
-  const [editingLineItem, setEditingLineItem] = useState<QuoteLineItem | null>(null)
-
   // Auto-add labor dialog
   const [autoAddLaborDialogOpen, setAutoAddLaborDialogOpen] = useState(false)
   const [pendingPart, setPendingPart] = useState<Part | null>(null)
@@ -114,9 +110,6 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
   const [selectedLaborId, setSelectedLaborId] = useState<string>("")
   const [selectedMiscId, setSelectedMiscId] = useState<string>("")
   const [quantity, setQuantity] = useState("1")
-
-  // Edit form fields
-  const [editQuantity, setEditQuantity] = useState("1")
 
   // Staged fulfillments (session only - not persisted until invoice created)
   const [stagedFulfillments, setStagedFulfillments] = useState<Map<number, number>>(new Map())
@@ -355,12 +348,6 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
     setAddDialogMode("select")
   }
 
-  const openEditDialog = (item: QuoteLineItem) => {
-    setEditingLineItem(item)
-    setEditQuantity(item.quantity.toString())
-    setEditDialogOpen(true)
-  }
-
   const handleAddLineItem = async () => {
     const qty = parseFloat(quantity) || 1
 
@@ -568,44 +555,6 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
       onUpdate?.()
     } catch (err) {
       alert(err instanceof Error ? err.message : "Failed to add part")
-    }
-  }
-
-  const handleUpdateLineItem = async () => {
-    if (!editingLineItem) return
-
-    const newQuantity = parseFloat(editQuantity) || 1
-
-    // In edit mode, stage the edit instead of immediate API call
-    if (editorMode === "edit") {
-      const changes: Partial<Omit<StagedEdit, "originalItem">> = {}
-
-      if (newQuantity !== editingLineItem.quantity) {
-        changes.quantity = newQuantity
-      }
-
-      if (Object.keys(changes).length > 0) {
-        stageEdit(editingLineItem, changes)
-      }
-
-      setEditDialogOpen(false)
-      setEditingLineItem(null)
-      return
-    }
-
-    // Direct API call when not in edit mode
-    const updateData: QuoteLineItemUpdate = {
-      quantity: newQuantity,
-    }
-
-    try {
-      await api.quotes.updateLine(quoteId, editingLineItem.id, updateData)
-      setEditDialogOpen(false)
-      setEditingLineItem(null)
-      fetchQuote()
-      onUpdate?.()
-    } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to update line item")
     }
   }
 
@@ -2246,9 +2195,22 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
                       </div>
                     </TableCell>
 
-                    {/* Qty Ordered Column */}
+                    {/* Qty Ordered Column — inline-editable in edit mode (non-PMS) */}
                     <TableCell className="text-right">
-                      {editedItem?.quantity !== undefined && editedItem.quantity !== item.quantity ? (
+                      {editorMode === "edit" && !item.is_pms ? (
+                        <Input
+                          type="number"
+                          step="1"
+                          min="1"
+                          className="w-20 h-7 text-right text-sm inline-block"
+                          value={editedItem?.quantity ?? item.quantity}
+                          onChange={(e) => {
+                            const val = e.target.value === "" ? 1 : parseInt(e.target.value, 10)
+                            if (!isNaN(val) && val >= 1) stageEdit(item, { quantity: val })
+                          }}
+                          disabled={isDeleted || hasBeenInvoiced}
+                        />
+                      ) : editedItem?.quantity !== undefined && editedItem.quantity !== item.quantity ? (
                         <span className="font-bold text-blue-600 dark:text-blue-400">{editedItem.quantity}</span>
                       ) : (
                         item.quantity
@@ -2445,16 +2407,6 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
                       {/* Edit Mode: Edit, Undo edit, Undo delete, Delete buttons */}
                       {editorMode === "edit" && (
                         <>
-                          {/* Edit button */}
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => openEditDialog(item)}
-                            disabled={hasBeenInvoiced || isDeleted}
-                            title={hasBeenInvoiced ? "Quote is frozen" : isDeleted ? "Item marked for deletion" : "Edit"}
-                          >
-                            <Pencil className="h-4 w-4" />
-                          </Button>
                           {/* Undo staged edit */}
                           {isEdited && !isDeleted && (
                             <Button
@@ -3702,48 +3654,6 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
         </DialogContent>
       </Dialog>
 
-      {/* Edit Line Item Dialog */}
-      <Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Edit Line Item</DialogTitle>
-            <DialogDescription>
-              Update the quantity for this line item.
-            </DialogDescription>
-          </DialogHeader>
-
-          {editingLineItem && (
-            <div className="space-y-4 pt-4">
-              <div className="bg-muted/50 p-3 rounded-md">
-                <p className="text-sm font-medium">{getDescriptionLabel(editingLineItem)}</p>
-                <p className="text-lg">{getLineItemDescription(editingLineItem)}</p>
-              </div>
-
-              <div className="space-y-2">
-                <Label>Quantity</Label>
-                <Input
-                  type="number"
-                  step="1"
-                  min="1"
-                  value={editQuantity}
-                  onChange={(e) => setEditQuantity(e.target.value)}
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label>Unit Price</Label>
-                <div className="px-3 py-2 bg-muted/50 rounded-md text-muted-foreground">
-                  ${getLineItemUnitPrice(editingLineItem).toFixed(2)}
-                </div>
-              </div>
-
-              <Button onClick={handleUpdateLineItem} className="w-full">
-                Save Changes
-              </Button>
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
 
       {/* Auto-Add Labor Confirmation Dialog */}
       <Dialog open={autoAddLaborDialogOpen} onOpenChange={setAutoAddLaborDialogOpen}>

--- a/frontend/src/components/pdf/InvoicePDF.tsx
+++ b/frontend/src/components/pdf/InvoicePDF.tsx
@@ -120,7 +120,7 @@ export function InvoicePDF({ invoice, quote, project, companySettings }: Invoice
             </View>
             <View style={styles.metaRow}>
               <Text style={styles.metaLabel}>Invoice #:</Text>
-              <Text style={styles.metaValue}>{invoice.id}</Text>
+              <Text style={styles.metaValue}>{invoice.invoice_number ?? invoice.id}</Text>
             </View>
             <View style={styles.metaRow}>
               <Text style={styles.metaLabel}>Quote Date:</Text>

--- a/frontend/src/components/pdf/ReceivedPurchaseOrderPDF.tsx
+++ b/frontend/src/components/pdf/ReceivedPurchaseOrderPDF.tsx
@@ -135,6 +135,12 @@ export function ReceivedPurchaseOrderPDF({
 }: ReceivedPurchaseOrderPDFProps) {
   const receiptIndex = buildReceiptIndex(receivings)
 
+  // For the receiving-history section: resolve line descriptions and order receipts.
+  const descById = new Map(po.line_items.map((i) => [i.id, getItemDescription(i)]))
+  const historyReceivings = [...receivings.filter((r) => !r.voided_at)].sort(
+    (a, b) => new Date(a.received_date).getTime() - new Date(b.received_date).getTime()
+  )
+
   const orderedSubtotal = po.line_items.reduce(
     (sum, item) => sum + (item.unit_price ?? 0) * item.quantity, 0
   )
@@ -249,6 +255,33 @@ export function ReceivedPurchaseOrderPDF({
             <Text style={[styles.totalsValue, styles.bold]}>{formatCurrency(receivedTotal)}</Text>
           </View>
         </View>
+
+        {/* Receiving History — what was received, when, and any notes */}
+        {historyReceivings.length > 0 && (
+          <View style={{ marginTop: 12 }}>
+            <Text style={styles.sectionTitle}>Receiving History</Text>
+            {historyReceivings.map((r, ri) => {
+              const lines = r.line_items.filter((li) => (li.qty_received_this_receiving ?? 0) > 0)
+              return (
+                <View
+                  key={ri}
+                  style={{ marginBottom: 6, paddingBottom: 4, borderBottomWidth: 0.5, borderBottomColor: BORDER_COLOR }}
+                  wrap={false}
+                >
+                  <Text style={[styles.bold, { fontSize: 8 }]}>{formatShortDate(r.received_date)}</Text>
+                  {lines.map((li, li_i) => (
+                    <Text key={li_i} style={{ fontSize: 8, marginLeft: 8 }}>
+                      • {li.qty_received_this_receiving} × {li.po_line_item_id != null ? (descById.get(li.po_line_item_id) ?? 'Item') : 'Item'}
+                    </Text>
+                  ))}
+                  {r.notes ? (
+                    <Text style={[styles.italic, { fontSize: 8, marginTop: 2 }]}>Notes: {r.notes}</Text>
+                  ) : null}
+                </View>
+              )
+            })}
+          </View>
+        )}
 
         <PDFFooter leftText={`PO ${po.po_number} — Receiving Document`} />
       </Page>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,6 +8,20 @@ import { ThemeProvider } from './components/theme-provider'
 
 const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string
 
+// Self-heal stale tabs after a deploy: hashed chunk filenames change between
+// builds, so a tab opened before a deploy references chunk names that 404 on
+// the next lazy import ("Failed to fetch dynamically imported module"). Reload
+// once to pull the fresh index.html + current chunks. The timestamp guard
+// avoids a reload loop if the import keeps failing for a real reason (offline).
+const PRELOAD_RELOAD_KEY = 'vite-preload-reloaded-at'
+window.addEventListener('vite:preloadError', (event) => {
+  const lastReload = Number(sessionStorage.getItem(PRELOAD_RELOAD_KEY) || 0)
+  if (Date.now() - lastReload < 10_000) return // already reloaded just now — let the error surface
+  event.preventDefault()
+  sessionStorage.setItem(PRELOAD_RELOAD_KEY, String(Date.now()))
+  window.location.reload()
+})
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ClerkProvider publishableKey={clerkPubKey} afterSignOutUrl="/">

--- a/frontend/src/pages/ProjectDetailsPage.tsx
+++ b/frontend/src/pages/ProjectDetailsPage.tsx
@@ -298,7 +298,7 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
     } else {
       const inv = invoices.find((x) => x.id === selectedDoc.id)
       if (!inv) return
-      label = `Invoice ${inv.id} - ${inv.quoteNumber}`
+      label = `Invoice ${inv.invoice_number ?? `${inv.id} - ${inv.quoteNumber}`}`
       sublabel = inv.status
     }
     setRecentDocs((prev) => {
@@ -885,7 +885,7 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
                   }}
                 >
                   <Receipt className="h-4 w-4" />
-                  <span className="flex-1">Invoice {inv.id} - {inv.quoteNumber}</span>
+                  <span className="flex-1">Invoice {inv.invoice_number ?? `${inv.id} - ${inv.quoteNumber}`}</span>
                   <StatusBadge status={inv.status} className="text-[10px]" />
                 </CommandItem>
               ))}
@@ -1008,7 +1008,7 @@ function InvoiceRow({ invoice, isSelected, isHighlighted, onSelect }: InvoiceRow
     >
       <div className="flex-1 min-w-0">
         <div className="text-sm font-medium flex items-center gap-2">
-          <span className="truncate">Invoice {invoice.id} - {invoice.quoteNumber}</span>
+          <span className="truncate">Invoice {invoice.invoice_number ?? `${invoice.id} - ${invoice.quoteNumber}`}</span>
           <StatusBadge status={invoice.status} className="text-[10px] px-1.5 py-0" />
         </div>
         <div className="text-xs text-muted-foreground">

--- a/frontend/src/pages/ProjectDetailsPage.tsx
+++ b/frontend/src/pages/ProjectDetailsPage.tsx
@@ -82,7 +82,7 @@ function EditorFallback() {
 interface ProjectDetailsPageProps {
   projectId: number
   onBack: () => void
-  initialDoc?: { type: "quote" | "po"; id: number } | null
+  initialDoc?: { type: "quote" | "po" | "invoice"; id: number } | null
 }
 
 type DocumentType = "quote" | "po" | "invoice"

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -643,6 +643,9 @@ export type InvoiceStatus = 'Sent' | 'Paid' | 'Voided';
 export interface Invoice {
   id: number;
   quote_id: number;
+  invoice_sequence: number;
+  quote_version: number;
+  invoice_number?: string | null; // Computed: "{invoice_sequence}-{UCA}-{quote_seq}-{quote_version}"
   created_at: string;
   status: InvoiceStatus;
   notes?: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -558,6 +558,8 @@ export interface POSnapshot {
   action_type: POSnapshotActionType;
   action_description?: string;
   created_at: string;
+  actor_user_id?: string | null;
+  actor_email?: string | null;
   receiving_id?: number;
   line_items_states: POLineItemSnapshot[];
 }
@@ -716,6 +718,8 @@ export interface QuoteSnapshot {
   action_type: SnapshotActionType;
   action_description?: string;
   created_at: string;
+  actor_user_id?: string | null;
+  actor_email?: string | null;
   invoice_id?: number;
   line_item_states: QuoteLineItemSnapshot[];
 }


### PR DESCRIPTION
## Scope-honest update

This PR started as two print-related bug fixes surfaced while testing #122, but accumulated five follow-up feature commits over the same session. Verification (2026-06-02) confirmed all seven commits are still needed (none has landed via another PR). CI is green, no conflicts with master.

The original title only described the first commit. Renamed to match the real shape.

**Closes #122** — see [#122 closure mapping](#122-closure-mapping) below: all ten items in the issue are addressed across this PR + prior merged work (#115, #121) + a pre-existing component (`InvoicePDF.tsx`).

## What lands (7 commits, 22 files, +690/−265)

### Fixes

- **Invoice deep-link routing** — `parseRoute` mapped `/projects/:id/invoices/:id` to `{type:"quote"}`, so fresh loads / bookmarks / back-forward loaded the wrong document and Print opened the wrong dialog. Now maps to `{type:"invoice"}`; `initialDoc` unions widened end-to-end (`App.tsx`, `ProjectDetailsPage`, `InvoiceEditor`). In-session clicks already worked; only fresh loads hit the broken path.
- **Stale-chunk self-heal** — `vite:preloadError` listener in `main.tsx` reloads once (timestamp-guarded against loops) so tabs opened before a deploy recover instead of throwing *"Failed to fetch dynamically imported module"* on the next lazy import.

### Quote Editor improvements

- **Inline-editable Qty Ordered** in edit mode — staged through the existing edit flow alongside unit-cost/markup. Removes the now-redundant per-row Edit pencil + quantity-only dialog. *(closes #122 item 8)*
- **Staged metadata edits** — Client PO / Work Description / Hardware Schedule edits now show a "Pending" badge in edit mode, persist on Commit alongside line-item changes, and revert on Discard. (Previously these wrote eagerly via `api.quotes.update` and felt like accidental commits.) *(closes #122 item 7)*

### PO Editor improvements

- **Add Line Item inventory details panel** — ports the #121 quote pattern to POEditor: after selecting a part, show inventory details with an "Edit details" affordance that swaps the dialog into PartForm edit mode and updates the master record. POs have no labour and misc is free-text, so only parts get the panel. *(closes #122 item 5, PO half)*
- **Receive All Pending button** on the receiving dialog (stages each line's full pending quantity) + **Receiving History section** on the received-PO PDF (per-receipt date, items/qtys, notes). *(closes #122 item 4 + extends item 3)*

### Invoice numbering

- **Structured invoice number** `{invoice_sequence}-{UCA}-{quote_seq:04d}-{quote_version}` replaces the raw DB id everywhere it's shown (invoice editor header, PDF, project sidebar, command palette).
- **Migration 021** (`20260528_021_add_invoice_numbering.py`) adds `invoice_sequence` (per-quote `ROW_NUMBER` backfill) and `quote_version` (linked-snapshot version backfill) as nullable columns, backfills, then enforces NOT NULL.
- ⚠️ Every existing invoice gets renumbered by the backfill. Verify the per-quote sequencing rule and the version-at-time-of-invoice capture are what you want on production data before merging. *(closes #122 item 10)*

### Audit-trail actor

- **Clerk JWT verification** via pure-ASGI middleware (`backend/auth.py`) — best-effort, non-blocking. Verifies session token against issuer JWKS, stashes user in a contextvar.
- `create_snapshot` / `create_po_snapshot` persist `actor_user_id` (verified Clerk `sub`) and `actor_email` (resolved via Clerk Admin API, cached per user). Frontend attaches the Clerk session token to every API request; audit-trail rows now show "by {email}".
- **Migration 022** (`20260528_022_add_snapshot_actor.py`) adds `actor_user_id` + `actor_email` (nullable) to `quote_snapshots` and `po_snapshots`.
- **New dependency:** `PyJWT[crypto]` in `backend/requirements.txt`. *(closes #122 item 6)*

## #122 closure mapping

All ten items in [#122 "Purchase Orders/Quotes"](https://github.com/Upper-Canada-Specialty-Hardware/uc-velocity/issues/122) are addressed:

| # | #122 item | Where addressed |
|---|---|---|
| 1 | PO printout reflects received/not | **#115** (`ReceivedPurchaseOrderPDF` + "Print Received" button at `POEditor.tsx:1753`) |
| 2 | Qty Pending colored RED | **#115** (`ReceivedPurchaseOrderPDF.tsx:66` — `bo` column color `#C00000`, rendered at line 124) |
| 3 | Receives in printout with notes + dates | **#115** + this PR commit 5 (Receiving History section) |
| 4 | Receive-all button for POs | This PR commit 5 (`811e9ed`) |
| 5 | Edit inventory while adding (quote + PO) | **#121** (quote half) + this PR commit 4 (`96ec39d`, PO half) |
| 6 | Audit trail — actor per action | This PR commit 7 (`654bc4c`) |
| 7 | Quote text fields don't auto-exit on Save | This PR commit 3 (`99e045f`) |
| 8 | Qty Ordered inline editable in quote | This PR commit 2 (`9ec5d79`) |
| 9 | Invoice printout entirely its own | **Pre-existing** — `InvoicePDF.tsx` already has its own `InvoiceLineItemTable`, own 6-column invoice-specific model (`qty_fulfilled_this_invoice`, `qty_pending_after`), own Payment Terms section, own header title "INVOICE". Shares only `styles.ts`/`PDFHeader`/`PDFFooter` (design-system primitives). |
| 10 | Invoice number `(invoice)-(quote)-(version)` | This PR commit 6 (`877ca9b`, + migration 021) |

## Deploy plan

This PR includes two Alembic migrations (021, 022). They apply automatically:

`backend/railway.toml` defines `preDeployCommand = "python -m alembic upgrade head"` (added by **#111**), so each Railway deploy runs migrations before workers boot. If the migration step fails, the deploy fails closed — no schema/code drift can silently ship.

**No env var setup needed.** The previous `ALEMBIC_AUTO_UPGRADE=1` dance is obsolete.

After merge:
1. Watch Railway deploy logs for `alembic upgrade head` — expect 021 + 022 to run.
2. Spot-check post-deploy: (a) open an existing invoice — new numbering renders correctly with backfilled sequence/version; (b) edit something — audit-trail row shows "by {your email}".