### PR TITLE
fix(models): cascade snapshot deletes so quote/PO/project deletion doesn't 500

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -186,7 +186,7 @@ class Quote(Base):
     project = relationship("Project", back_populates="quotes")
     line_items = relationship("QuoteLineItem", back_populates="quote", cascade="all, delete-orphan")
     invoices = relationship("Invoice", back_populates="quote", order_by="Invoice.created_at")
-    snapshots = relationship("QuoteSnapshot", back_populates="quote", order_by="QuoteSnapshot.version")
+    snapshots = relationship("QuoteSnapshot", back_populates="quote", cascade="all, delete-orphan", order_by="QuoteSnapshot.version")
     cost_code = relationship("CostCode")
 
 
@@ -241,7 +241,7 @@ class PurchaseOrder(Base):
     vendor = relationship("Profile", back_populates="purchase_orders")
     line_items = relationship("POLineItem", back_populates="purchase_order", cascade="all, delete-orphan")
     receivings = relationship("POReceiving", back_populates="purchase_order", order_by="POReceiving.created_at")
-    snapshots = relationship("POSnapshot", back_populates="purchase_order", order_by="POSnapshot.version")
+    snapshots = relationship("POSnapshot", back_populates="purchase_order", cascade="all, delete-orphan", order_by="POSnapshot.version")
     cost_code = relationship("CostCode")
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -19,6 +19,7 @@ if not _pg_reachable():
         "test_backlog_report.py",
         "test_invoice_summary.py",
         "test_created_at_versioning.py",
+        "test_delete_cascade.py",
         # Imports routes.migration -> database, which requires DATABASE_URL.
         # That env var is present in CI (alongside Postgres) but not locally.
         "test_migration_import.py",

--- a/backend/tests/test_created_at_versioning.py
+++ b/backend/tests/test_created_at_versioning.py
@@ -62,22 +62,10 @@ def _make_project(db, suffix):
 
 
 def _cleanup(db, *objs):
-    """Delete test objects, first removing snapshot rows whose FK back to the parent is
-    NOT NULL with no DB/ORM cascade (quote_snapshots, po_snapshots). Without this, deleting
-    a quote/PO that owns a date_edit snapshot raises an IntegrityError as SQLAlchemy tries
-    to NULL the snapshot's FK. invoice_snapshots cascade via the ORM relationship, so the
-    invoice itself can just be deleted."""
-    for obj in objs:
-        if isinstance(obj, Quote):
-            snaps = db.query(QuoteSnapshot).filter(QuoteSnapshot.quote_id == obj.id).all()
-        elif isinstance(obj, PurchaseOrder):
-            snaps = db.query(POSnapshot).filter(POSnapshot.purchase_order_id == obj.id).all()
-        else:
-            snaps = []
-        # ORM delete so cascade clears the *_line_item_snapshots children too.
-        for snap in snaps:
-            db.delete(snap)
-    db.flush()
+    """Delete test objects directly. Since issue #158 added cascade="all, delete-orphan"
+    to Quote.snapshots and PurchaseOrder.snapshots (invoice_snapshots already had it),
+    deleting a quote/PO that owns snapshot rows cascades to the snapshot and
+    line-item-snapshot rows instead of tripping the NOT NULL parent FK."""
     for obj in objs:
         if obj is not None:
             db.delete(obj)

--- a/backend/tests/test_delete_cascade.py
+++ b/backend/tests/test_delete_cascade.py
@@ -1,0 +1,179 @@
+"""Tests for issue #158: deleting a quote/PO (or a project containing one) that owns
+snapshot rows must cascade-delete the snapshots instead of trying to NULL their NOT NULL
+parent FK (which raised psycopg2.errors.NotNullViolation -> 500, surfaced as "Failed to
+fetch" once the Railway edge stripped CORS off the 5xx).
+
+Each test builds the parent with at least one snapshot AND a line-item-snapshot child, so
+it exercises the full cascade chain: parent -> *_snapshots -> *_line_item_snapshots. The
+deletes go through the real endpoints, the same path the frontend and e2e cleanup hit.
+"""
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+import main
+from database import SessionLocal
+from models import (
+    Profile, ProfileType, Project, Quote,
+    PurchaseOrder, POStatus,
+    QuoteSnapshot, QuoteLineItemSnapshot,
+    POSnapshot, POLineItemSnapshot,
+)
+
+client = TestClient(main.app)
+
+
+def _unique_suffix():
+    return datetime.utcnow().strftime("%H%M%S%f")
+
+
+@pytest.fixture
+def db():
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _make_project(db, suffix):
+    customer = Profile(
+        name=f"[TEST] Cust {suffix}", type=ProfileType.customer,
+        pst="PST-TEST", address="123 Test St", postal_code="A1A1A1",
+    )
+    db.add(customer)
+    db.flush()
+    project = Project(
+        name=f"[TEST] Project {suffix}", customer_id=customer.id,
+        uca_project_number=f"TST{suffix}",
+    )
+    db.add(project)
+    db.flush()
+    return customer, project
+
+
+def _make_vendor(db, suffix):
+    vendor = Profile(
+        name=f"[TEST] Vendor {suffix}", type=ProfileType.vendor,
+        pst="PST-V", address="1 Vendor Rd", postal_code="B2B2B2",
+    )
+    db.add(vendor)
+    db.flush()
+    return vendor
+
+
+def _add_quote_with_snapshot(db, project):
+    """A quote carrying one snapshot that itself owns a line-item-snapshot child."""
+    quote = Quote(project_id=project.id, quote_sequence=1, current_version=1)
+    db.add(quote)
+    db.flush()
+    snap = QuoteSnapshot(quote_id=quote.id, version=1, action_type="edit",
+                         action_description="[TEST] cascade")
+    db.add(snap)
+    db.flush()
+    db.add(QuoteLineItemSnapshot(snapshot_id=snap.id, item_type="misc",
+                                 description="li", quantity=1, unit_price=1.0))
+    db.flush()
+    return quote, snap
+
+
+def _add_po_with_snapshot(db, project, vendor):
+    """A PO carrying the v0 'create' snapshot (every PO gets one) with a line-item child."""
+    po = PurchaseOrder(project_id=project.id, vendor_id=vendor.id, po_sequence=1,
+                       current_version=0, status=POStatus.draft)
+    db.add(po)
+    db.flush()
+    snap = POSnapshot(purchase_order_id=po.id, version=0, action_type="create",
+                      action_description="[TEST] cascade")
+    db.add(snap)
+    db.flush()
+    db.add(POLineItemSnapshot(snapshot_id=snap.id, item_type="part",
+                              quantity=1, unit_price=1.0))
+    db.flush()
+    return po, snap
+
+
+def test_delete_snapshotted_quote_returns_200_and_cascades(db):
+    suffix = _unique_suffix()
+    customer, project = _make_project(db, suffix)
+    quote, snap = _add_quote_with_snapshot(db, project)
+    db.commit()
+    quote_id, snap_id = quote.id, snap.id
+
+    r = client.delete(f"/quotes/{quote_id}")
+    assert r.status_code == 200, r.text
+
+    db.expire_all()
+    assert db.query(Quote).filter(Quote.id == quote_id).first() is None
+    assert db.query(QuoteSnapshot).filter(QuoteSnapshot.id == snap_id).first() is None
+    assert (
+        db.query(QuoteLineItemSnapshot)
+        .filter(QuoteLineItemSnapshot.snapshot_id == snap_id)
+        .count()
+    ) == 0
+
+    db.delete(project)
+    db.delete(customer)
+    db.commit()
+
+
+def test_delete_snapshotted_po_returns_200_and_cascades(db):
+    suffix = _unique_suffix()
+    customer, project = _make_project(db, suffix)
+    vendor = _make_vendor(db, suffix)
+    po, snap = _add_po_with_snapshot(db, project, vendor)
+    db.commit()
+    po_id, snap_id = po.id, snap.id
+
+    r = client.delete(f"/purchase-orders/{po_id}")
+    assert r.status_code == 200, r.text
+
+    db.expire_all()
+    assert db.query(PurchaseOrder).filter(PurchaseOrder.id == po_id).first() is None
+    assert db.query(POSnapshot).filter(POSnapshot.id == snap_id).first() is None
+    assert (
+        db.query(POLineItemSnapshot)
+        .filter(POLineItemSnapshot.snapshot_id == snap_id)
+        .count()
+    ) == 0
+
+    db.delete(project)
+    db.delete(vendor)
+    db.delete(customer)
+    db.commit()
+
+
+def test_delete_project_with_snapshotted_quote_and_po_cascades(db):
+    suffix = _unique_suffix()
+    customer, project = _make_project(db, suffix)
+    vendor = _make_vendor(db, suffix)
+    quote, qsnap = _add_quote_with_snapshot(db, project)
+    po, posnap = _add_po_with_snapshot(db, project, vendor)
+    db.commit()
+    project_id, quote_id, po_id = project.id, quote.id, po.id
+    qsnap_id, posnap_id = qsnap.id, posnap.id
+
+    r = client.delete(f"/projects/{project_id}")
+    assert r.status_code == 200, r.text
+
+    db.expire_all()
+    assert db.query(Project).filter(Project.id == project_id).first() is None
+    assert db.query(Quote).filter(Quote.id == quote_id).first() is None
+    assert db.query(PurchaseOrder).filter(PurchaseOrder.id == po_id).first() is None
+    assert db.query(QuoteSnapshot).filter(QuoteSnapshot.id == qsnap_id).first() is None
+    assert db.query(POSnapshot).filter(POSnapshot.id == posnap_id).first() is None
+    assert (
+        db.query(QuoteLineItemSnapshot)
+        .filter(QuoteLineItemSnapshot.snapshot_id == qsnap_id)
+        .count()
+    ) == 0
+    assert (
+        db.query(POLineItemSnapshot)
+        .filter(POLineItemSnapshot.snapshot_id == posnap_id)
+        .count()
+    ) == 0
+
+    db.delete(vendor)
+    db.delete(customer)
+    db.commit()


### PR DESCRIPTION
deleting a quote or purchase order that owns snapshot rows returned a 500, and deleting a project containing one failed the same way. `Quote.snapshots` and `PurchaseOrder.snapshots` had no cascade configured, so `db.delete(parent)` tried to set the snapshot's `quote_id` / `purchase_order_id` to NULL and tripped the NOT NULL constraint (`psycopg2.errors.NotNullViolation`). the frontend saw it as "Failed to fetch" because the railway edge strips CORS headers off 5xx responses.

every PO carries a v0 "create" snapshot from the moment it's created, so PO deletion was effectively always broken. a quote broke as soon as it had any snapshot - invoiced, line edited, reverted, or (since #148) its created date edited. a brand-new untouched quote still deleted fine, which is why it slipped through.

this mirrors what `Invoice.snapshots` already does, adding `cascade="all, delete-orphan"` to `Quote.snapshots` and `PurchaseOrder.snapshots`. the snapshot to line-item-snapshot relationships (`QuoteSnapshot.line_item_states`, `POSnapshot.line_item_states`) already cascade, so the whole chain deletes once the parent link does. it's a pure ORM change with no migration - a DB-level `ondelete CASCADE` could be added later for defense in depth but isn't needed to stop the 500, since every delete goes through the ORM.

backend coverage in `test_delete_cascade.py` deletes a snapshotted quote, a snapshotted PO, and a project containing both through the real endpoints, asserting the parent, snapshot, and line-item-snapshot rows are all gone. the #148 cleanup helper used to pre-delete snapshot rows by hand before the parent; that workaround is now redundant, so it's simplified and its tests exercise the cascade directly.

one thing i noticed while in here is that `Quote.invoices` and `PurchaseOrder.receivings` have the identical no-cascade + NOT NULL shape, so deleting an invoiced quote or a received PO would still 500 the same way. #158's repro reaches neither (created-date-edit quote, draft PO), so they're left for a separate follow-up rather than widening this change.

three e2e test entities are currently stuck undeletable because of this bug and will be removed once this deploys:
- project 3464
- quote 12965 (A3768-0001-1)
- purchase order 4787 (PO-A3768-0001-1)

Fixes #158