### PR TITLE
fix(inventory): default new items to 50% markup in forms and CSV import

### DIFF
--- a/backend/routes/vendor_pricebook.py
+++ b/backend/routes/vendor_pricebook.py
@@ -125,7 +125,7 @@ async def import_pricebook(
                 cost=cost,
                 vendor_id=vendor_id,
                 discount_percent=discount_percent,
-                markup_percent=0.0,
+                markup_percent=50.0,
             )
             db.add(new_part)
             created += 1

--- a/frontend/src/components/forms/LaborForm.tsx
+++ b/frontend/src/components/forms/LaborForm.tsx
@@ -21,7 +21,8 @@ export function LaborForm({ labor, onSuccess, onCancel }: LaborFormProps) {
   const [description, setDescription] = useState("")
   const [hours, setHours] = useState("")
   const [rate, setRate] = useState("")
-  const [markupPercent, setMarkupPercent] = useState("")
+  // New labour defaults to 50% markup; edit mode loads the item's real value below.
+  const [markupPercent, setMarkupPercent] = useState(isEditing ? "" : "50")
 
   // Populate form when editing
   useEffect(() => {

--- a/frontend/src/components/forms/MiscForm.tsx
+++ b/frontend/src/components/forms/MiscForm.tsx
@@ -20,7 +20,8 @@ export function MiscForm({ misc, onSuccess, onCancel }: MiscFormProps) {
   // Form state - use strings for number fields to allow empty while editing
   const [description, setDescription] = useState("")
   const [unitPrice, setUnitPrice] = useState("")
-  const [markupPercent, setMarkupPercent] = useState("")
+  // New misc items default to 50% markup; edit mode loads the item's real value below.
+  const [markupPercent, setMarkupPercent] = useState(isEditing ? "" : "50")
 
   // Populate form when editing
   useEffect(() => {

--- a/frontend/src/components/forms/PartForm.tsx
+++ b/frontend/src/components/forms/PartForm.tsx
@@ -33,7 +33,8 @@ export function PartForm({ part, onSuccess, onCancel }: PartFormProps) {
   const [partNumber, setPartNumber] = useState("")
   const [description, setDescription] = useState("")
   const [cost, setCost] = useState("")
-  const [markupPercent, setMarkupPercent] = useState("")
+  // New parts default to 50% markup; edit mode loads the part's real value below.
+  const [markupPercent, setMarkupPercent] = useState(isEditing ? "" : "50")
   const [selectedLaborIds, setSelectedLaborIds] = useState<string[]>([])
 
   // New pricing flow fields

--- a/frontend/src/test/form-markup-default.test.tsx
+++ b/frontend/src/test/form-markup-default.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { LaborForm } from '@/components/forms/LaborForm'
+import { MiscForm } from '@/components/forms/MiscForm'
+import { PartForm } from '@/components/forms/PartForm'
+import type { Labor, Miscellaneous, Part } from '@/types'
+
+// PartForm fetches labour + vendors on mount, and the create dialog for linked
+// labour relies on a couple of browser APIs jsdom does not implement. Mock the
+// api client so the form mounts without touching the network, and stub the
+// missing DOM APIs so the multi-select can render.
+vi.mock('@/api/client', () => ({
+  api: {
+    labor: { getAll: vi.fn().mockResolvedValue([]) },
+    profiles: { getAll: vi.fn().mockResolvedValue([]) },
+  },
+}))
+
+beforeAll(() => {
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  ;(globalThis as unknown as { ResizeObserver: typeof ResizeObserverMock }).ResizeObserver = ResizeObserverMock
+})
+
+// Follow-up to issue #146: new inventory must default to 50% markup. The
+// backend create-schema default only applies when the request omits
+// markup_percent, but these forms always send an explicit value, so the field
+// itself has to default to 50 in create mode (and still show the real value
+// when editing an existing item).
+describe('inventory forms — markup defaults to 50% on create (issue #146)', () => {
+  const markupValue = (container: HTMLElement): string =>
+    (container.querySelector('#markup') as HTMLInputElement).value
+
+  it('LaborForm defaults markup to 50 in create mode', () => {
+    const { container } = render(<LaborForm />)
+    expect(markupValue(container)).toBe('50')
+  })
+
+  it('MiscForm defaults markup to 50 in create mode', () => {
+    const { container } = render(<MiscForm />)
+    expect(markupValue(container)).toBe('50')
+  })
+
+  it('PartForm defaults markup to 50 in create mode', async () => {
+    const { container } = render(<PartForm />)
+    await waitFor(() => expect(container.querySelector('#markup')).not.toBeNull())
+    expect(markupValue(container)).toBe('50')
+  })
+
+  it('LaborForm shows the existing markup when editing, not 50', () => {
+    const labor = { id: 1, description: 'Install', hours: 2, rate: 50, markup_percent: 12 } as Labor
+    const { container } = render(<LaborForm labor={labor} />)
+    expect(markupValue(container)).toBe('12')
+  })
+
+  it('MiscForm shows the existing markup when editing, not 50', () => {
+    const misc = { id: 1, description: 'Rental', unit_price: 100, markup_percent: 12 } as Miscellaneous
+    const { container } = render(<MiscForm misc={misc} />)
+    expect(markupValue(container)).toBe('12')
+  })
+
+  it('PartForm shows the existing markup when editing, not 50', async () => {
+    const part = { id: 1, part_number: 'P-1', description: 'Widget', cost: 100, markup_percent: 12 } as Part
+    const { container } = render(<PartForm part={part} />)
+    await waitFor(() => expect(markupValue(container)).toBe('12'))
+  })
+})


### PR DESCRIPTION
follow-up to #146. that PR set markup_percent=50 on existing inventory and flipped the backend model + create-schema defaults to 50.0. but the schema default only kicks in when the create request OMITS markup_percent, and both the manual create forms and the vendor pricebook CSV import always send an explicit value - so newly created inventory still came in at 0%.

this makes new-inventory creation actually default to 50% across both paths:

- PartForm / LaborForm / MiscForm now seed the markup field with "50" in create mode (no existing item prop). edit mode is unchanged - the populate effect still loads the item's real markup, so editing an existing part/labour/misc shows its true value.
- vendor_pricebook CSV import constructed Part(... markup_percent=0.0); now markup_percent=50.0, so CSV-imported parts default to 50% too.
- added frontend/src/test/form-markup-default.test.tsx covering both behaviors: create mode defaults to 50, edit mode loads the existing value.

no schema or migration change here - this is purely the create-path default that #146 left at 0%. backend pytest is skipped locally (no Postgres); the vendor_pricebook change rides CI.