### PR TITLE
fix(invoices): split customer/project into two report columns and sort by date, customer, project

### DIFF
--- a/backend/routes/invoices.py
+++ b/backend/routes/invoices.py
@@ -51,7 +51,7 @@ def list_invoices(
     )
     if project_id is not None:
         query = query.filter(Project.id == project_id)
-    invoices = query.order_by(Invoice.created_at).all()
+    invoices = query.order_by(Invoice.created_at, Profile.name, Project.name).all()
 
     results = []
     for inv in invoices:

--- a/backend/tests/test_invoice_summary.py
+++ b/backend/tests/test_invoice_summary.py
@@ -28,6 +28,34 @@ def test_invoice_summary_rows_carry_project_fields():
         assert item["customer_name"]
 
 
+def test_invoice_summary_customer_and_project_are_distinct_fields():
+    """customer_name and project_name must come through as separate string fields."""
+    r = client.get(f"/invoices/?start_date={WIDE_START}&end_date={WIDE_END}")
+    assert r.status_code == 200
+    for item in r.json():
+        assert "customer_name" in item
+        assert "project_name" in item
+        assert isinstance(item["customer_name"], str)
+        assert isinstance(item["project_name"], str)
+
+
+def test_invoice_summary_sorted_by_date_then_customer_then_project():
+    """Rows must be ordered by invoice date, then customer name, then project name."""
+    r = client.get(f"/invoices/?start_date={WIDE_START}&end_date={WIDE_END}")
+    assert r.status_code == 200
+    rows = r.json()
+
+    # The sort key mirrors the backend order_by: created_at, then customer, then project.
+    # Casefold the text tie-breakers so the oracle is collation-agnostic: Python's
+    # code-point ordering and Postgres' locale-aware collation disagree on raw case,
+    # but both put names in the same case-insensitive order.
+    keys = [
+        (row["invoice_date"], row["customer_name"].casefold(), row["project_name"].casefold())
+        for row in rows
+    ]
+    assert keys == sorted(keys), "Rows are not sorted by date, then customer, then project"
+
+
 def test_invoice_summary_project_filter_narrows_results():
     """Passing project_id must return only invoices for that project."""
     all_rows = client.get(

--- a/frontend/src/components/pdf/InvoiceSummaryPDF.tsx
+++ b/frontend/src/components/pdf/InvoiceSummaryPDF.tsx
@@ -17,7 +17,8 @@ const col = {
   invoiceDate: { width: '11%' } as const,
   ucaProject: { width: '10%' } as const,
   poNumber: { width: '10%' } as const,
-  customerProject: { width: '28%' } as const,
+  customer: { width: '14%' } as const,
+  project: { width: '14%' } as const,
   netSales: { width: '11%', textAlign: 'right' as const },
   hst: { width: '11%', textAlign: 'right' as const },
   total: { width: '11%', textAlign: 'right' as const },
@@ -59,7 +60,8 @@ export function InvoiceSummaryPDF({ invoices, dateRange, companySettings, projec
           <Text style={[styles.colHeaderText, col.invoiceDate]}>Invoice Date</Text>
           <Text style={[styles.colHeaderText, col.ucaProject]}>UCA Project #</Text>
           <Text style={[styles.colHeaderText, col.poNumber]}>P/O Number</Text>
-          <Text style={[styles.colHeaderText, col.customerProject]}>Customer / Project Name</Text>
+          <Text style={[styles.colHeaderText, col.customer]}>Customer</Text>
+          <Text style={[styles.colHeaderText, col.project]}>Project</Text>
           <Text style={[styles.colHeaderText, col.netSales]}>Net Sales</Text>
           <Text style={[styles.colHeaderText, col.hst]}>HST</Text>
           <Text style={[styles.colHeaderText, col.total]}>Total</Text>
@@ -76,9 +78,8 @@ export function InvoiceSummaryPDF({ invoices, dateRange, companySettings, projec
             <Text style={col.invoiceDate}>{formatDate(inv.invoice_date)}</Text>
             <Text style={col.ucaProject}>{inv.uca_project_number}</Text>
             <Text style={col.poNumber}>{inv.client_po_number || ''}</Text>
-            <Text style={col.customerProject}>
-              {inv.customer_name} — {inv.project_name}
-            </Text>
+            <Text style={col.customer}>{inv.customer_name}</Text>
+            <Text style={col.project}>{inv.project_name}</Text>
             <Text style={col.netSales}>{formatCurrency(inv.net_sales)}</Text>
             <Text style={col.hst}>{formatCurrency(inv.hst_amount)}</Text>
             <Text style={col.total}>{formatCurrency(inv.grand_total)}</Text>
@@ -91,7 +92,8 @@ export function InvoiceSummaryPDF({ invoices, dateRange, companySettings, projec
           <Text style={col.invoiceDate} />
           <Text style={col.ucaProject} />
           <Text style={col.poNumber} />
-          <Text style={col.customerProject} />
+          <Text style={col.customer} />
+          <Text style={col.project} />
           <Text style={[col.netSales, styles.bold]}>{formatCurrency(totals.netSales)}</Text>
           <Text style={[col.hst, styles.bold]}>{formatCurrency(totals.hst)}</Text>
           <Text style={[col.total, styles.bold]}>{formatCurrency(totals.total)}</Text>

--- a/frontend/src/pages/ReportsPage.tsx
+++ b/frontend/src/pages/ReportsPage.tsx
@@ -292,7 +292,8 @@ export function ReportsPage() {
                         <th className="px-3 py-2 text-left font-medium text-muted-foreground">Date</th>
                         <th className="px-3 py-2 text-left font-medium text-muted-foreground">UCA Project #</th>
                         <th className="px-3 py-2 text-left font-medium text-muted-foreground">P/O Number</th>
-                        <th className="px-3 py-2 text-left font-medium text-muted-foreground">Customer / Project</th>
+                        <th className="px-3 py-2 text-left font-medium text-muted-foreground">Customer</th>
+                        <th className="px-3 py-2 text-left font-medium text-muted-foreground">Project</th>
                         <th className="px-3 py-2 text-right font-medium text-muted-foreground">Net Sales</th>
                         <th className="px-3 py-2 text-right font-medium text-muted-foreground">HST</th>
                         <th className="px-3 py-2 text-right font-medium text-muted-foreground">Total</th>
@@ -305,7 +306,8 @@ export function ReportsPage() {
                           <td className="px-3 py-2">{formatDate(inv.invoice_date)}</td>
                           <td className="px-3 py-2">{inv.uca_project_number}</td>
                           <td className="px-3 py-2">{inv.client_po_number || '—'}</td>
-                          <td className="px-3 py-2">{inv.customer_name} — {inv.project_name}</td>
+                          <td className="px-3 py-2">{inv.customer_name}</td>
+                          <td className="px-3 py-2">{inv.project_name}</td>
                           <td className="px-3 py-2 text-right">${inv.net_sales.toFixed(2)}</td>
                           <td className="px-3 py-2 text-right">${inv.hst_amount.toFixed(2)}</td>
                           <td className="px-3 py-2 text-right font-medium">${inv.grand_total.toFixed(2)}</td>
@@ -314,7 +316,7 @@ export function ReportsPage() {
                     </tbody>
                     <tfoot className="bg-muted/50 font-medium">
                       <tr>
-                        <td colSpan={5} className="px-3 py-2">Totals</td>
+                        <td colSpan={6} className="px-3 py-2">Totals</td>
                         <td className="px-3 py-2 text-right">
                           ${invoices.reduce((s, i) => s + i.net_sales, 0).toFixed(2)}
                         </td>


### PR DESCRIPTION
the invoice summary report glued the customer and project names into one "Customer / Project" cell in both places it renders - the on-screen preview table on the reports page and the generated PDF. this splits that into two distinct columns, "Customer" and "Project", in both spots. the underlying data was already split (InvoiceSummaryItem carries customer_name and project_name as separate fields), so there's no api or type change - it's presentation plus a sort tweak.

three files carry the change:

- backend/routes/invoices.py - the list endpoint kept created_at as the primary sort and added Profile.name then Project.name as tie-breakers, so rows now order by date, then customer, then project. the Profile and Project joins were already in the query.
- frontend/src/pages/ReportsPage.tsx - the preview table's single "Customer / Project" header and cell became two columns; the totals row colSpan bumped 5 to 6 to keep the footer aligned with the 9 columns.
- frontend/src/components/pdf/InvoiceSummaryPDF.tsx - same split in the PDF. the old 28% customer/project column became customer at 14% and project at 14%, so the row still sums to 100%.

dropping the join also removes the dash that used to sit between the two names in each combined cell.

the backend test in backend/tests/test_invoice_summary.py now asserts the new ordering and that customer_name and project_name come through as distinct string fields. the sort assertion casefolds the text keys so the oracle agrees with postgres collation regardless of locale.

Fixes #147