### PR TITLE
fix(a11y/ux): P1 hardening pass — dialogs, table semantics, currency

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,18 @@ import { ProjectsPage } from "@/pages/ProjectsPage"
 import { api } from "@/api/client"
 import { useIsAdmin } from "@/hooks/use-is-admin"
 import { VirtualizedTable, headerCellClass, cellClass } from "@/components/ui/virtualized-table"
+import { formatCurrency } from "@/lib/format"
+import { toast } from "@/hooks/use-toast"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 
 // Lazy-loaded pages: keep ProjectsPage eager (default landing), defer the rest.
 const ProfilesPage = lazy(() =>
@@ -134,6 +146,13 @@ function App() {
   const [editingLabor, setEditingLabor] = useState<Labor | null>(null)
   const [editingMisc, setEditingMisc] = useState<Miscellaneous | null>(null)
 
+  // Inventory delete confirmation. One AlertDialog handles all three types,
+  // discriminated on `type` so the copy and the API call adapt.
+  type InventoryKind = "part" | "labor" | "misc"
+  const [deleteConfirm, setDeleteConfirm] = useState<
+    { type: InventoryKind; id: number; label: string } | null
+  >(null)
+
   // Mobile sidebar drawer state (#127): hidden by default, hamburger toggles it on `< md:`.
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
 
@@ -179,23 +198,33 @@ function App() {
     }
   }, [currentView])
 
-  const handleDeletePart = async (id: number) => {
-    if (!confirm("Are you sure you want to delete this part?")) return
-    try {
-      await api.parts.delete(id)
-      fetchInventory()
-    } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to delete part")
-    }
+  const requestDeletePart = (part: Part) => {
+    setDeleteConfirm({ type: "part", id: part.id, label: part.part_number })
   }
 
-  const handleDeleteLabor = async (id: number) => {
-    if (!confirm("Are you sure you want to delete this labor item?")) return
+  const requestDeleteLabor = (labor: Labor) => {
+    setDeleteConfirm({ type: "labor", id: labor.id, label: labor.description })
+  }
+
+  const requestDeleteMisc = (misc: Miscellaneous) => {
+    setDeleteConfirm({ type: "misc", id: misc.id, label: misc.description })
+  }
+
+  const performInventoryDelete = async () => {
+    if (!deleteConfirm) return
+    const { type, id } = deleteConfirm
+    setDeleteConfirm(null)
     try {
-      await api.labor.delete(id)
+      if (type === "part") await api.parts.delete(id)
+      else if (type === "labor") await api.labor.delete(id)
+      else await api.misc.delete(id)
       fetchInventory()
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to delete labor")
+      toast({
+        variant: "destructive",
+        title: `Failed to delete ${type === "labor" ? "labour" : type === "misc" ? "miscellaneous item" : type}`,
+        description: err instanceof Error ? err.message : "Unknown error",
+      })
     }
   }
 
@@ -207,16 +236,6 @@ function App() {
   const handleEditLabor = (labor: Labor) => {
     setEditingLabor(labor)
     setLaborDialogOpen(true)
-  }
-
-  const handleDeleteMisc = async (id: number) => {
-    if (!confirm("Are you sure you want to delete this miscellaneous item?")) return
-    try {
-      await api.misc.delete(id)
-      fetchInventory()
-    } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to delete miscellaneous item")
-    }
   }
 
   const handleEditMisc = (misc: Miscellaneous) => {
@@ -374,6 +393,7 @@ function App() {
               <div className="relative max-w-sm mb-4">
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <Input
+                  aria-label="Search inventory"
                   placeholder="Search inventory..."
                   value={inventorySearchTerm}
                   onChange={(e) => setInventorySearchTerm(e.target.value)}
@@ -396,6 +416,7 @@ function App() {
                     <div className="p-8 text-center text-muted-foreground">Loading...</div>
                   ) : (
                     <VirtualizedTable
+                      tableLabel="Parts inventory"
                       items={filteredParts}
                       rowHeight={52}
                       height="calc(100vh - 360px)"
@@ -418,9 +439,9 @@ function App() {
                         <>
                           <div className={`${cellClass} font-medium`}>{part.part_number}</div>
                           <div className={`${cellClass} text-muted-foreground truncate`}>{part.description}</div>
-                          <div className={`${cellClass} text-muted-foreground justify-end`}>${part.cost.toFixed(2)}</div>
+                          <div className={`${cellClass} text-muted-foreground justify-end`}>{formatCurrency(part.cost)}</div>
                           <div className={`${cellClass} text-muted-foreground justify-end`}>{part.markup_percent ?? 0}%</div>
-                          <div className={`${cellClass} font-medium justify-end`}>${(part.cost * (1 + (part.markup_percent ?? 0) / 100)).toFixed(2)}</div>
+                          <div className={`${cellClass} font-medium justify-end`}>{formatCurrency(part.cost * (1 + (part.markup_percent ?? 0) / 100))}</div>
                           <div className={`${cellClass} justify-end gap-1`}>
                             <Button
                               variant="ghost"
@@ -433,7 +454,7 @@ function App() {
                             <Button
                               variant="ghost"
                               size="sm"
-                              onClick={() => handleDeletePart(part.id)}
+                              onClick={() => requestDeletePart(part)}
                               className="text-destructive hover:text-destructive hover:bg-destructive/10"
                               aria-label={`Delete part ${part.part_number}`}
                             >
@@ -462,6 +483,7 @@ function App() {
                     <div className="p-8 text-center text-muted-foreground">Loading...</div>
                   ) : (
                     <VirtualizedTable
+                      tableLabel="Labour items"
                       items={filteredLaborItems}
                       rowHeight={52}
                       height="calc(100vh - 360px)"
@@ -484,9 +506,9 @@ function App() {
                         <>
                           <div className={`${cellClass} font-medium truncate`}>{labor.description}</div>
                           <div className={`${cellClass} text-muted-foreground justify-end`}>{labor.hours}</div>
-                          <div className={`${cellClass} text-muted-foreground justify-end`}>${labor.rate.toFixed(2)}/hr</div>
+                          <div className={`${cellClass} text-muted-foreground justify-end`}>{formatCurrency(labor.rate)}/hr</div>
                           <div className={`${cellClass} text-muted-foreground justify-end`}>{labor.markup_percent}%</div>
-                          <div className={`${cellClass} font-medium justify-end`}>${(labor.hours * labor.rate * (1 + labor.markup_percent / 100)).toFixed(2)}</div>
+                          <div className={`${cellClass} font-medium justify-end`}>{formatCurrency(labor.hours * labor.rate * (1 + labor.markup_percent / 100))}</div>
                           <div className={`${cellClass} justify-end gap-1`}>
                             <Button
                               variant="ghost"
@@ -499,7 +521,7 @@ function App() {
                             <Button
                               variant="ghost"
                               size="sm"
-                              onClick={() => handleDeleteLabor(labor.id)}
+                              onClick={() => requestDeleteLabor(labor)}
                               className="text-destructive hover:text-destructive hover:bg-destructive/10"
                               aria-label={`Delete labour ${labor.description}`}
                             >
@@ -528,6 +550,7 @@ function App() {
                     <div className="p-8 text-center text-muted-foreground">Loading...</div>
                   ) : (
                     <VirtualizedTable
+                      tableLabel="Miscellaneous items"
                       items={filteredMiscItems}
                       rowHeight={52}
                       height="calc(100vh - 360px)"
@@ -548,9 +571,9 @@ function App() {
                       renderRow={(misc) => (
                         <>
                           <div className={`${cellClass} font-medium truncate`}>{misc.description}</div>
-                          <div className={`${cellClass} text-muted-foreground justify-end`}>${misc.unit_price.toFixed(2)}</div>
+                          <div className={`${cellClass} text-muted-foreground justify-end`}>{formatCurrency(misc.unit_price)}</div>
                           <div className={`${cellClass} text-muted-foreground justify-end`}>{misc.markup_percent}%</div>
-                          <div className={`${cellClass} font-medium justify-end`}>${(misc.unit_price * (1 + misc.markup_percent / 100)).toFixed(2)}</div>
+                          <div className={`${cellClass} font-medium justify-end`}>{formatCurrency(misc.unit_price * (1 + misc.markup_percent / 100))}</div>
                           <div className={`${cellClass} justify-end gap-1`}>
                             <Button
                               variant="ghost"
@@ -563,7 +586,7 @@ function App() {
                             <Button
                               variant="ghost"
                               size="sm"
-                              onClick={() => handleDeleteMisc(misc.id)}
+                              onClick={() => requestDeleteMisc(misc)}
                               className="text-destructive hover:text-destructive hover:bg-destructive/10"
                               aria-label={`Delete miscellaneous item ${misc.description}`}
                             >
@@ -674,12 +697,22 @@ function App() {
 
     <Show when="signed-in">
     <div className="min-h-screen bg-background flex">
+      {/* Skip link — first focusable element on Tab, jumps past the sidebar/nav
+          to the main region. Visible only while focused. WCAG 2.4.1. */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-background focus:p-2 focus:ring-2 focus:ring-ring"
+      >
+        Skip to main content
+      </a>
       {/* Desktop sidebar — hidden below md, where the drawer takes over. */}
       <aside className="hidden md:flex w-64 border-r bg-card flex-col">
         <div className="p-6 border-b">
           <div className="flex items-start justify-between">
             <div>
-              <h1 className="text-xl font-bold">UC Velocity</h1>
+              {/* Brand chrome — page-level h1 lives on each route, so this is a styled
+                  paragraph rather than a heading to keep one h1 per page (a11y). */}
+              <p className="text-xl font-bold">UC Velocity</p>
               <p className="text-sm text-muted-foreground">ERP System</p>
             </div>
             <div className="flex items-center gap-1">
@@ -708,7 +741,7 @@ function App() {
           >
             <div className="p-4 border-b flex items-center justify-between gap-2">
               <div className="min-w-0">
-                <h1 className="text-lg font-bold truncate">UC Velocity</h1>
+                <p className="text-lg font-bold truncate">UC Velocity</p>
                 <p className="text-xs text-muted-foreground">ERP System</p>
               </div>
               <Button
@@ -726,7 +759,7 @@ function App() {
       )}
 
       {/* Main Content */}
-      <main className="flex-1 overflow-auto min-w-0">
+      <main id="main-content" tabIndex={-1} className="flex-1 overflow-auto min-w-0">
         {/* Mobile top bar — only visible below md. */}
         <header className="md:hidden sticky top-0 z-30 bg-card/95 backdrop-blur border-b flex items-center gap-2 px-3 py-2">
           <Button
@@ -809,6 +842,38 @@ function App() {
           />
         </DialogContent>
       </Dialog>
+
+      {/* Inventory Delete Confirmation (shared across Parts / Labour / Misc) */}
+      <AlertDialog
+        open={deleteConfirm !== null}
+        onOpenChange={(open) => { if (!open) setDeleteConfirm(null) }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {deleteConfirm?.type === "part" && "Delete part?"}
+              {deleteConfirm?.type === "labor" && "Delete labour item?"}
+              {deleteConfirm?.type === "misc" && "Delete miscellaneous item?"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleteConfirm ? (
+                <>
+                  This will permanently remove <span className="font-medium">{deleteConfirm.label}</span> from inventory. This action cannot be undone.
+                </>
+              ) : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={performInventoryDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <Toaster />
     </div>

--- a/frontend/src/components/editors/POAuditTrail.tsx
+++ b/frontend/src/components/editors/POAuditTrail.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { api } from "@/api/client"
+import { formatCurrency } from "@/lib/format"
 import type { POSnapshot, PORevertPreview } from "@/types"
 import { RevertConfirmDialog } from "./RevertConfirmDialog"
 import {
@@ -150,10 +151,6 @@ export function POAuditTrail({ purchaseOrderId, currentVersion, onRevert }: POAu
       hour: "numeric",
       minute: "2-digit",
     })
-  }
-
-  const formatCurrency = (value: number): string => {
-    return `$${value.toFixed(2)}`
   }
 
   if (loading) {

--- a/frontend/src/components/editors/POEditor.tsx
+++ b/frontend/src/components/editors/POEditor.tsx
@@ -62,7 +62,7 @@ import {
   History, ChevronDown, ChevronRight, Receipt, Info, ArrowLeft
 } from "lucide-react"
 import { StatusBadge } from "@/components/ui/status-badge"
-import { formatDate } from "@/lib/format"
+import { formatDate, formatCurrency } from "@/lib/format"
 import { PartForm } from "@/components/forms/PartForm"
 import { POAuditTrail } from "./POAuditTrail"
 
@@ -947,14 +947,10 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
     }
   }
 
-  const formatCurrency = (value: number): string => {
-    return `$${value.toFixed(2)}`
-  }
-
   const formatVariance = (variance: number): string => {
-    if (variance === 0) return "$0.00"
+    if (variance === 0) return formatCurrency(0)
     const sign = variance > 0 ? "+" : ""
-    return `${sign}$${variance.toFixed(2)}`
+    return `${sign}${formatCurrency(variance)}`
   }
 
   const getVarianceColor = (variance: number): string => {

--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -2097,7 +2097,7 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
                   onClick={() => openAddDialog(type)}
                   disabled={hasBeenInvoiced}
                   className="gap-2"
-                  title={hasBeenInvoiced ? "Quote is frozen" : `Add ${addButtonLabel}`}
+                  title={hasBeenInvoiced ? "Quote is frozen" : undefined}
                 >
                   <Plus className="h-4 w-4" />
                   {addButtonLabel}

--- a/frontend/src/components/ui/virtualized-table.tsx
+++ b/frontend/src/components/ui/virtualized-table.tsx
@@ -1,4 +1,12 @@
-import { useRef, type HTMLAttributes, type ReactNode } from "react"
+import {
+  cloneElement,
+  Fragment,
+  isValidElement,
+  useRef,
+  type HTMLAttributes,
+  type ReactElement,
+  type ReactNode,
+} from "react"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { cn } from "@/lib/utils"
 
@@ -31,6 +39,75 @@ interface VirtualizedTableProps<T> {
    * Use when rows can grow/shrink (e.g. expandable sub-rows). `rowHeight` becomes the initial estimate.
    */
   measureRows?: boolean
+  /**
+   * Accessible label for the table. Surfaced via aria-label on the outer
+   * role="table" so screen readers can announce e.g. "Parts inventory, table
+   * with 1,250 rows".
+   */
+  tableLabel?: string
+}
+
+type RoleableProps = { role?: string }
+type FragmentProps = { children?: ReactNode }
+
+/**
+ * Flatten a children tree (Fragment-aware) into a list of leaf elements with
+ * `role` injected. We descend into fragments because consumers commonly pass
+ * `<><div/><div/></>` as `header` / `renderRow` return values, and React's
+ * Children helpers treat the fragment itself as one child. Pre-existing `role`
+ * props are preserved so a consumer can override (e.g. `role="presentation"`).
+ */
+function withRole(children: ReactNode, role: string): ReactNode {
+  const out: ReactNode[] = []
+  let keyCounter = 0
+  const walk = (node: ReactNode): void => {
+    if (node == null || typeof node === "boolean") return
+    if (Array.isArray(node)) {
+      node.forEach(walk)
+      return
+    }
+    if (!isValidElement(node)) {
+      out.push(node)
+      return
+    }
+    if (node.type === Fragment) {
+      walk((node.props as FragmentProps).children)
+      return
+    }
+    const existing = (node.props as RoleableProps).role
+    const key = node.key ?? `__vt_${keyCounter++}`
+    out.push(
+      cloneElement(node as ReactElement<RoleableProps>, {
+        role: existing ?? role,
+        key,
+      })
+    )
+  }
+  walk(children)
+  return out
+}
+
+/** Count the leaf elements in a children tree (fragments transparent). */
+function countLeafChildren(children: ReactNode): number {
+  let count = 0
+  const walk = (node: ReactNode): void => {
+    if (node == null || typeof node === "boolean") return
+    if (Array.isArray(node)) {
+      node.forEach(walk)
+      return
+    }
+    if (!isValidElement(node)) {
+      count += 1
+      return
+    }
+    if (node.type === Fragment) {
+      walk((node.props as FragmentProps).children)
+      return
+    }
+    count += 1
+  }
+  walk(children)
+  return count
 }
 
 const HEADER_CLASS = "px-4 py-3 text-left text-sm font-medium text-muted-foreground"
@@ -57,6 +134,7 @@ export function VirtualizedTable<T>({
   rowClassName,
   getRowProps,
   measureRows = false,
+  tableLabel,
 }: VirtualizedTableProps<T>) {
   const parentRef = useRef<HTMLDivElement>(null)
   const virtualizer = useVirtualizer({
@@ -66,9 +144,28 @@ export function VirtualizedTable<T>({
     overscan,
   })
 
+  // Tag each direct child of the header fragment as a column header so AT
+  // sees real header cells rather than flat text inside a row.
+  const headerCells = withRole(header, "columnheader")
+  const colCount = countLeafChildren(header)
+
   return (
-    <div className={cn("bg-card rounded-lg border shadow-sm overflow-hidden", className)}>
-      <div className={cn("grid bg-muted/50 border-b", gridCols)}>{header}</div>
+    <div
+      className={cn("bg-card rounded-lg border shadow-sm overflow-hidden", className)}
+      role="table"
+      aria-label={tableLabel}
+      aria-rowcount={items.length + 1}
+      aria-colcount={colCount}
+    >
+      <div role="rowgroup">
+        <div
+          className={cn("grid bg-muted/50 border-b", gridCols)}
+          role="row"
+          aria-rowindex={1}
+        >
+          {headerCells}
+        </div>
+      </div>
       {items.length === 0 ? (
         <div className="p-8 text-center text-muted-foreground text-sm">{emptyMessage}</div>
       ) : (
@@ -76,7 +173,10 @@ export function VirtualizedTable<T>({
           ref={parentRef}
           style={{ height, overflow: "auto" }}
         >
-          <div style={{ height: virtualizer.getTotalSize(), position: "relative", width: "100%" }}>
+          <div
+            style={{ height: virtualizer.getTotalSize(), position: "relative", width: "100%" }}
+            role="rowgroup"
+          >
             {virtualizer.getVirtualItems().map((vi) => {
               const item = items[vi.index]
               const baseRowClass = "grid border-b hover:bg-muted/50 transition-colors"
@@ -84,11 +184,14 @@ export function VirtualizedTable<T>({
                 ? rowClassName(item, vi.index)
                 : rowClassName
               const rowProps = getRowProps?.(item, vi.index)
+              const rowCells = withRole(renderRow(item, vi.index), "gridcell")
               return (
                 <div
                   key={getKey(item, vi.index)}
                   data-index={vi.index}
                   ref={measureRows ? virtualizer.measureElement : undefined}
+                  role="row"
+                  aria-rowindex={vi.index + 2}
                   {...rowProps}
                   style={{
                     position: "absolute",
@@ -101,7 +204,7 @@ export function VirtualizedTable<T>({
                   }}
                   className={cn(baseRowClass, gridCols, customRowClass, rowProps?.className)}
                 >
-                  {renderRow(item, vi.index)}
+                  {rowCells}
                 </div>
               )
             })}

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,6 +1,7 @@
 /**
- * Shared formatting utilities so dates and empty values look identical across
- * the entire app. Adopting these is part of UX-3 (visual consistency).
+ * Shared formatting utilities so dates, currency, and empty values look
+ * identical across the entire app. Adopting these is part of UX-3
+ * (visual consistency).
  */
 
 const dateFormatter = new Intl.DateTimeFormat("en-US", {
@@ -9,12 +10,26 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
 })
 
+// narrowSymbol → `$` instead of the default `CA$` for en-CA.
+const currencyFormatter = new Intl.NumberFormat("en-CA", {
+  style: "currency",
+  currency: "CAD",
+  currencyDisplay: "narrowSymbol",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+})
+
 /** Render a date as `MMM d, yyyy` (e.g. `Jun 8, 2020`); em-dash for missing values. */
 export function formatDate(value: string | Date | null | undefined): string {
   if (value == null || value === "") return "—"
   const date = value instanceof Date ? value : new Date(value)
   if (Number.isNaN(date.getTime())) return "—"
   return dateFormatter.format(date)
+}
+
+/** Render a number as CAD currency with thousand separators (e.g. `$1,234.56`). */
+export function formatCurrency(amount: number): string {
+  return currencyFormatter.format(amount)
 }
 
 /** The single empty-value glyph used everywhere a read-only value is missing. */

--- a/frontend/src/lib/pricing.ts
+++ b/frontend/src/lib/pricing.ts
@@ -1,4 +1,9 @@
 import type { QuoteLineItem } from '@/types'
+import { formatCurrency } from '@/lib/format'
+
+// Re-exported so existing `import { formatCurrency } from '@/lib/pricing'`
+// call-sites keep working after the canonical formatter moved to lib/format.
+export { formatCurrency }
 
 /**
  * Get the base cost (before markup) for a quote line item.
@@ -117,7 +122,3 @@ export function calculateQuoteTotal(lineItems: QuoteLineItem[]): number {
   return nonPmsTotal + pmsTotal
 }
 
-/** Format a number as currency with 2 decimal places. */
-export function formatCurrency(amount: number): string {
-  return `$${amount.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',')}`
-}

--- a/frontend/src/pages/ProjectDetailsPage.tsx
+++ b/frontend/src/pages/ProjectDetailsPage.tsx
@@ -43,6 +43,7 @@ import {
   CommandList,
 } from "@/components/ui/command"
 import { api } from "@/api/client"
+import { toast } from "@/hooks/use-toast"
 import type { ProjectFull, Profile, Invoice } from "@/types"
 import {
   ArrowLeft,
@@ -212,12 +213,11 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
 
   const fetchInvoices = async (quotes: { id: number; quote_number: string }[]) => {
     try {
-      const allInvoices: (Invoice & { quoteId: number; quoteNumber: string })[] = []
-      for (const quote of quotes) {
-        const quoteInvoices = await api.quotes.getInvoices(quote.id)
-        allInvoices.push(...quoteInvoices.map(inv => ({ ...inv, quoteId: quote.id, quoteNumber: quote.quote_number })))
-      }
-      // Sort by created_at descending
+      // Fan out once per quote instead of waiting on each round-trip serially.
+      const results = await Promise.all(quotes.map((q) => api.quotes.getInvoices(q.id)))
+      const allInvoices = results.flatMap((arr, i) =>
+        arr.map((inv) => ({ ...inv, quoteId: quotes[i].id, quoteNumber: quotes[i].quote_number }))
+      )
       allInvoices.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
       setInvoices(allInvoices)
     } catch (err) {
@@ -337,7 +337,11 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
       setSelectedDoc({ type: "quote", id: quote.id })
       navigate(`/projects/${projectId}/quotes/${quote.id}?tab=quotes`)
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to create quote")
+      toast({
+        variant: "destructive",
+        title: "Failed to create quote",
+        description: err instanceof Error ? err.message : "Unknown error",
+      })
     }
   }
 
@@ -355,7 +359,11 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
       setSelectedDoc({ type: "po", id: po.id })
       navigate(`/projects/${projectId}/pos/${po.id}?tab=pos`)
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to create purchase order")
+      toast({
+        variant: "destructive",
+        title: "Failed to create purchase order",
+        description: err instanceof Error ? err.message : "Unknown error",
+      })
     }
   }
 
@@ -386,7 +394,11 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
       }
       fetchProject()
     } catch (err) {
-      alert(err instanceof Error ? err.message : `Failed to delete ${type === "po" ? "PO" : "quote"}`)
+      toast({
+        variant: "destructive",
+        title: `Failed to delete ${type === "po" ? "purchase order" : "quote"}`,
+        description: err instanceof Error ? err.message : "Unknown error",
+      })
     }
   }
 

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -10,10 +10,21 @@ import {
   DialogTitle,
   DialogDescription,
 } from "@/components/ui/dialog"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 import { VirtualizedTable, headerCellClass, cellClass } from "@/components/ui/virtualized-table"
 import { ProjectForm } from "@/components/forms/ProjectForm"
 import type { ProjectFormInput } from "@/components/forms/ProjectForm"
 import { api } from "@/api/client"
+import { toast } from "@/hooks/use-toast"
 import type { ProjectListView, ProjectSearchResult } from "@/types"
 import { Plus, Trash2, Pencil, FolderOpen, Search, FileText, ShoppingCart, Loader2, ChevronUp, ChevronDown, ArrowUpDown } from "lucide-react"
 
@@ -64,6 +75,7 @@ export function ProjectsPage({
   const [debouncedTerm, setDebouncedTerm] = useState(searchTerm)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [editingProject, setEditingProject] = useState<ProjectFormInput | null>(null)
+  const [deleteConfirm, setDeleteConfirm] = useState<{ id: number; name: string } | null>(null)
 
   // UX-4 filter controls
   const [showArchived, setShowArchived] = useState(false)
@@ -177,14 +189,24 @@ export function ProjectsPage({
     }
   }
 
-  const handleDelete = async (id: number, e: React.MouseEvent) => {
+  const requestDelete = (project: ProjectListView, e: React.MouseEvent) => {
     e.stopPropagation()
-    if (!confirm("Are you sure you want to delete this project? All quotes and purchase orders will be deleted.")) return
+    setDeleteConfirm({ id: project.id, name: project.name })
+  }
+
+  const performDelete = async () => {
+    if (!deleteConfirm) return
+    const { id } = deleteConfirm
+    setDeleteConfirm(null)
     try {
       await api.projects.delete(id)
       refreshAll()
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to delete project")
+      toast({
+        variant: "destructive",
+        title: "Failed to delete project",
+        description: err instanceof Error ? err.message : "Unknown error",
+      })
     }
   }
 
@@ -207,19 +229,23 @@ export function ProjectsPage({
   }
 
   // Sort headers — icon-only sort arrows pair with the column label, so they
-  // already have an accessible name. Kept as a small helper for clarity.
-  const SortHeader = ({ col, label, className = "" }: { col: SortColumn; label: string; className?: string }) => (
-    <div className={`${headerCellClass} ${className}`}>
-      <button
-        type="button"
-        onClick={() => toggleSort(col)}
-        className="inline-flex items-center gap-1 hover:text-foreground"
-        aria-label={`Sort by ${label}`}
-      >
-        {label} {renderSortIcon(col)}
-      </button>
-    </div>
-  )
+  // already have an accessible name. aria-sort communicates current state to AT.
+  const SortHeader = ({ col, label, className = "" }: { col: SortColumn; label: string; className?: string }) => {
+    const ariaSort: "ascending" | "descending" | "none" =
+      sortBy === col ? (sortDir === "asc" ? "ascending" : "descending") : "none"
+    return (
+      <div className={`${headerCellClass} ${className}`} role="columnheader" aria-sort={ariaSort}>
+        <button
+          type="button"
+          onClick={() => toggleSort(col)}
+          className="inline-flex items-center gap-1 hover:text-foreground"
+          aria-label={`Sort by ${label}`}
+        >
+          {label} {renderSortIcon(col)}
+        </button>
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-6">
@@ -245,6 +271,7 @@ export function ProjectsPage({
         <div className="relative max-w-md flex-1 min-w-[260px]">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
+            aria-label="Search projects, purchase orders, quotes, and vendors"
             placeholder="Search projects, POs, quotes, vendors..."
             value={searchTerm}
             onChange={(e) => onSearchTermChange(e.target.value)}
@@ -276,6 +303,7 @@ export function ProjectsPage({
         </div>
       ) : (
         <VirtualizedTable
+          tableLabel="Projects"
           items={displayProjects}
           rowHeight={60}
           measureRows
@@ -344,7 +372,7 @@ export function ProjectsPage({
                   <Button
                     variant="ghost"
                     size="sm"
-                    onClick={(e) => handleDelete(project.id, e)}
+                    onClick={(e) => requestDelete(project, e)}
                     className="text-destructive hover:text-destructive hover:bg-destructive/10"
                     aria-label={`Delete project ${project.name}`}
                   >
@@ -352,7 +380,7 @@ export function ProjectsPage({
                   </Button>
                 </div>
                 {hasChildMatches && (
-                  <div className="col-span-full bg-muted/20 border-l-2 border-l-primary/40 px-4 py-2 pl-10 flex flex-col gap-1 text-xs">
+                  <div className="col-span-full bg-muted/20 px-4 py-2 pl-10 flex flex-col gap-1 text-xs">
                     {project.matched_quotes.map((q) => (
                       <button
                         key={`q-${q.id}`}
@@ -414,6 +442,33 @@ export function ProjectsPage({
           />
         </DialogContent>
       </Dialog>
+
+      <AlertDialog
+        open={deleteConfirm !== null}
+        onOpenChange={(open) => { if (!open) setDeleteConfirm(null) }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete project?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleteConfirm ? (
+                <>
+                  This will permanently delete <span className="font-medium">{deleteConfirm.name}</span> along with all of its quotes and purchase orders. This action cannot be undone.
+                </>
+              ) : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={performDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete project
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Closes the ten P1 findings from the audit doc surfaced in #126.

### Replaced native dialogs with shadcn primitives — #132
- `ProjectsPage` delete → `AlertDialog` with project name in the body.
- `App.tsx` inventory deletes (parts, labour, misc) → one shared `AlertDialog` keyed by `type`, copy adapts.
- All six `alert(...)` error paths → `toast({variant:'destructive'})`.
- `ProjectDetailsPage` create/delete error notifications switched from `alert()` to `toast`; delete confirm was already on `AlertDialog`.

### A11y — table semantics
- **#133** `aria-sort="ascending|descending|none"` + `role="columnheader"` on `ProjectsPage` `SortHeader`.
- **#134** `VirtualizedTable` now exposes `role="table"`, `aria-label` (new `tableLabel` prop), `aria-rowcount`, `aria-colcount`, `role="rowgroup"` on header + body, and `role="row"` + `aria-rowindex` on each row. A `withRole` helper auto-injects `role="columnheader"` / `role="gridcell"` onto direct cell children — Fragment-aware so existing callers (`<>...</>`) don't need updates. Wired into all four callers (Projects + 3 Inventory tabs).
- **#135** Demoted `<h1>UC Velocity</h1>` in the sidebar (desktop + mobile drawer) to `<p>` so each page has a single `<h1>`.
- **#136** `aria-label` on the Projects search and Inventory search inputs.
- **#139** Skip-to-main-content link as the first focusable element of the signed-in shell; `<main id="main-content" tabIndex={-1}>` as the target so keyboard focus actually lands there.
- **#140** Quote Editor section add buttons no longer render `title="Add Add Part"` (the visible label `Add Part` is already self-describing; `title` is now only set to `"Quote is frozen"` when disabled).

### UX polish
- **#138** `formatCurrency` moved to `lib/format.ts` using `Intl.NumberFormat('en-CA', { style: 'currency', currency: 'CAD', currencyDisplay: 'narrowSymbol' })` — proper thousand separators and locale handling. Re-exported from `lib/pricing.ts` so every existing import keeps working. Inventory rows in `App.tsx` and the two local copies in `POEditor`/`POAuditTrail` now use the shared formatter.
- **#141** Removed the banned `border-l-2 border-l-primary/40` side-stripe on the matched-docs sub-row in `ProjectsPage` — the leading `↳` arrow and indent already convey hierarchy.

### Performance
- **#137** `fetchInvoices` in `ProjectDetailsPage` parallelized with `Promise.all` instead of awaiting per-quote sequentially.

Fixes #132
Fixes #133
Fixes #134
Fixes #135
Fixes #136
Fixes #137
Fixes #138
Fixes #139
Fixes #140
Fixes #141