### PR TITLE
chore(build): raise chunkSizeWarningLimit to 2000

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     },
   },
   build: {
+    chunkSizeWarningLimit: 2000,
     rollupOptions: {
       output: {
         manualChunks(id) {


### PR DESCRIPTION
## Summary

- Adds `build.chunkSizeWarningLimit: 2000` (kB) to `frontend/vite.config.ts`
- Silences the Vite warning about `react-pdf.browser-*.js` (1.57 MB raw / 525 KB gzip), which exceeds the default 500 kB threshold
- The flagged chunk is **already lazy-loaded** — only fetched when a user clicks Print/Preview — so this is a cosmetic warning, not a runtime concern

## Context

Phase 4 bundle splitting (#90) already did the meaningful work: initial JS payload dropped from 2,710 KB to 567 KB raw (-79%) and the CSS bundle sits at ~67 KB (well under the threshold).

The remaining oversized chunk is \`@react-pdf/renderer\` itself. Per the existing comment in \`vite.config.ts\` (lines 18-24), splitting it further produced a circular chunk dependency via Rollup's CJS interop helper and undid the lazy split. So we've accepted the chunk size and are now telling Vite the same.

Fixes #28