### PR TITLE
fix(migration): prepend legacy work-order number to imported quote descriptions

### DIFF
--- a/backend/routes/migration.py
+++ b/backend/routes/migration.py
@@ -106,6 +106,19 @@ def safe_str(val: str | None, default: str = "") -> str:
     return val.strip() or default
 
 
+def wo_prefixed_description(legacy_wo_id: int, raw_desc: str | None) -> str:
+    """Prepend the legacy UC Vision work-order number to a quote's work description.
+
+    Issue #54: in UC Vision the WorkorderID was the human-facing quote-number.
+    Velocity replaced it with its own quote_number, so the legacy reference is
+    preserved at the very start of the migrated work description as "[WO {id}]".
+    A blank description collapses to just the "[WO {id}]" tag.
+    """
+    prefix = f"[WO {legacy_wo_id}]"
+    desc = safe_str(raw_desc)
+    return f"{prefix} {desc}" if desc else prefix
+
+
 def flush_batch(db: Session, batch: list, id_map: dict):
     """Flush a batch of (legacy_id, orm_object) and populate id_map."""
     if not batch:
@@ -636,12 +649,19 @@ async def import_legacy_data(
                 for seq, row in enumerate(quote_rows, start=1):
                     legacy_wo_id = int(row["_legacy_wo_id"])
 
+                    # Issue #54: prepend the legacy UC Vision work-order number
+                    # (WorkorderID) to the start of the work description so the old
+                    # quote-number reference survives the migration.
+                    work_description = wo_prefixed_description(
+                        legacy_wo_id, row.get("memWorkDescription", "")
+                    )
+
                     quote = Quote(
                         project_id=project_map[proj_legacy_id],
                         quote_sequence=seq,
                         created_at=parse_date(row.get("dtmDateStarted", "")) or datetime.utcnow(),
                         status="Closed",
-                        work_description=safe_str(row.get("memWorkDescription", "")) or None,
+                        work_description=work_description,
                         client_po_number=safe_str(row.get("intPONumber", "")) or None,
                         cost_code_id=None,
                         current_version=0,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -14,4 +14,11 @@ def _pg_reachable():
 # This prevents the ImportError from `from main import app` when
 # there's no local Postgres — while CI (which has Postgres) is unaffected.
 if not _pg_reachable():
-    collect_ignore = ["test_smoke.py", "test_backlog_report.py", "test_invoice_summary.py"]
+    collect_ignore = [
+        "test_smoke.py",
+        "test_backlog_report.py",
+        "test_invoice_summary.py",
+        # Imports routes.migration -> database, which requires DATABASE_URL.
+        # That env var is present in CI (alongside Postgres) but not locally.
+        "test_migration_import.py",
+    ]

--- a/backend/tests/test_migration_import.py
+++ b/backend/tests/test_migration_import.py
@@ -1,0 +1,34 @@
+"""Unit tests for legacy-import helpers.
+
+Issue #54: the legacy UC Vision WorkorderID (its quote-number) must be
+prepended as "[WO {id}]" to the very start of a migrated quote's work
+description. These tests exercise the pure prefixing helper directly,
+without standing up the full /import integration path.
+"""
+from routes.migration import wo_prefixed_description
+
+
+def test_wo_prefix_with_description():
+    assert (
+        wo_prefixed_description(29, "Install 2 hidden switches")
+        == "[WO 29] Install 2 hidden switches"
+    )
+
+
+def test_wo_prefix_strips_surrounding_whitespace():
+    # safe_str strips, so leading/trailing whitespace and newlines are normalized
+    assert wo_prefixed_description(29, "  \n Arrive on site \n ") == "[WO 29] Arrive on site"
+
+
+def test_wo_prefix_preserves_internal_newlines():
+    raw = "Line one.\nLine two."
+    assert wo_prefixed_description(100, raw) == "[WO 100] Line one.\nLine two."
+
+
+def test_wo_prefix_empty_description_collapses_to_tag():
+    assert wo_prefixed_description(29, "") == "[WO 29]"
+    assert wo_prefixed_description(29, "   ") == "[WO 29]"
+
+
+def test_wo_prefix_none_description_collapses_to_tag():
+    assert wo_prefixed_description(7, None) == "[WO 7]"


### PR DESCRIPTION
work order number from legacy quotes now lands at the very start of each migrated quote's work description, so the old UC Vision quote-number reference survives the move to Velocity.

in UC Vision the WorkorderID was the human-facing quote-number. Velocity replaced that with its own computed quote_number ({UCA Project Number}-{Sequence:04d}-{Version}), which left the legacy reference with nowhere to live. the legacy importer (POST /migration/import, tblServiceRecords.csv -> quotes) now prepends it inline as "[WO {WorkorderID}]".

a quote that previously imported as

    Arrive at N.Y.G.H and meet with Wayne at the emergency entrance...

now imports as

    [WO 29] Arrive at N.Y.G.H and meet with Wayne at the emergency entrance...

WorkorderID is the right field to prepend, confirmed against the legacy data:
- it's the only column in tblServiceRecords that's populated and unique across all 12,943 rows
- it's the linking key every child table references (intWorkorderID in tblWorkorderApplication / tblWorkorderMaterial / tblWorkorderZones)
- intOrderExtNumber (only 23 distinct values), intHeadingNumber (non-unique, many "n/a"), intSN, intWOType, and chrRevisionNumber ("W-0" / "Q-0" revision markers) were all ruled out as non-identifiers

the format also pins down a couple of edge cases:
- a blank memWorkDescription collapses to just the tag "[WO 29]" instead of the previous None, so the WO number is preserved even on quotes that never had a description
- leading/trailing whitespace on the legacy description is normalized away while internal newlines are kept
- only quote imports change. POs and quotes created natively in Velocity are untouched, since they never had a legacy WO number

this takes effect on the next full re-import. the importer wipes and rebuilds (TRUNCATE projects CASCADE), so the prefix bakes into every legacy quote the next time POST /migration/import runs. no separate backfill is needed, since the legacy data hasn't been cut over on top of live native data.

the prefixing logic is a small pure helper (wo_prefixed_description) next to the other import helpers, with unit tests covering the format and the empty / whitespace / None cases. that test file is gated like the other DB-dependent tests, skipped locally where there's no Postgres and run in CI.

Fixes #54
