### PR TITLE
fix(api): disable HTTP caching for all api calls

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -38,6 +38,10 @@ async function request<T>(
   }
 
   const response = await fetch(`${API_BASE}${endpoint}`, {
+    // Disable HTTP caching for all API calls so a cold full-page reload never
+    // replays a stale cached GET. Placed before ...options so a caller can
+    // still override it per-call if ever needed.
+    cache: 'no-store',
     ...options,
     headers: {
       'Content-Type': 'application/json',

--- a/frontend/src/test/api-cache.test.ts
+++ b/frontend/src/test/api-cache.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { api } from '@/api/client'
+
+describe('api client - HTTP caching', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('passes cache: no-store to fetch on a GET routed through request()', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    } as Response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    await api.costCodes.getAll()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [, options] = fetchMock.mock.calls[0]
+    expect(options).toMatchObject({ cache: 'no-store' })
+  })
+})


### PR DESCRIPTION
api client GET responses were going out with the browser's default cache mode, so a cold full-page reload could replay a stale cached GET and show out-of-date data.

fixed at the single chokepoint - the shared request() fetch wrapper in frontend/src/api/client.ts now sets cache: 'no-store' on the fetch options. it's placed before ...options so a caller could still override it per-call if that ever becomes necessary.

the two raw fetch calls that bypass request() (migration.import and vendorPricebook.import) are POST multipart uploads that caching never applied to, so they're left unchanged.

added a vitest that mocks fetch, calls a GET routed through request() (api.costCodes.getAll()), and asserts the second arg to fetch carries cache: 'no-store'.

Fixes #151