### PR TITLE
feat(audit): editable created-on date for quotes, POs, and invoices

### DIFF
--- a/backend/alembic/versions/20260617_024_invoice_versioning.py
+++ b/backend/alembic/versions/20260617_024_invoice_versioning.py
@@ -1,0 +1,82 @@
+"""Invoice versioning: current_version column + invoice snapshot tables
+
+Mirrors the quote snapshot/revert machinery for invoices so a "created on" date edit
+(and future invoice edits) can bump a version, land in an audit trail with the acting
+user, and be reverted. entity_created_at on invoice_snapshots holds the invoice's
+created_at at snapshot time so a revert can restore the date as well as the line items.
+
+Note: revision id kept short - alembic_version.version_num is VARCHAR(32).
+
+Revision ID: 024_invoice_versioning
+Revises: 023_bulk_markup_50
+Create Date: 2026-06-17
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '024_invoice_versioning'
+down_revision = '023_bulk_markup_50'
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(conn, table_name: str) -> bool:
+    return conn.dialect.has_table(conn, table_name)
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # invoices.current_version (invoice's own snapshot version)
+    conn.execute(sa.text(
+        "ALTER TABLE invoices ADD COLUMN IF NOT EXISTS current_version INTEGER NOT NULL DEFAULT 0"
+    ))
+
+    # invoice_snapshots
+    if not _table_exists(conn, 'invoice_snapshots'):
+        op.create_table(
+            'invoice_snapshots',
+            sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column('invoice_id', sa.Integer(), sa.ForeignKey('invoices.id'), nullable=False),
+            sa.Column('version', sa.Integer(), nullable=False),
+            sa.Column('action_type', sa.String(), nullable=False),
+            sa.Column('action_description', sa.String()),
+            sa.Column('created_at', sa.DateTime()),
+            sa.Column('entity_created_at', sa.DateTime()),
+            sa.Column('actor_user_id', sa.String()),
+            sa.Column('actor_email', sa.String()),
+        )
+        op.create_index('ix_invoice_snapshots_id', 'invoice_snapshots', ['id'])
+
+    # invoice_line_item_snapshots
+    if not _table_exists(conn, 'invoice_line_item_snapshots'):
+        op.create_table(
+            'invoice_line_item_snapshots',
+            sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column('snapshot_id', sa.Integer(), sa.ForeignKey('invoice_snapshots.id'), nullable=False),
+            sa.Column('original_line_item_id', sa.Integer()),
+            sa.Column('quote_line_item_id', sa.Integer()),
+            sa.Column('item_type', sa.String(), nullable=False),
+            sa.Column('description', sa.String()),
+            sa.Column('unit_price', sa.Float()),
+            sa.Column('qty_ordered', sa.Integer()),
+            sa.Column('qty_fulfilled_this_invoice', sa.Integer()),
+            sa.Column('qty_fulfilled_total', sa.Integer()),
+            sa.Column('qty_pending_after', sa.Integer()),
+            sa.Column('labor_id', sa.Integer()),
+            sa.Column('part_id', sa.Integer()),
+            sa.Column('misc_id', sa.Integer()),
+        )
+        op.create_index('ix_invoice_line_item_snapshots_id', 'invoice_line_item_snapshots', ['id'])
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    if _table_exists(conn, 'invoice_line_item_snapshots'):
+        op.drop_table('invoice_line_item_snapshots')
+    if _table_exists(conn, 'invoice_snapshots'):
+        op.drop_table('invoice_snapshots')
+
+    conn.execute(sa.text("ALTER TABLE invoices DROP COLUMN IF EXISTS current_version"))

--- a/backend/models.py
+++ b/backend/models.py
@@ -308,7 +308,7 @@ class POSnapshot(Base):
     id = Column(Integer, primary_key=True, index=True)
     purchase_order_id = Column(Integer, ForeignKey('purchase_orders.id'), nullable=False)
     version = Column(Integer, nullable=False)
-    action_type = Column(String, nullable=False)  # "create", "edit", "delete", "receive", "status_change", "revert"
+    action_type = Column(String, nullable=False)  # "create", "edit", "delete", "receive", "status_change", "date_edit", "revert"
     action_description = Column(String, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     receiving_id = Column(Integer, ForeignKey('po_receivings.id'), nullable=True)
@@ -352,12 +352,14 @@ class Invoice(Base):
     notes = Column(String)  # Optional notes for this invoice
     invoice_sequence = Column(Integer, default=1)  # Per-quote sequence (1, 2, 3...)
     quote_version = Column(Integer, default=0)  # Quote version captured at invoice time
+    current_version = Column(Integer, default=0, server_default='0')  # Invoice's own snapshot version (audit trail)
     voided_at = Column(DateTime)  # When voided (if applicable)
     voided_by_snapshot_id = Column(Integer)  # Which revert voided this
 
     # Relationships
     quote = relationship("Quote", back_populates="invoices")
     line_items = relationship("InvoiceLineItem", back_populates="invoice", cascade="all, delete-orphan")
+    snapshots = relationship("InvoiceSnapshot", back_populates="invoice", cascade="all, delete-orphan", order_by="InvoiceSnapshot.version")
 
 
 class InvoiceLineItem(Base):
@@ -385,6 +387,50 @@ class InvoiceLineItem(Base):
     invoice = relationship("Invoice", back_populates="line_items")
 
 
+# ===== Invoice Snapshot Models (for versioning/revert) =====
+
+class InvoiceSnapshot(Base):
+    __tablename__ = "invoice_snapshots"
+
+    id = Column(Integer, primary_key=True, index=True)
+    invoice_id = Column(Integer, ForeignKey('invoices.id'), nullable=False)
+    version = Column(Integer, nullable=False)
+    action_type = Column(String, nullable=False)  # "date_edit", "revert"
+    action_description = Column(String)
+    created_at = Column(DateTime, default=datetime.utcnow)  # When this snapshot was taken
+    entity_created_at = Column(DateTime, nullable=True)  # The invoice's created_at at snapshot time (for revert)
+    actor_user_id = Column(String, nullable=True)  # Clerk user id (sub) who performed the action
+    actor_email = Column(String, nullable=True)  # Resolved email, for display
+
+    # Relationships
+    invoice = relationship("Invoice", back_populates="snapshots")
+    line_item_states = relationship("InvoiceLineItemSnapshot", back_populates="snapshot", cascade="all, delete-orphan")
+
+
+class InvoiceLineItemSnapshot(Base):
+    __tablename__ = "invoice_line_item_snapshots"
+
+    id = Column(Integer, primary_key=True, index=True)
+    snapshot_id = Column(Integer, ForeignKey('invoice_snapshots.id'), nullable=False)
+    original_line_item_id = Column(Integer, nullable=True)  # Reference to original invoice line item
+    quote_line_item_id = Column(Integer, nullable=True)  # The invoice line's quote_line_item_id
+
+    # Full state of the invoice line at this snapshot
+    item_type = Column(String, nullable=False)
+    description = Column(String, nullable=True)
+    unit_price = Column(Float, nullable=True)
+    qty_ordered = Column(Integer, nullable=True)
+    qty_fulfilled_this_invoice = Column(Integer, nullable=True)
+    qty_fulfilled_total = Column(Integer, nullable=True)
+    qty_pending_after = Column(Integer, nullable=True)
+    labor_id = Column(Integer, nullable=True)
+    part_id = Column(Integer, nullable=True)
+    misc_id = Column(Integer, nullable=True)
+
+    # Relationships
+    snapshot = relationship("InvoiceSnapshot", back_populates="line_item_states")
+
+
 # ===== Quote Snapshot Models (for versioning/revert) =====
 
 class QuoteSnapshot(Base):
@@ -393,7 +439,7 @@ class QuoteSnapshot(Base):
     id = Column(Integer, primary_key=True, index=True)
     quote_id = Column(Integer, ForeignKey('quotes.id'), nullable=False)
     version = Column(Integer, nullable=False)
-    action_type = Column(String, nullable=False)  # "create", "edit", "delete", "invoice", "revert"
+    action_type = Column(String, nullable=False)  # "create", "edit", "delete", "invoice", "date_edit", "revert"
     action_description = Column(String)
     created_at = Column(DateTime, default=datetime.utcnow)
     invoice_id = Column(Integer)  # If action_type="invoice", link to Invoice

--- a/backend/routes/invoices.py
+++ b/backend/routes/invoices.py
@@ -4,21 +4,82 @@ from typing import List, Optional
 from datetime import datetime, date
 
 from database import get_db
+from auth import current_actor
+from utils import to_naive_utc
 from models import (
     Quote, QuoteLineItem, Invoice, InvoiceLineItem,
     QuoteSnapshot, QuoteLineItemSnapshot, Labor, Part, Miscellaneous,
-    Project, Profile, CompanySettings
+    Project, Profile, CompanySettings,
+    InvoiceSnapshot, InvoiceLineItemSnapshot
 )
 from schemas import (
     Invoice as InvoiceSchema,
     InvoiceCreate,
     InvoiceStatusUpdate,
     LineItemFulfillment,
-    InvoiceSummaryItem
+    InvoiceSummaryItem,
+    InvoiceSnapshot as InvoiceSnapshotSchema,
+    InvoiceRevertPreview,
+    CreatedAtUpdate
 )
 from routes.quotes import populate_invoice_number
 
 router = APIRouter(prefix="/invoices", tags=["invoices"])
+
+
+def create_invoice_snapshot(
+    db: Session,
+    invoice: Invoice,
+    action_type: str,
+    action_description: str,
+) -> InvoiceSnapshot:
+    """
+    Create a snapshot of the current invoice state (mirrors create_snapshot for quotes).
+
+    Increments invoice.current_version by 1, writes an InvoiceSnapshot (capturing the
+    invoice's created_at in entity_created_at so a revert can restore the date) plus a
+    snapshot of every invoice line item, and stamps the acting user from the request
+    context.
+    """
+    new_version = invoice.current_version + 1
+    invoice.current_version = new_version
+
+    actor = current_actor.get()
+    snapshot = InvoiceSnapshot(
+        invoice_id=invoice.id,
+        version=new_version,
+        action_type=action_type,
+        action_description=action_description,
+        entity_created_at=invoice.created_at,
+        actor_user_id=actor["user_id"] if actor else None,
+        actor_email=actor.get("email") if actor else None,
+    )
+    db.add(snapshot)
+    db.flush()  # Get the snapshot ID
+
+    line_items = (
+        db.query(InvoiceLineItem)
+        .filter(InvoiceLineItem.invoice_id == invoice.id)
+        .all()
+    )
+    for item in line_items:
+        db.add(InvoiceLineItemSnapshot(
+            snapshot_id=snapshot.id,
+            original_line_item_id=item.id,
+            quote_line_item_id=item.quote_line_item_id,
+            item_type=item.item_type,
+            description=item.description,
+            unit_price=item.unit_price,
+            qty_ordered=item.qty_ordered,
+            qty_fulfilled_this_invoice=item.qty_fulfilled_this_invoice,
+            qty_fulfilled_total=item.qty_fulfilled_total,
+            qty_pending_after=item.qty_pending_after,
+            labor_id=item.labor_id,
+            part_id=item.part_id,
+            misc_id=item.misc_id,
+        ))
+
+    return snapshot
 
 
 @router.get("/", response_model=List[InvoiceSummaryItem])
@@ -149,6 +210,179 @@ def update_invoice_status(
             joinedload(Invoice.line_items),
             joinedload(Invoice.quote).joinedload(Quote.project),
         )
+        .filter(Invoice.id == invoice_id)
+        .first()
+    )
+    return populate_invoice_number(invoice, db)
+
+
+@router.put("/{invoice_id}/created-at", response_model=InvoiceSchema)
+def update_invoice_created_at(invoice_id: int, payload: CreatedAtUpdate, db: Session = Depends(get_db)):
+    """
+    Edit the 'created on' date/time of an invoice.
+
+    Bumps current_version by 1 and records the change in the invoice audit trail. There
+    is NO frozen guard: an invoice only exists once its quote has been frozen, so the
+    parent quote is always frozen and the invoice date must stay editable.
+
+    invoice_number does NOT embed the invoice's own version, so bumping current_version
+    here does not change the visible invoice number.
+    """
+    invoice = (
+        db.query(Invoice)
+        .options(joinedload(Invoice.line_items), joinedload(Invoice.quote).joinedload(Quote.project))
+        .filter(Invoice.id == invoice_id)
+        .first()
+    )
+    if not invoice:
+        raise HTTPException(status_code=404, detail="Invoice not found")
+
+    old_created_at = invoice.created_at
+    invoice.created_at = to_naive_utc(payload.created_at)
+
+    create_invoice_snapshot(
+        db,
+        invoice,
+        action_type="date_edit",
+        action_description=f"Created date changed from {old_created_at} to {invoice.created_at}",
+    )
+
+    db.commit()
+
+    invoice = (
+        db.query(Invoice)
+        .options(joinedload(Invoice.line_items), joinedload(Invoice.quote).joinedload(Quote.project))
+        .filter(Invoice.id == invoice_id)
+        .first()
+    )
+    return populate_invoice_number(invoice, db)
+
+
+# ==================== Snapshots (audit trail) ====================
+
+@router.get("/{invoice_id}/snapshots", response_model=List[InvoiceSnapshotSchema])
+def get_invoice_snapshots(invoice_id: int, db: Session = Depends(get_db)):
+    """Get all snapshots (audit trail) for an invoice, newest first."""
+    invoice = db.query(Invoice).filter(Invoice.id == invoice_id).first()
+    if not invoice:
+        raise HTTPException(status_code=404, detail="Invoice not found")
+
+    snapshots = (
+        db.query(InvoiceSnapshot)
+        .options(joinedload(InvoiceSnapshot.line_item_states))
+        .filter(InvoiceSnapshot.invoice_id == invoice_id)
+        .order_by(InvoiceSnapshot.version.desc())
+        .all()
+    )
+    return snapshots
+
+
+@router.get("/{invoice_id}/snapshots/{version}", response_model=InvoiceSnapshotSchema)
+def get_invoice_snapshot(invoice_id: int, version: int, db: Session = Depends(get_db)):
+    """Get a specific invoice snapshot by version."""
+    snapshot = (
+        db.query(InvoiceSnapshot)
+        .options(joinedload(InvoiceSnapshot.line_item_states))
+        .filter(InvoiceSnapshot.invoice_id == invoice_id, InvoiceSnapshot.version == version)
+        .first()
+    )
+    if not snapshot:
+        raise HTTPException(status_code=404, detail="Snapshot not found")
+    return snapshot
+
+
+# ==================== Revert ====================
+
+@router.get("/{invoice_id}/revert/{version}/preview", response_model=InvoiceRevertPreview)
+def preview_invoice_revert(invoice_id: int, version: int, db: Session = Depends(get_db)):
+    """Preview what would happen if we revert the invoice to a specific version."""
+    invoice = db.query(Invoice).filter(Invoice.id == invoice_id).first()
+    if not invoice:
+        raise HTTPException(status_code=404, detail="Invoice not found")
+
+    target_snapshot = (
+        db.query(InvoiceSnapshot)
+        .filter(InvoiceSnapshot.invoice_id == invoice_id, InvoiceSnapshot.version == version)
+        .first()
+    )
+    if not target_snapshot:
+        raise HTTPException(status_code=404, detail="Snapshot not found")
+
+    if target_snapshot.entity_created_at is not None:
+        summary = f"Reverting will restore the created date to {target_snapshot.entity_created_at} and the line items as of version {version}."
+    else:
+        summary = f"Reverting will restore the line items as of version {version}."
+
+    return InvoiceRevertPreview(target_version=version, changes_summary=summary)
+
+
+@router.post("/{invoice_id}/revert/{version}", response_model=InvoiceSchema)
+def revert_invoice_to_snapshot(invoice_id: int, version: int, db: Session = Depends(get_db)):
+    """
+    Revert the invoice to a specific snapshot version.
+    - Restores all line items to their state at that version
+    - Restores created_at from the snapshot's entity_created_at
+    - Creates a new snapshot recording the revert action
+    """
+    invoice = (
+        db.query(Invoice)
+        .options(joinedload(Invoice.line_items), joinedload(Invoice.quote).joinedload(Quote.project))
+        .filter(Invoice.id == invoice_id)
+        .first()
+    )
+    if not invoice:
+        raise HTTPException(status_code=404, detail="Invoice not found")
+
+    target_snapshot = (
+        db.query(InvoiceSnapshot)
+        .options(joinedload(InvoiceSnapshot.line_item_states))
+        .filter(InvoiceSnapshot.invoice_id == invoice_id, InvoiceSnapshot.version == version)
+        .first()
+    )
+    if not target_snapshot:
+        raise HTTPException(status_code=404, detail="Snapshot not found")
+
+    if version >= invoice.current_version:
+        raise HTTPException(status_code=400, detail="Cannot revert to current or future version")
+
+    # Restore created_at from the snapshot (entity_created_at captured at snapshot time)
+    if target_snapshot.entity_created_at is not None:
+        invoice.created_at = target_snapshot.entity_created_at
+
+    # Replace current line items with the snapshot's line items
+    db.query(InvoiceLineItem).filter(InvoiceLineItem.invoice_id == invoice_id).delete()
+
+    for item_state in target_snapshot.line_item_states:
+        db.add(InvoiceLineItem(
+            invoice_id=invoice_id,
+            quote_line_item_id=item_state.quote_line_item_id,
+            item_type=item_state.item_type,
+            description=item_state.description,
+            unit_price=item_state.unit_price,
+            qty_ordered=item_state.qty_ordered,
+            qty_fulfilled_this_invoice=item_state.qty_fulfilled_this_invoice,
+            qty_fulfilled_total=item_state.qty_fulfilled_total,
+            qty_pending_after=item_state.qty_pending_after,
+            labor_id=item_state.labor_id,
+            part_id=item_state.part_id,
+            misc_id=item_state.misc_id,
+        ))
+
+    db.flush()
+
+    # Snapshot the revert action (re-captures the now-restored state)
+    create_invoice_snapshot(
+        db,
+        invoice,
+        action_type="revert",
+        action_description=f"Reverted to version {version}",
+    )
+
+    db.commit()
+
+    invoice = (
+        db.query(Invoice)
+        .options(joinedload(Invoice.line_items), joinedload(Invoice.quote).joinedload(Quote.project))
         .filter(Invoice.id == invoice_id)
         .first()
     )

--- a/backend/routes/purchase_orders.py
+++ b/backend/routes/purchase_orders.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 from database import get_db
 from auth import current_actor
+from utils import to_naive_utc
 from models import (
     PurchaseOrder, POLineItem, Project, Profile, ProfileType, Part,
     POReceiving, POReceivingLineItem, POSnapshot, POLineItemSnapshot, POStatus, CostCode
@@ -17,7 +18,8 @@ from schemas import (
     POReceiving as POReceivingSchema, POReceivingCreate, POReceivingLineItemCreate,
     POReceivingLineItem as POReceivingLineItemSchema,
     POSnapshot as POSnapshotSchema, POLineItemSnapshot as POLineItemSnapshotSchema,
-    PORevertPreview, POCommitEditsRequest, POCommitEditsResponse, StagedPOLineItemChange
+    PORevertPreview, POCommitEditsRequest, POCommitEditsResponse, StagedPOLineItemChange,
+    CreatedAtUpdate
 )
 
 DEFAULT_LIMIT = 50
@@ -433,6 +435,48 @@ def update_purchase_order(
             joinedload(PurchaseOrder.cost_code)
         )
         .filter(PurchaseOrder.id == db_po.id)
+        .first()
+    )
+    return populate_po_number(db_po, db_po.project.uca_project_number)
+
+
+@router.put("/{po_id}/created-at", response_model=PurchaseOrderSchema)
+def update_po_created_at(po_id: int, payload: CreatedAtUpdate, db: Session = Depends(get_db)):
+    """
+    Edit the 'created on' date/time of a purchase order.
+
+    Bumps current_version by 1 (which changes the visible PO number) and records the
+    change in the audit trail. POs have no frozen/invoiced state, so this is always allowed.
+    """
+    db_po = (
+        db.query(PurchaseOrder)
+        .options(joinedload(PurchaseOrder.project))
+        .filter(PurchaseOrder.id == po_id)
+        .first()
+    )
+    if not db_po:
+        raise HTTPException(status_code=404, detail="Purchase order not found")
+
+    old_created_at = db_po.created_at
+    db_po.created_at = to_naive_utc(payload.created_at)
+
+    create_po_snapshot(
+        db,
+        db_po,
+        "date_edit",
+        f"Created date changed from {old_created_at} to {db_po.created_at}",
+    )
+
+    db.commit()
+
+    db_po = (
+        db.query(PurchaseOrder)
+        .options(
+            joinedload(PurchaseOrder.vendor),
+            joinedload(PurchaseOrder.project),
+            joinedload(PurchaseOrder.cost_code)
+        )
+        .filter(PurchaseOrder.id == po_id)
         .first()
     )
     return populate_po_number(db_po, db_po.project.uca_project_number)

--- a/backend/routes/quotes.py
+++ b/backend/routes/quotes.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 from database import get_db
 from auth import current_actor
+from utils import to_naive_utc
 from models import (
     Quote, QuoteLineItem, Project, Labor, Part, Miscellaneous,
     QuoteSnapshot, QuoteLineItemSnapshot, Invoice, InvoiceLineItem, CostCode
@@ -18,7 +19,7 @@ from schemas import (
     QuoteSnapshot as QuoteSnapshotSchema,
     Invoice as InvoiceSchema, InvoiceCreate,
     RevertPreview, MarkupControlToggleRequest, MarkupControlToggleResponse,
-    CommitEditsRequest, CommitEditsResponse
+    CommitEditsRequest, CommitEditsResponse, CreatedAtUpdate
 )
 
 DEFAULT_LIMIT = 50
@@ -424,6 +425,43 @@ def update_quote(quote_id: int, quote_data: QuoteUpdate, db: Session = Depends(g
     db.refresh(db_quote)
 
     # Return with computed quote_number
+    return populate_quote_number(db_quote, db_quote.project.uca_project_number)
+
+
+@router.put("/{quote_id}/created-at", response_model=QuoteSchema)
+def update_quote_created_at(quote_id: int, payload: CreatedAtUpdate, db: Session = Depends(get_db)):
+    """
+    Edit the 'created on' date/time of a quote.
+
+    Bumps current_version by 1 (which changes the visible quote number) and records
+    the change in the audit trail. Rejected if the quote is frozen (invoiced), matching
+    the line-item edit guard.
+    """
+    db_quote = (
+        db.query(Quote)
+        .options(joinedload(Quote.project))
+        .filter(Quote.id == quote_id)
+        .first()
+    )
+    if not db_quote:
+        raise HTTPException(status_code=404, detail="Quote not found")
+
+    # Reject the edit if the quote has been invoiced (frozen) - same guard as line edits
+    check_quote_not_frozen(quote_id, db)
+
+    old_created_at = db_quote.created_at
+    db_quote.created_at = to_naive_utc(payload.created_at)
+
+    create_snapshot(
+        db,
+        db_quote,
+        action_type="date_edit",
+        action_description=f"Created date changed from {old_created_at} to {db_quote.created_at}",
+    )
+
+    db.commit()
+    db.refresh(db_quote)
+
     return populate_quote_number(db_quote, db_quote.project.uca_project_number)
 
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -897,6 +897,7 @@ class Invoice(InvoiceBase):
     id: int
     invoice_sequence: int = 1
     quote_version: int = 0
+    current_version: int = 0
     invoice_number: Optional[str] = None  # Computed: "{invoice_sequence}-{UCA}-{quote_seq:04d}-{quote_version}"
     created_at: datetime
     status: str
@@ -906,6 +907,61 @@ class Invoice(InvoiceBase):
 
     class Config:
         from_attributes = True
+
+
+# ===== Created-at edit request (quotes / POs / invoices) =====
+class CreatedAtUpdate(BaseModel):
+    created_at: datetime  # ISO-8601 string; parsed to naive-UTC on the backend
+
+
+# ===== Invoice Line Item Snapshot Schemas =====
+class InvoiceLineItemSnapshotBase(BaseModel):
+    original_line_item_id: Optional[int] = None
+    quote_line_item_id: Optional[int] = None
+    item_type: str
+    description: Optional[str] = None
+    unit_price: Optional[float] = None
+    qty_ordered: Optional[int] = None
+    qty_fulfilled_this_invoice: Optional[int] = None
+    qty_fulfilled_total: Optional[int] = None
+    qty_pending_after: Optional[int] = None
+    labor_id: Optional[int] = None
+    part_id: Optional[int] = None
+    misc_id: Optional[int] = None
+
+
+class InvoiceLineItemSnapshot(InvoiceLineItemSnapshotBase):
+    id: int
+    snapshot_id: int
+
+    class Config:
+        from_attributes = True
+
+
+# ===== Invoice Snapshot Schemas =====
+class InvoiceSnapshotBase(BaseModel):
+    invoice_id: int
+    version: int
+    action_type: str  # "date_edit", "revert"
+    action_description: Optional[str] = None
+
+
+class InvoiceSnapshot(InvoiceSnapshotBase):
+    id: int
+    created_at: datetime
+    entity_created_at: Optional[datetime] = None
+    actor_user_id: Optional[str] = None
+    actor_email: Optional[str] = None
+    line_item_states: List[InvoiceLineItemSnapshot] = []
+
+    class Config:
+        from_attributes = True
+
+
+# ===== Invoice Revert Preview Schema =====
+class InvoiceRevertPreview(BaseModel):
+    target_version: int
+    changes_summary: str
 
 
 # ===== Quote Line Item Snapshot Schemas =====

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -18,6 +18,7 @@ if not _pg_reachable():
         "test_smoke.py",
         "test_backlog_report.py",
         "test_invoice_summary.py",
+        "test_created_at_versioning.py",
         # Imports routes.migration -> database, which requires DATABASE_URL.
         # That env var is present in CI (alongside Postgres) but not locally.
         "test_migration_import.py",

--- a/backend/tests/test_created_at_versioning.py
+++ b/backend/tests/test_created_at_versioning.py
@@ -1,0 +1,323 @@
+"""Tests for issue #148: editing the "created on" date of quotes, POs, and invoices.
+
+Covers:
+- created_at actually changes through the endpoint
+- the entity version increments by exactly 1 per date edit
+- a snapshot row is written with the acting user populated (via a monkeypatched actor)
+- a frozen (invoiced) quote rejects a date edit
+- the invoice snapshot/revert round-trip restores created_at
+- the timezone round-trip: a UTC ISO string with offset is stored as naive-UTC unchanged
+"""
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+import auth
+import main
+from database import SessionLocal
+from models import (
+    Profile, ProfileType, Project, Quote, QuoteLineItem,
+    PurchaseOrder, POLineItem, POStatus, Invoice, InvoiceLineItem,
+    QuoteSnapshot, POSnapshot, InvoiceSnapshot,
+)
+from utils import to_naive_utc
+
+client = TestClient(main.app)
+
+
+# A counter to keep UCA project numbers unique across this module's fixtures so we
+# never collide with seeded data or other tests.
+def _unique_suffix():
+    return datetime.utcnow().strftime("%H%M%S%f")
+
+
+@pytest.fixture
+def db():
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _make_project(db, suffix):
+    customer = Profile(
+        name=f"[TEST] Cust {suffix}",
+        type=ProfileType.customer,
+        pst="PST-TEST",
+        address="123 Test St",
+        postal_code="A1A1A1",
+    )
+    db.add(customer)
+    db.flush()
+    project = Project(
+        name=f"[TEST] Project {suffix}",
+        customer_id=customer.id,
+        uca_project_number=f"TST{suffix}",
+    )
+    db.add(project)
+    db.flush()
+    return customer, project
+
+
+def _cleanup(db, *objs):
+    """Delete test objects, first removing snapshot rows whose FK back to the parent is
+    NOT NULL with no DB/ORM cascade (quote_snapshots, po_snapshots). Without this, deleting
+    a quote/PO that owns a date_edit snapshot raises an IntegrityError as SQLAlchemy tries
+    to NULL the snapshot's FK. invoice_snapshots cascade via the ORM relationship, so the
+    invoice itself can just be deleted."""
+    for obj in objs:
+        if isinstance(obj, Quote):
+            snaps = db.query(QuoteSnapshot).filter(QuoteSnapshot.quote_id == obj.id).all()
+        elif isinstance(obj, PurchaseOrder):
+            snaps = db.query(POSnapshot).filter(POSnapshot.purchase_order_id == obj.id).all()
+        else:
+            snaps = []
+        # ORM delete so cascade clears the *_line_item_snapshots children too.
+        for snap in snaps:
+            db.delete(snap)
+    db.flush()
+    for obj in objs:
+        if obj is not None:
+            db.delete(obj)
+    db.commit()
+
+
+# ----------------------------------------------------------------------------
+# Quote date edit
+# ----------------------------------------------------------------------------
+
+def test_quote_created_at_changes_and_bumps_version_once(db):
+    suffix = _unique_suffix()
+    customer, project = _make_project(db, suffix)
+    quote = Quote(project_id=project.id, quote_sequence=1, current_version=0,
+                  created_at=datetime(2026, 1, 1, 12, 0, 0))
+    db.add(quote)
+    db.commit()
+    quote_id = quote.id
+    start_version = quote.current_version
+
+    new_dt = "2026-03-15T09:30:00Z"
+    r = client.put(f"/quotes/{quote_id}/created-at", json={"created_at": new_dt})
+    assert r.status_code == 200, r.text
+    body = r.json()
+
+    # Version bumped by exactly 1
+    assert body["current_version"] == start_version + 1
+
+    # created_at changed (stored naive-UTC -> 09:30:00 with no offset)
+    db.expire_all()
+    refreshed = db.query(Quote).filter(Quote.id == quote_id).first()
+    assert refreshed.created_at == datetime(2026, 3, 15, 9, 30, 0)
+
+    # A date_edit snapshot row exists at the new version
+    snap = (
+        db.query(QuoteSnapshot)
+        .filter(QuoteSnapshot.quote_id == quote_id, QuoteSnapshot.action_type == "date_edit")
+        .first()
+    )
+    assert snap is not None
+    assert snap.version == start_version + 1
+
+    _cleanup(db, refreshed, project, customer)
+
+
+def test_frozen_quote_rejects_date_edit(db):
+    suffix = _unique_suffix()
+    customer, project = _make_project(db, suffix)
+    quote = Quote(project_id=project.id, quote_sequence=1, current_version=0,
+                  created_at=datetime(2026, 1, 1, 12, 0, 0))
+    db.add(quote)
+    db.flush()
+    # A fulfilled line item freezes the quote
+    line = QuoteLineItem(quote_id=quote.id, item_type="misc", description="frozen",
+                         quantity=1, unit_price=10.0, qty_pending=0, qty_fulfilled=1)
+    db.add(line)
+    db.commit()
+    quote_id = quote.id
+
+    r = client.put(f"/quotes/{quote_id}/created-at", json={"created_at": "2026-04-01T00:00:00Z"})
+    assert r.status_code == 400
+    assert "frozen" in r.json()["detail"].lower() or "invoiced" in r.json()["detail"].lower()
+
+    # Version unchanged
+    db.expire_all()
+    refreshed = db.query(Quote).filter(Quote.id == quote_id).first()
+    assert refreshed.current_version == 0
+
+    _cleanup(db, refreshed, project, customer)
+
+
+# ----------------------------------------------------------------------------
+# PO date edit
+# ----------------------------------------------------------------------------
+
+def test_po_created_at_changes_and_bumps_version_once(db):
+    suffix = _unique_suffix()
+    customer, project = _make_project(db, suffix)
+    vendor = Profile(name=f"[TEST] Vendor {suffix}", type=ProfileType.vendor,
+                     pst="PST-V", address="1 Vendor Rd", postal_code="B2B2B2")
+    db.add(vendor)
+    db.flush()
+    po = PurchaseOrder(project_id=project.id, vendor_id=vendor.id, po_sequence=1,
+                       current_version=0, status=POStatus.draft,
+                       created_at=datetime(2026, 2, 1, 8, 0, 0))
+    db.add(po)
+    db.commit()
+    po_id = po.id
+
+    r = client.put(f"/purchase-orders/{po_id}/created-at", json={"created_at": "2026-05-20T14:45:00Z"})
+    assert r.status_code == 200, r.text
+    assert r.json()["current_version"] == 1
+
+    db.expire_all()
+    refreshed = db.query(PurchaseOrder).filter(PurchaseOrder.id == po_id).first()
+    assert refreshed.created_at == datetime(2026, 5, 20, 14, 45, 0)
+
+    snap = (
+        db.query(POSnapshot)
+        .filter(POSnapshot.purchase_order_id == po_id, POSnapshot.action_type == "date_edit")
+        .first()
+    )
+    assert snap is not None and snap.version == 1
+
+    _cleanup(db, refreshed, project, customer, vendor)
+
+
+# ----------------------------------------------------------------------------
+# Invoice date edit + snapshot/revert round-trip
+# ----------------------------------------------------------------------------
+
+def _make_invoice(db, suffix):
+    customer, project = _make_project(db, suffix)
+    quote = Quote(project_id=project.id, quote_sequence=1, current_version=0)
+    db.add(quote)
+    db.flush()
+    invoice = Invoice(quote_id=quote.id, invoice_sequence=1, quote_version=0,
+                      current_version=0, status="Sent",
+                      created_at=datetime(2026, 1, 10, 10, 0, 0))
+    db.add(invoice)
+    db.flush()
+    li = InvoiceLineItem(invoice_id=invoice.id, quote_line_item_id=None, item_type="misc",
+                         description="svc", unit_price=100.0, qty_ordered=2,
+                         qty_fulfilled_this_invoice=2, qty_fulfilled_total=2, qty_pending_after=0)
+    db.add(li)
+    db.commit()
+    return customer, project, quote, invoice
+
+
+def test_invoice_created_at_changes_and_bumps_version_once(db):
+    suffix = _unique_suffix()
+    customer, project, quote, invoice = _make_invoice(db, suffix)
+    invoice_id = invoice.id
+
+    r = client.put(f"/invoices/{invoice_id}/created-at", json={"created_at": "2026-06-01T16:00:00Z"})
+    assert r.status_code == 200, r.text
+    assert r.json()["current_version"] == 1
+
+    db.expire_all()
+    refreshed = db.query(Invoice).filter(Invoice.id == invoice_id).first()
+    assert refreshed.created_at == datetime(2026, 6, 1, 16, 0, 0)
+
+    snap = (
+        db.query(InvoiceSnapshot)
+        .filter(InvoiceSnapshot.invoice_id == invoice_id, InvoiceSnapshot.action_type == "date_edit")
+        .first()
+    )
+    assert snap is not None and snap.version == 1
+    # entity_created_at is captured AT snapshot time, which is AFTER the endpoint set the
+    # new created_at - so v1's entity_created_at is the new value, not the pre-edit one.
+    assert snap.entity_created_at == datetime(2026, 6, 1, 16, 0, 0)
+
+    refreshed = db.query(Invoice).filter(Invoice.id == invoice_id).first()
+    _cleanup(db, refreshed, quote, project, customer)
+
+
+def test_invoice_revert_restores_created_at(db):
+    suffix = _unique_suffix()
+    customer, project, quote, invoice = _make_invoice(db, suffix)
+    invoice_id = invoice.id
+
+    # First edit -> version 1; its entity_created_at captures the value just set: 2026-02-02 02:00.
+    client.put(f"/invoices/{invoice_id}/created-at", json={"created_at": "2026-02-02T02:00:00Z"})
+    # Second edit -> version 2; its entity_created_at captures 2026-09-09 20:00.
+    client.put(f"/invoices/{invoice_id}/created-at", json={"created_at": "2026-09-09T20:00:00Z"})
+
+    db.expire_all()
+    inv = db.query(Invoice).filter(Invoice.id == invoice_id).first()
+    assert inv.current_version == 2
+    assert inv.created_at == datetime(2026, 9, 9, 20, 0, 0)
+
+    # Reverting to version 1 restores the created_at captured in that snapshot
+    # (the invoice's date at the moment version 1 was taken: 2026-02-02 02:00).
+    r = client.post(f"/invoices/{invoice_id}/revert/1")
+    assert r.status_code == 200, r.text
+
+    db.expire_all()
+    inv = db.query(Invoice).filter(Invoice.id == invoice_id).first()
+    # Revert restores the date from version 1's entity_created_at and bumps to v3.
+    assert inv.created_at == datetime(2026, 2, 2, 2, 0, 0)
+    assert inv.current_version == 3
+
+    inv = db.query(Invoice).filter(Invoice.id == invoice_id).first()
+    _cleanup(db, inv, quote, project, customer)
+
+
+# ----------------------------------------------------------------------------
+# Actor stamping (monkeypatch the JWT verification to yield a fake actor)
+# ----------------------------------------------------------------------------
+
+def test_date_edit_snapshot_records_actor(db, monkeypatch):
+    monkeypatch.setattr(
+        auth, "extract_actor",
+        lambda authorization: {"user_id": "user_test_123", "email": "tester@ucsh.com"},
+    )
+    suffix = _unique_suffix()
+    customer, project = _make_project(db, suffix)
+    quote = Quote(project_id=project.id, quote_sequence=1, current_version=0,
+                  created_at=datetime(2026, 1, 1, 12, 0, 0))
+    db.add(quote)
+    db.commit()
+    quote_id = quote.id
+
+    r = client.put(
+        f"/quotes/{quote_id}/created-at",
+        json={"created_at": "2026-03-15T09:30:00Z"},
+        headers={"Authorization": "Bearer fake-token"},
+    )
+    assert r.status_code == 200, r.text
+
+    db.expire_all()
+    snap = (
+        db.query(QuoteSnapshot)
+        .filter(QuoteSnapshot.quote_id == quote_id, QuoteSnapshot.action_type == "date_edit")
+        .first()
+    )
+    assert snap is not None
+    assert snap.actor_user_id == "user_test_123"
+    assert snap.actor_email == "tester@ucsh.com"
+
+    refreshed = db.query(Quote).filter(Quote.id == quote_id).first()
+    _cleanup(db, refreshed, project, customer)
+
+
+# ----------------------------------------------------------------------------
+# Timezone round-trip unit test (no DB)
+# ----------------------------------------------------------------------------
+
+def test_to_naive_utc_offset_is_normalized_not_shifted():
+    from datetime import timedelta
+
+    # 09:30 at a -05:00 offset is 14:30 UTC; stored value must be the UTC wall clock.
+    minus5 = datetime(2026, 3, 15, 9, 30, 0, tzinfo=timezone(timedelta(hours=-5)))
+    assert to_naive_utc(minus5) == datetime(2026, 3, 15, 14, 30, 0)
+    assert to_naive_utc(minus5).tzinfo is None
+
+    # A UTC ('Z') datetime keeps the same wall clock, just drops tzinfo.
+    utc = datetime(2026, 3, 15, 9, 30, 0, tzinfo=timezone.utc)
+    assert to_naive_utc(utc) == datetime(2026, 3, 15, 9, 30, 0)
+
+    # A naive datetime is assumed already-UTC and returned unchanged.
+    naive = datetime(2026, 3, 15, 9, 30, 0)
+    assert to_naive_utc(naive) == naive

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -1,0 +1,21 @@
+"""Shared backend utilities."""
+from datetime import datetime, timezone
+
+
+def to_naive_utc(dt: datetime) -> datetime:
+    """
+    Normalize an incoming datetime to naive-UTC for storage.
+
+    created_at columns are stored naive-UTC (datetime.utcnow). A datetime-local
+    input is local wall-clock, so the frontend converts it to a UTC ISO-8601 string
+    (e.g. via ``new Date(localValue).toISOString()``, which ends in ``Z``). Pydantic
+    parses that into a tz-aware datetime; we convert it back to UTC and drop the
+    tzinfo so it matches the stored naive-UTC convention.
+
+    A naive datetime (no offset supplied) is assumed to already be UTC and returned
+    unchanged. This keeps a single round-trip convention so the stored time does not
+    silently shift by the browser's offset.
+    """
+    if dt.tzinfo is not None:
+        return dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -12,6 +12,7 @@ import type {
   POReceiving, POReceivingCreate, POSnapshot, PORevertPreview,
   POCommitEditsRequest, POCommitEditsResponse,
   Invoice, InvoiceCreate, InvoiceStatusUpdate, QuoteSnapshot, RevertPreview,
+  InvoiceSnapshot, InvoiceRevertPreview,
   MarkupControlToggleRequest, MarkupControlToggleResponse,
   CommitEditsRequest, CommitEditsResponse,
   CompanySettings, CompanySettingsUpdate, InvoiceSummaryItem,
@@ -193,6 +194,10 @@ export const api = {
       request<Quote>('/quotes/', { method: 'POST', body: JSON.stringify(data) }),
     update: (id: number, data: QuoteUpdate) =>
       request<Quote>(`/quotes/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+    // Edit the "created on" date/time (bumps version, snapshots, changes quote number).
+    // `iso` is a UTC ISO-8601 string (e.g. from new Date(localValue).toISOString()).
+    updateCreatedAt: (id: number, iso: string) =>
+      request<Quote>(`/quotes/${id}/created-at`, { method: 'PUT', body: JSON.stringify({ created_at: iso }) }),
     delete: (id: number) =>
       request<{ message: string }>(`/quotes/${id}`, { method: 'DELETE' }),
 
@@ -242,11 +247,27 @@ export const api = {
     get: (id: number) => request<Invoice>(`/invoices/${id}`),
     updateStatus: (id: number, data: InvoiceStatusUpdate) =>
       request<Invoice>(`/invoices/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+    // Edit the "created on" date/time (bumps version, snapshots; invoice number unchanged).
+    // `iso` is a UTC ISO-8601 string (e.g. from new Date(localValue).toISOString()).
+    updateCreatedAt: (id: number, iso: string) =>
+      request<Invoice>(`/invoices/${id}/created-at`, { method: 'PUT', body: JSON.stringify({ created_at: iso }) }),
     getSummary: (startDate: string, endDate: string, projectId?: number) => {
       const qs = new URLSearchParams({ start_date: startDate, end_date: endDate })
       if (projectId !== undefined) qs.set('project_id', String(projectId))
       return request<InvoiceSummaryItem[]>(`/invoices/?${qs.toString()}`)
     },
+
+    // Snapshots (Audit Trail)
+    getSnapshots: (invoiceId: number) =>
+      request<InvoiceSnapshot[]>(`/invoices/${invoiceId}/snapshots`),
+    getSnapshot: (invoiceId: number, version: number) =>
+      request<InvoiceSnapshot>(`/invoices/${invoiceId}/snapshots/${version}`),
+
+    // Revert
+    previewRevert: (invoiceId: number, version: number) =>
+      request<InvoiceRevertPreview>(`/invoices/${invoiceId}/revert/${version}/preview`),
+    revert: (invoiceId: number, version: number) =>
+      request<Invoice>(`/invoices/${invoiceId}/revert/${version}`, { method: 'POST' }),
   },
 
   // ===== Company Settings =====
@@ -271,6 +292,11 @@ export const api = {
 
     update: (id: number, data: PurchaseOrderUpdate) =>
       request<PurchaseOrder>(`/purchase-orders/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+
+    // Edit the "created on" date/time (bumps version, snapshots, changes PO number).
+    // `iso` is a UTC ISO-8601 string (e.g. from new Date(localValue).toISOString()).
+    updateCreatedAt: (id: number, iso: string) =>
+      request<PurchaseOrder>(`/purchase-orders/${id}/created-at`, { method: 'PUT', body: JSON.stringify({ created_at: iso }) }),
 
     delete: (id: number) =>
       request<{ message: string }>(`/purchase-orders/${id}`, { method: 'DELETE' }),

--- a/frontend/src/components/editors/EditCreatedAtDialog.tsx
+++ b/frontend/src/components/editors/EditCreatedAtDialog.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from "react"
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from "@/components/ui/alert-dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { AlertTriangle } from "lucide-react"
+import { toDateTimeLocalValue, dateTimeLocalToIso, formatDateTime } from "@/lib/format"
+
+interface EditCreatedAtDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** The entity's current created_at (stored UTC ISO string). */
+  currentCreatedAt: string
+  /** "quote" | "purchase order" | "invoice" - drives the warning copy. */
+  entityLabel: string
+  /** Whether changing the date also changes the visible document number (quotes/POs). */
+  changesDocumentNumber: boolean
+  /** Called with a UTC ISO-8601 string when the user confirms. */
+  onConfirm: (iso: string) => Promise<void> | void
+  isLoading?: boolean
+}
+
+/**
+ * Confirmation dialog for editing an entity's "created on" date/time.
+ *
+ * The user picks a local wall-clock value via a datetime-local input; on confirm we
+ * convert it to a UTC ISO-8601 string (single round-trip convention) and hand it to
+ * onConfirm. Warns that the change adds a new version and (for quotes/POs) changes the
+ * document number.
+ */
+export function EditCreatedAtDialog({
+  open,
+  onOpenChange,
+  currentCreatedAt,
+  entityLabel,
+  changesDocumentNumber,
+  onConfirm,
+  isLoading = false,
+}: EditCreatedAtDialogProps) {
+  const [localValue, setLocalValue] = useState("")
+
+  // Reset the input to the current value each time the dialog opens.
+  useEffect(() => {
+    if (open) setLocalValue(toDateTimeLocalValue(currentCreatedAt))
+  }, [open, currentCreatedAt])
+
+  const iso = dateTimeLocalToIso(localValue)
+  const canSubmit = iso !== null && !isLoading
+
+  const handleConfirm = async () => {
+    if (iso === null) return
+    await onConfirm(iso)
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Edit created date</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-3">
+              <p>
+                Current created date is{" "}
+                <span className="font-medium text-foreground">{formatDateTime(currentCreatedAt)}</span>.
+              </p>
+              <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-amber-700 dark:text-amber-300">
+                <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                <span className="text-sm">
+                  Changing the created date adds a new version to this {entityLabel}'s audit trail
+                  {changesDocumentNumber ? ` and changes its document number` : ``}.
+                </span>
+              </div>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="space-y-2 py-2">
+          <Label htmlFor="created-at-input">New created date &amp; time</Label>
+          <Input
+            id="created-at-input"
+            type="datetime-local"
+            value={localValue}
+            onChange={(e) => setLocalValue(e.target.value)}
+            disabled={isLoading}
+          />
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isLoading}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              // Keep the dialog open until the async call resolves; the parent closes it.
+              e.preventDefault()
+              void handleConfirm()
+            }}
+            disabled={!canSubmit}
+          >
+            {isLoading ? "Saving..." : "Save new date"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/frontend/src/components/editors/InvoiceAuditTrail.tsx
+++ b/frontend/src/components/editors/InvoiceAuditTrail.tsx
@@ -1,0 +1,302 @@
+import { useState, useEffect } from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from "@/components/ui/alert-dialog"
+import { api } from "@/api/client"
+import type { InvoiceSnapshot, InvoiceRevertPreview } from "@/types"
+import { formatDateTime } from "@/lib/format"
+import {
+  History,
+  Pencil,
+  RotateCcw,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react"
+
+interface InvoiceAuditTrailProps {
+  invoiceId: number
+  currentVersion: number
+  onRevert?: () => void
+}
+
+export function InvoiceAuditTrail({ invoiceId, currentVersion, onRevert }: InvoiceAuditTrailProps) {
+  const [snapshots, setSnapshots] = useState<InvoiceSnapshot[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [expandedSnapshots, setExpandedSnapshots] = useState<Set<number>>(new Set())
+
+  // Revert dialog state
+  const [revertDialogOpen, setRevertDialogOpen] = useState(false)
+  const [revertPreview, setRevertPreview] = useState<InvoiceRevertPreview | null>(null)
+  const [selectedVersion, setSelectedVersion] = useState<number | null>(null)
+  const [isReverting, setIsReverting] = useState(false)
+
+  const fetchSnapshots = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await api.invoices.getSnapshots(invoiceId)
+      setSnapshots(data.sort((a, b) => b.version - a.version))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch audit trail")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchSnapshots()
+  }, [invoiceId, currentVersion])
+
+  const toggleExpand = (snapshotId: number) => {
+    const newExpanded = new Set(expandedSnapshots)
+    if (newExpanded.has(snapshotId)) {
+      newExpanded.delete(snapshotId)
+    } else {
+      newExpanded.add(snapshotId)
+    }
+    setExpandedSnapshots(newExpanded)
+  }
+
+  const handleRevertClick = async (version: number) => {
+    try {
+      const preview = await api.invoices.previewRevert(invoiceId, version)
+      setRevertPreview(preview)
+      setSelectedVersion(version)
+      setRevertDialogOpen(true)
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to preview revert")
+    }
+  }
+
+  const handleConfirmRevert = async () => {
+    if (selectedVersion === null) return
+
+    setIsReverting(true)
+    try {
+      await api.invoices.revert(invoiceId, selectedVersion)
+      setRevertDialogOpen(false)
+      setRevertPreview(null)
+      setSelectedVersion(null)
+      fetchSnapshots()
+      onRevert?.()
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to revert")
+    } finally {
+      setIsReverting(false)
+    }
+  }
+
+  const getActionIcon = (actionType: string) => {
+    switch (actionType) {
+      case "date_edit":
+        return <Pencil className="h-4 w-4 text-blue-600" />
+      case "revert":
+        return <RotateCcw className="h-4 w-4 text-orange-600" />
+      default:
+        return <History className="h-4 w-4" />
+    }
+  }
+
+  const getActionBadgeVariant = (actionType: string) => {
+    switch (actionType) {
+      case "date_edit":
+        return "secondary" as const
+      case "revert":
+        return "outline" as const
+      default:
+        return "secondary" as const
+    }
+  }
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <History className="h-4 w-4" />
+            Audit Trail
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground text-center py-4">Loading...</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <History className="h-4 w-4" />
+            Audit Trail
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-destructive text-center py-4">{error}</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2">
+            <History className="h-4 w-4" />
+            Audit Trail
+            <Badge variant="secondary" className="ml-2">
+              v{currentVersion}
+            </Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {snapshots.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-4">
+              No history yet.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {snapshots.map((snapshot, index) => {
+                const isExpanded = expandedSnapshots.has(snapshot.id)
+                const isCurrentVersion = snapshot.version === currentVersion
+                const canRevert = !isCurrentVersion && index > 0
+
+                return (
+                  <div
+                    key={snapshot.id}
+                    className={`border rounded-md ${
+                      isCurrentVersion ? "bg-primary/5 border-primary/20" : ""
+                    }`}
+                  >
+                    <div
+                      className="flex items-center justify-between p-3 cursor-pointer hover:bg-muted/50"
+                      onClick={() => toggleExpand(snapshot.id)}
+                    >
+                      <div className="flex items-center gap-3">
+                        <div className="flex items-center gap-1 text-muted-foreground">
+                          {isExpanded ? (
+                            <ChevronDown className="h-4 w-4" />
+                          ) : (
+                            <ChevronRight className="h-4 w-4" />
+                          )}
+                        </div>
+                        {getActionIcon(snapshot.action_type)}
+                        <div>
+                          <div className="flex items-center gap-2">
+                            <span className="text-sm font-medium">
+                              v{snapshot.version}
+                            </span>
+                            <Badge variant={getActionBadgeVariant(snapshot.action_type)}>
+                              {snapshot.action_type}
+                            </Badge>
+                            {isCurrentVersion && (
+                              <Badge variant="outline" className="text-xs">
+                                Current
+                              </Badge>
+                            )}
+                          </div>
+                          <p className="text-xs text-muted-foreground">
+                            {formatDateTime(snapshot.created_at)}
+                            {snapshot.actor_email && (
+                              <span className="ml-2">· by {snapshot.actor_email}</span>
+                            )}
+                            {snapshot.action_description && (
+                              <span className="ml-2">
+                                - {snapshot.action_description}
+                              </span>
+                            )}
+                          </p>
+                        </div>
+                      </div>
+                      {canRevert && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            handleRevertClick(snapshot.version)
+                          }}
+                          className="gap-1"
+                        >
+                          <RotateCcw className="h-3 w-3" />
+                          Revert
+                        </Button>
+                      )}
+                    </div>
+
+                    {isExpanded && snapshot.line_item_states.length > 0 && (
+                      <div className="px-3 pb-3 pt-1 border-t bg-muted/30">
+                        <p className="text-xs font-medium text-muted-foreground mb-2">
+                          Line Items at this version:
+                        </p>
+                        <div className="space-y-1">
+                          {snapshot.line_item_states.map((item) => (
+                            <div
+                              key={item.id}
+                              className="flex items-center justify-between text-xs p-2 rounded bg-background"
+                            >
+                              <span>
+                                {item.item_type}: {item.description || `ID ${item.original_line_item_id}`}
+                              </span>
+                              <div className="flex gap-4 text-muted-foreground">
+                                <span>Qty: {item.qty_ordered}</span>
+                                <span>This invoice: {item.qty_fulfilled_this_invoice}</span>
+                                {item.unit_price != null && (
+                                  <span>${item.unit_price.toFixed(2)}</span>
+                                )}
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <AlertDialog open={revertDialogOpen} onOpenChange={setRevertDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <RotateCcw className="h-5 w-5" />
+              Revert to version {revertPreview?.target_version}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {revertPreview?.changes_summary} This adds a new version to the invoice audit trail.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isReverting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault()
+                void handleConfirmRevert()
+              }}
+              disabled={isReverting}
+            >
+              {isReverting ? "Reverting..." : "Confirm revert"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/frontend/src/components/editors/InvoiceEditor.tsx
+++ b/frontend/src/components/editors/InvoiceEditor.tsx
@@ -19,7 +19,10 @@ import {
 import { Button } from "@/components/ui/button"
 import { api } from "@/api/client"
 import type { Invoice, Project, CompanySettings } from "@/types"
-import { Receipt, Package, Wrench, FileText, AlertTriangle, Printer, Loader2 } from "lucide-react"
+import { Receipt, Package, Wrench, FileText, AlertTriangle, Printer, Loader2, Pencil } from "lucide-react"
+import { formatDateTime } from "@/lib/format"
+import { EditCreatedAtDialog } from "./EditCreatedAtDialog"
+import { InvoiceAuditTrail } from "./InvoiceAuditTrail"
 
 interface InvoiceEditorProps {
   invoiceId: number
@@ -31,6 +34,8 @@ export function InvoiceEditor({ invoiceId, onUpdate }: InvoiceEditorProps) {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [isPrinting, setIsPrinting] = useState(false)
+  const [createdAtDialogOpen, setCreatedAtDialogOpen] = useState(false)
+  const [savingCreatedAt, setSavingCreatedAt] = useState(false)
 
   const fetchInvoice = async () => {
     setLoading(true)
@@ -58,6 +63,20 @@ export function InvoiceEditor({ invoiceId, onUpdate }: InvoiceEditorProps) {
       onUpdate?.()
     } catch (err) {
       alert(err instanceof Error ? err.message : "Failed to update status")
+    }
+  }
+
+  const handleSaveCreatedAt = async (iso: string) => {
+    setSavingCreatedAt(true)
+    try {
+      await api.invoices.updateCreatedAt(invoiceId, iso)
+      setCreatedAtDialogOpen(false)
+      await fetchInvoice()
+      onUpdate?.()
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to update created date")
+    } finally {
+      setSavingCreatedAt(false)
     }
   }
 
@@ -146,12 +165,23 @@ export function InvoiceEditor({ invoiceId, onUpdate }: InvoiceEditorProps) {
               {invoice.status}
             </Badge>
           </div>
-          <p className="text-sm text-muted-foreground mt-1">
-            Created: {new Date(invoice.created_at).toLocaleString()}
+          <p className="flex items-center gap-1.5 text-sm text-muted-foreground mt-1">
+            <span>Created: {formatDateTime(invoice.created_at)}</span>
+            {!isVoided && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-1.5 text-muted-foreground hover:text-foreground"
+                onClick={() => setCreatedAtDialogOpen(true)}
+              >
+                <Pencil className="mr-1 h-3 w-3" />
+                Edit
+              </Button>
+            )}
           </p>
           {invoice.voided_at && (
             <p className="text-sm text-destructive mt-1">
-              Voided: {new Date(invoice.voided_at).toLocaleString()}
+              Voided: {formatDateTime(invoice.voided_at)}
             </p>
           )}
         </div>
@@ -288,11 +318,32 @@ export function InvoiceEditor({ invoiceId, onUpdate }: InvoiceEditorProps) {
         </CardContent>
       </Card>
 
+      {/* Audit Trail */}
+      <InvoiceAuditTrail
+        invoiceId={invoiceId}
+        currentVersion={invoice.current_version}
+        onRevert={() => {
+          fetchInvoice()
+          onUpdate?.()
+        }}
+      />
+
       {/* Read-only notice */}
       <p className="text-xs text-muted-foreground text-center">
         Invoices are read-only. To modify fulfilled quantities, revert the quote to a
         previous version.
       </p>
+
+      {/* Edit Created Date Dialog */}
+      <EditCreatedAtDialog
+        open={createdAtDialogOpen}
+        onOpenChange={setCreatedAtDialogOpen}
+        currentCreatedAt={invoice.created_at}
+        entityLabel="invoice"
+        changesDocumentNumber={false}
+        onConfirm={handleSaveCreatedAt}
+        isLoading={savingCreatedAt}
+      />
     </div>
   )
 }

--- a/frontend/src/components/editors/POEditor.tsx
+++ b/frontend/src/components/editors/POEditor.tsx
@@ -62,9 +62,10 @@ import {
   History, ChevronDown, ChevronRight, Receipt, Info, ArrowLeft
 } from "lucide-react"
 import { StatusBadge } from "@/components/ui/status-badge"
-import { formatDate, formatCurrency } from "@/lib/format"
+import { formatDate, formatDateTime, formatCurrency } from "@/lib/format"
 import { PartForm } from "@/components/forms/PartForm"
 import { POAuditTrail } from "./POAuditTrail"
+import { EditCreatedAtDialog } from "./EditCreatedAtDialog"
 
 interface POEditorProps {
   poId: number
@@ -117,6 +118,10 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
   // ===== Version Tracking =====
   const [editModeStartVersion, setEditModeStartVersion] = useState<number | null>(null)
   const [poChangedDialogOpen, setPOChangedDialogOpen] = useState(false)
+
+  // ===== "Edit created date" affordance (edit mode only) =====
+  const [createdAtDialogOpen, setCreatedAtDialogOpen] = useState(false)
+  const [savingCreatedAt, setSavingCreatedAt] = useState(false)
 
   // ===== Metadata Editing States =====
   const [workDescription, setWorkDescription] = useState("")
@@ -173,14 +178,19 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
 
   // ===== Data Fetching =====
 
-  const fetchPO = async () => {
+  // expectedVersion: when this refetch follows an edit WE just made that bumped the
+  // version (e.g. a created-date edit), pass the new version so it isn't mistaken for an
+  // external change. Defaults to the captured edit baseline from state.
+  const fetchPO = async (expectedVersion?: number) => {
     setLoading(true)
     setError(null)
     try {
       const data = await api.purchaseOrders.get(poId)
 
+      const editBaseline = expectedVersion ?? editModeStartVersion
+
       // Detect external changes during edit mode
-      if (editorMode === "edit" && editModeStartVersion !== null && data.current_version !== editModeStartVersion) {
+      if (editorMode === "edit" && editBaseline !== null && data.current_version !== editBaseline) {
         clearEditModeState()
         setPOChangedDialogOpen(true)
         setEditModeStartVersion(data.current_version)
@@ -619,6 +629,24 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
       alert(err instanceof Error ? err.message : "Failed to update cost code")
     } finally {
       setSavingCostCode(false)
+    }
+  }
+
+  // Edit the PO's "created on" date. Commits immediately (bumps version, changes the PO
+  // number) - advance editModeStartVersion so fetchPO() doesn't flag our own bump.
+  const handleSaveCreatedAt = async (iso: string) => {
+    setSavingCreatedAt(true)
+    try {
+      const updated = await api.purchaseOrders.updateCreatedAt(poId, iso)
+      setEditModeStartVersion(updated.current_version)
+      setCreatedAtDialogOpen(false)
+      // Pass the new version so the refetch doesn't flag our own bump as an external change.
+      await fetchPO(updated.current_version)
+      onUpdate?.()
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to update created date")
+    } finally {
+      setSavingCreatedAt(false)
     }
   }
 
@@ -1312,8 +1340,19 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
             <Building className="h-4 w-4" />
             <span>Vendor: {po.vendor.name}</span>
           </div>
-          <p className="text-sm text-muted-foreground">
-            Created: {formatDate(po.created_at)}
+          <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
+            <span>Created: {formatDateTime(po.created_at)}</span>
+            {editorMode === "edit" && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-1.5 text-muted-foreground hover:text-foreground"
+                onClick={() => setCreatedAtDialogOpen(true)}
+              >
+                <Pencil className="mr-1 h-3 w-3" />
+                Edit
+              </Button>
+            )}
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -2520,6 +2559,17 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Edit Created Date Dialog */}
+      <EditCreatedAtDialog
+        open={createdAtDialogOpen}
+        onOpenChange={setCreatedAtDialogOpen}
+        currentCreatedAt={po.created_at}
+        entityLabel="purchase order"
+        changesDocumentNumber
+        onConfirm={handleSaveCreatedAt}
+        isLoading={savingCreatedAt}
+      />
     </div>
   )
 }

--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -57,9 +57,10 @@ import type {
 } from "@/types"
 import { Plus, Minus, Trash2, Wrench, Package, FileText, Pencil, ClipboardCheck, Receipt, Percent, Info, Copy, Car, MapPin, X, Lock, GitCommit, Eye, AlertTriangle, Check, CheckCircle2, Printer, Loader2, Hash, ChevronUp, ChevronDown, ArrowLeft } from "lucide-react"
 import { StatusBadge } from "@/components/ui/status-badge"
-import { formatDate } from "@/lib/format"
+import { formatDateTime } from "@/lib/format"
 import type { CompanySettings, Project, SystemRate } from '@/types'
 import { QuoteAuditTrail } from "./QuoteAuditTrail"
+import { EditCreatedAtDialog } from "./EditCreatedAtDialog"
 import { PartForm } from "@/components/forms/PartForm"
 import { LaborForm } from "@/components/forms/LaborForm"
 import { MiscForm } from "@/components/forms/MiscForm"
@@ -206,6 +207,10 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
   const [editModeStartVersion, setEditModeStartVersion] = useState<number | null>(null)
   const [quoteChangedDialogOpen, setQuoteChangedDialogOpen] = useState(false)
 
+  // "Edit created date" affordance (edit mode only, hidden once invoiced/frozen)
+  const [createdAtDialogOpen, setCreatedAtDialogOpen] = useState(false)
+  const [savingCreatedAt, setSavingCreatedAt] = useState(false)
+
   // Computed: Is quote frozen (has been invoiced)?
   const hasBeenInvoiced = quote?.line_items.some(item => item.qty_fulfilled > 0) ?? false
 
@@ -227,20 +232,26 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
   // Computed: Does any line item have qty_pending > 0? (Flow 1 precondition)
   const hasAnyPendingQuantity = quote?.line_items.some(item => item.qty_pending > 0) ?? false
 
-  const fetchQuote = async () => {
+  // expectedVersion: when this refetch follows an edit WE just made that bumped the
+  // version (e.g. a created-date edit), pass the new version so it isn't mistaken for an
+  // external change. Defaults to the captured edit/invoicing baseline from state.
+  const fetchQuote = async (expectedVersion?: number) => {
     setLoading(true)
     setError(null)
     try {
       const data = await api.quotes.get(quoteId)
 
+      const invoicingBaseline = expectedVersion ?? initialQuoteVersion
+      const editBaseline = expectedVersion ?? editModeStartVersion
+
       // Flow 7E: Detect external changes during invoicing or edit mode
-      if (editorMode === "invoicing" && initialQuoteVersion !== null && data.current_version !== initialQuoteVersion) {
+      if (editorMode === "invoicing" && invoicingBaseline !== null && data.current_version !== invoicingBaseline) {
         // Quote was modified externally - clear staging and warn user
         clearInvoicingState()
         setQuoteChangedDialogOpen(true)
         // Update the version to the new value so subsequent fetches don't re-trigger
         setInitialQuoteVersion(data.current_version)
-      } else if (editorMode === "edit" && editModeStartVersion !== null && data.current_version !== editModeStartVersion) {
+      } else if (editorMode === "edit" && editBaseline !== null && data.current_version !== editBaseline) {
         // Quote was modified externally while editing - clear staging and warn user
         clearEditModeState()
         setQuoteChangedDialogOpen(true)
@@ -607,6 +618,29 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
     setIsEditingHardwareScheduleVersion(false)
     setEditorMode("view")
     setDiscardConfirmOpen(false)
+  }
+
+  // Edit the quote's "created on" date. Commits immediately (bumps version, changes the
+  // quote number) - so we advance editModeStartVersion to avoid fetchQuote() mistaking
+  // our own bump for an external change.
+  const handleSaveCreatedAt = async (iso: string) => {
+    setSavingCreatedAt(true)
+    try {
+      const updated = await api.quotes.updateCreatedAt(quoteId, iso)
+      setEditModeStartVersion(updated.current_version)
+      setCreatedAtDialogOpen(false)
+      toast({ title: "Created date updated", description: `Now ${formatDateTime(updated.created_at)} (version ${updated.current_version}).` })
+      // Pass the new version so the refetch doesn't flag our own bump as an external change.
+      await fetchQuote(updated.current_version)
+    } catch (err) {
+      toast({
+        variant: "destructive",
+        title: "Could not update created date",
+        description: err instanceof Error ? err.message : "Unknown error",
+      })
+    } finally {
+      setSavingCreatedAt(false)
+    }
   }
 
   // ===== Invoice Staging Mode Handlers =====
@@ -2789,8 +2823,19 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
       <div className="flex justify-between items-start">
         <div>
           <h2 className="text-xl font-semibold">{quote.quote_number}</h2>
-          <p className="text-sm text-muted-foreground">
-            Created: {formatDate(quote.created_at)}
+          <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
+            <span>Created: {formatDateTime(quote.created_at)}</span>
+            {editorMode === "edit" && !hasBeenInvoiced && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-1.5 text-muted-foreground hover:text-foreground"
+                onClick={() => setCreatedAtDialogOpen(true)}
+              >
+                <Pencil className="mr-1 h-3 w-3" />
+                Edit
+              </Button>
+            )}
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -4233,6 +4278,17 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* Edit Created Date Dialog */}
+      <EditCreatedAtDialog
+        open={createdAtDialogOpen}
+        onOpenChange={setCreatedAtDialogOpen}
+        currentCreatedAt={quote.created_at}
+        entityLabel="quote"
+        changesDocumentNumber
+        onConfirm={handleSaveCreatedAt}
+        isLoading={savingCreatedAt}
+      />
 
       {/* Commit Changes Confirmation Dialog */}
       <AlertDialog open={commitConfirmOpen} onOpenChange={setCommitConfirmOpen}>

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -10,6 +10,14 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
 })
 
+const dateTimeFormatter = new Intl.DateTimeFormat("en-CA", {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+})
+
 // narrowSymbol → `$` instead of the default `CA$` for en-CA.
 const currencyFormatter = new Intl.NumberFormat("en-CA", {
   style: "currency",
@@ -25,6 +33,65 @@ export function formatDate(value: string | Date | null | undefined): string {
   const date = value instanceof Date ? value : new Date(value)
   if (Number.isNaN(date.getTime())) return "—"
   return dateFormatter.format(date)
+}
+
+/**
+ * Render a stored timestamp as local date + time (e.g. `Jun 8, 2020, 3:30 p.m.`).
+ *
+ * Backend timestamps are naive-UTC and serialized without a timezone suffix, so we
+ * append `Z` before parsing to force UTC interpretation; the formatter then renders
+ * them in the viewer's local timezone. em-dash for missing values.
+ */
+export function formatDateTime(value: string | Date | null | undefined): string {
+  if (value == null || value === "") return EMPTY_VALUE
+  const date = value instanceof Date ? value : new Date(asUtcIso(value))
+  if (Number.isNaN(date.getTime())) return EMPTY_VALUE
+  return dateTimeFormatter.format(date)
+}
+
+/**
+ * Normalize a backend timestamp string to an unambiguous UTC ISO string.
+ *
+ * Backend created_at values are naive-UTC and may arrive without a timezone (e.g.
+ * `2026-06-17T14:30:00`). A bare `new Date(...)` of that string is interpreted as
+ * LOCAL time by JS, shifting it by the browser offset. Appending `Z` (when no offset
+ * is already present) pins it to UTC so every conversion stays consistent.
+ */
+function asUtcIso(value: string): string {
+  // Already has a timezone (Z or ±hh:mm)? leave it.
+  if (/[zZ]$|[+-]\d{2}:?\d{2}$/.test(value)) return value
+  return `${value}Z`
+}
+
+/**
+ * Convert a stored UTC timestamp into the `YYYY-MM-DDTHH:mm` value a
+ * `<input type="datetime-local">` expects, expressed in the viewer's local time.
+ */
+export function toDateTimeLocalValue(value: string | null | undefined): string {
+  if (value == null || value === "") return ""
+  const date = new Date(asUtcIso(value))
+  if (Number.isNaN(date.getTime())) return ""
+  // Build local wall-clock components (the input is local time).
+  const pad = (n: number) => String(n).padStart(2, "0")
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}`
+  )
+}
+
+/**
+ * Convert a `datetime-local` input value (local wall-clock, no timezone) into a UTC
+ * ISO-8601 string with a `Z` suffix, ready to send to the backend. Returns null for
+ * empty/invalid input.
+ */
+export function dateTimeLocalToIso(localValue: string | null | undefined): string | null {
+  if (!localValue) return null
+  // `new Date("YYYY-MM-DDTHH:mm")` parses as LOCAL time (per the spec for that form),
+  // which is exactly what we want: the user typed local wall-clock. toISOString() then
+  // yields the equivalent UTC instant.
+  const date = new Date(localValue)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toISOString()
 }
 
 /** Render a number as CAD currency with thousand separators (e.g. `$1,234.56`). */

--- a/frontend/src/test/created-at-format.test.ts
+++ b/frontend/src/test/created-at-format.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { dateTimeLocalToIso, toDateTimeLocalValue, formatDateTime } from '@/lib/format'
+
+describe('created-at datetime round-trip', () => {
+  it('round-trips a local wall-clock value through ISO and back unchanged', () => {
+    // The datetime-local input value the user picked (local wall clock, no offset).
+    const localValue = '2026-03-15T09:30'
+
+    // Convert to the UTC ISO string we send to the backend.
+    const iso = dateTimeLocalToIso(localValue)
+    expect(iso).not.toBeNull()
+    // The ISO is a valid instant ending in Z (UTC).
+    expect(iso as string).toMatch(/Z$/)
+
+    // Converting that stored value back for the input yields the SAME local value,
+    // regardless of the machine's timezone. This is the property that guarantees the
+    // displayed/edited time does not silently shift by the browser offset.
+    expect(toDateTimeLocalValue(iso as string)).toBe(localValue)
+  })
+
+  it('treats a backend naive-UTC timestamp (no offset) as UTC, not local', () => {
+    // Backend serializes created_at as naive-UTC with no timezone suffix.
+    const stored = '2026-03-15T14:30:00'
+    // new Date(stored) would parse as LOCAL and shift; our helper appends Z first, so
+    // the instant is fixed to 14:30 UTC. Re-deriving the same instant proves it.
+    const local = toDateTimeLocalValue(stored)
+    const iso = dateTimeLocalToIso(local)
+    expect(new Date(iso as string).toISOString()).toBe('2026-03-15T14:30:00.000Z')
+  })
+
+  it('returns null / empty for blank input', () => {
+    expect(dateTimeLocalToIso('')).toBeNull()
+    expect(dateTimeLocalToIso(null)).toBeNull()
+    expect(toDateTimeLocalValue('')).toBe('')
+    expect(toDateTimeLocalValue(null)).toBe('')
+  })
+
+  it('formatDateTime renders a non-empty string for a valid timestamp and em-dash for missing', () => {
+    expect(formatDateTime('2026-03-15T14:30:00')).not.toBe('—')
+    expect(formatDateTime('')).toBe('—')
+    expect(formatDateTime(null)).toBe('—')
+  })
+})

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -549,7 +549,7 @@ export interface POLineItemSnapshot {
   is_deleted: boolean;
 }
 
-export type POSnapshotActionType = 'create' | 'edit' | 'delete' | 'receive' | 'status_change' | 'revert';
+export type POSnapshotActionType = 'create' | 'edit' | 'delete' | 'receive' | 'status_change' | 'date_edit' | 'revert';
 
 export interface POSnapshot {
   id: number;
@@ -647,6 +647,7 @@ export interface Invoice {
   quote_id: number;
   invoice_sequence: number;
   quote_version: number;
+  current_version: number;
   invoice_number?: string | null; // Computed: "{invoice_sequence}-{UCA}-{quote_seq}-{quote_version}"
   created_at: string;
   status: InvoiceStatus;
@@ -709,7 +710,7 @@ export interface MigrationResult {
 }
 
 // ===== Quote Snapshots =====
-export type SnapshotActionType = 'create' | 'edit' | 'delete' | 'invoice' | 'revert';
+export type SnapshotActionType = 'create' | 'edit' | 'delete' | 'invoice' | 'date_edit' | 'revert';
 
 export interface QuoteSnapshot {
   id: number;
@@ -728,6 +729,44 @@ export interface QuoteSnapshot {
 export interface RevertPreview {
   target_version: number;
   invoices_to_void: Invoice[];
+  changes_summary: string;
+}
+
+// ===== Invoice Snapshots =====
+export type InvoiceSnapshotActionType = 'date_edit' | 'revert';
+
+export interface InvoiceLineItemSnapshot {
+  id: number;
+  snapshot_id: number;
+  original_line_item_id?: number;
+  quote_line_item_id?: number;
+  item_type: LineItemType;
+  description?: string;
+  unit_price?: number;
+  qty_ordered?: number;
+  qty_fulfilled_this_invoice?: number;
+  qty_fulfilled_total?: number;
+  qty_pending_after?: number;
+  labor_id?: number;
+  part_id?: number;
+  misc_id?: number;
+}
+
+export interface InvoiceSnapshot {
+  id: number;
+  invoice_id: number;
+  version: number;
+  action_type: InvoiceSnapshotActionType;
+  action_description?: string;
+  created_at: string;
+  entity_created_at?: string | null;
+  actor_user_id?: string | null;
+  actor_email?: string | null;
+  line_item_states: InvoiceLineItemSnapshot[];
+}
+
+export interface InvoiceRevertPreview {
+  target_version: number;
   changes_summary: string;
 }
 


### PR DESCRIPTION
Fixes #148

lets a user edit the "created on" date/time of a quote, PO, or invoice, behind a confirmation prompt, recorded in the audit trail, bumping the entity version by 1.

quotes and POs already have the snapshot machinery, so they get a thin new endpoint each:
- PUT /quotes/{id}/created-at - loads the quote, rejects the edit if it's frozen (invoiced) via the same check_quote_not_frozen guard line-item edits use, sets the new created_at, calls create_snapshot with a new "date_edit" action_type, commits, returns the quote with its recomputed number. it does NOT piggy-back on PUT /quotes/{id} (that edits metadata without snapshotting or bumping the version).
- PUT /purchase-orders/{id}/created-at - sets created_at, calls create_po_snapshot("date_edit", ...) which bumps the version, returns the PO with its recomputed number. POs have no frozen state so it's always allowed.
- "date_edit" is just a new free-form string, so no migration is needed for the action_type column; the existing quote/PO audit views show the new snapshot with the actor's email and the old-to-new description for free.

both quote_number and po_number embed current_version, so a date edit deliberately changes the visible document number. the confirmation dialog warns about that.

invoices had no versioning at all, so they get a full system mirroring quotes:
- a current_version column on the invoices table, model, and read schema
- InvoiceSnapshot / InvoiceLineItemSnapshot models, where InvoiceSnapshot carries an extra entity_created_at column holding the invoice's created_at at snapshot time
- a create_invoice_snapshot helper that increments current_version, writes the snapshot plus line-item snapshots, and stamps the actor from the same contextvar
- PUT /invoices/{id}/created-at (no frozen guard - an invoice only exists once its quote is frozen, so it must stay editable), plus GET /invoices/{id}/snapshots, GET /invoices/{id}/snapshots/{version}, GET /invoices/{id}/revert/{version}/preview, and POST /invoices/{id}/revert/{version}. revert restores line-item state AND created_at via entity_created_at.
- invoice_number embeds the quote's version, not the invoice's own, so bumping the invoice's current_version here does not change the visible invoice number.

migration 024_invoice_versioning adds invoices.current_version (server_default '0') and creates the two snapshot tables with IF-NOT-EXISTS-style guards, mirroring the quote snapshot DDL and including entity_created_at. downgrade drops the two tables and the column. models.py and schemas.py are kept in sync, and the alembic history stays single-headed (024 -> 023_bulk_markup_50).

each editor (QuoteEditor, POEditor, InvoiceEditor) shows the current created-on value and, in edit mode, a small "edit" action next to it. on submit it opens a shadcn AlertDialog confirming the change and warning it adds a new version (and, for quotes/POs, that it changes the document number); only on confirm does it fire the API call and refetch. the quote affordance is hidden once the quote is invoiced, matching the backend guard. a new InvoiceAuditTrail mirrors QuoteAuditTrail and is wired into InvoiceEditor. client.ts gains quotes.updateCreatedAt / purchaseOrders.updateCreatedAt / invoices.updateCreatedAt plus the invoice snapshot/revert methods, and the TS types pick up InvoiceSnapshot / InvoiceRevertPreview / current_version on Invoice.

timezone was the main correctness risk. created_at is naive-UTC. the frontend converts the local datetime-local input to a UTC ISO-8601 string, the backend normalizes any tz-aware value back to naive-UTC (to_naive_utc) so it matches the stored convention, and display goes through a shared en-CA formatDateTime helper. this is covered by tests on both sides so the stored time can't silently shift by the browser offset. a subtle bug surfaced and got fixed along the way: the editors' edit-mode version tracking would have read the version bump from our own date edit as an external change and wiped staged line-item edits, so the refetch now takes the known-new version as its baseline.

backend tests exercise: created_at actually changes, the version increments by exactly 1, a snapshot row appears with the actor populated, a frozen quote's date edit is rejected, and the invoice snapshot/revert round-trip restores created_at. frontend tests cover the datetime round-trip helpers.
