### PR TITLE
fix(models): cascade invoice/receiving deletes so invoiced-quote/received-PO deletion doesn't 500

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -185,7 +185,7 @@ class Quote(Base):
     # Relationships
     project = relationship("Project", back_populates="quotes")
     line_items = relationship("QuoteLineItem", back_populates="quote", cascade="all, delete-orphan")
-    invoices = relationship("Invoice", back_populates="quote", order_by="Invoice.created_at")
+    invoices = relationship("Invoice", back_populates="quote", cascade="all, delete-orphan", order_by="Invoice.created_at")
     snapshots = relationship("QuoteSnapshot", back_populates="quote", cascade="all, delete-orphan", order_by="QuoteSnapshot.version")
     cost_code = relationship("CostCode")
 
@@ -240,7 +240,7 @@ class PurchaseOrder(Base):
     project = relationship("Project", back_populates="purchase_orders")
     vendor = relationship("Profile", back_populates="purchase_orders")
     line_items = relationship("POLineItem", back_populates="purchase_order", cascade="all, delete-orphan")
-    receivings = relationship("POReceiving", back_populates="purchase_order", order_by="POReceiving.created_at")
+    receivings = relationship("POReceiving", back_populates="purchase_order", cascade="all, delete-orphan", order_by="POReceiving.created_at")
     snapshots = relationship("POSnapshot", back_populates="purchase_order", cascade="all, delete-orphan", order_by="POSnapshot.version")
     cost_code = relationship("CostCode")
 
@@ -318,6 +318,10 @@ class POSnapshot(Base):
     # Relationships
     purchase_order = relationship("PurchaseOrder", back_populates="snapshots")
     line_item_states = relationship("POLineItemSnapshot", back_populates="snapshot", cascade="all, delete-orphan")
+    # FK-only link to the receiving a "receive" snapshot recorded. The relationship (not the bare
+    # receiving_id FK) is what registers a unit-of-work dependency, so on PO delete SQLAlchemy
+    # deletes po_snapshots before po_receivings instead of tripping the FK constraint (issue #160).
+    receiving = relationship("POReceiving", foreign_keys=[receiving_id])
 
 
 class POLineItemSnapshot(Base):

--- a/backend/tests/test_delete_cascade.py
+++ b/backend/tests/test_delete_cascade.py
@@ -15,8 +15,9 @@ from fastapi.testclient import TestClient
 import main
 from database import SessionLocal
 from models import (
-    Profile, ProfileType, Project, Quote,
-    PurchaseOrder, POStatus,
+    Profile, ProfileType, Project, Quote, QuoteLineItem,
+    PurchaseOrder, POStatus, POLineItem, POReceiving, POReceivingLineItem,
+    Invoice, InvoiceLineItem, InvoiceSnapshot, InvoiceLineItemSnapshot,
     QuoteSnapshot, QuoteLineItemSnapshot,
     POSnapshot, POLineItemSnapshot,
 )
@@ -173,6 +174,158 @@ def test_delete_project_with_snapshotted_quote_and_po_cascades(db):
         .filter(POLineItemSnapshot.snapshot_id == posnap_id)
         .count()
     ) == 0
+
+    db.delete(vendor)
+    db.delete(customer)
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Issue #160: invoiced-quote and received-PO deletion (sibling defects of #158).
+# Quote.invoices and PurchaseOrder.receivings also lacked cascade. The PO side
+# additionally needs the new POSnapshot.receiving relationship so the unit of work
+# deletes po_snapshots before the po_receivings their receiving_id points at.
+# ---------------------------------------------------------------------------
+
+def _add_invoiced_quote(db, project):
+    """A quote with a line item, an invoice (+ line item + its own audit snapshot), and an
+    'invoice' quote-snapshot. Exercises Quote.invoices cascade plus the invoice's own
+    line_items / snapshots chains. invoice_snapshots.invoice_id is a real NOT NULL FK, so the
+    invoice's snapshot rows must cascade-delete before the invoice itself."""
+    quote = Quote(project_id=project.id, quote_sequence=1, current_version=1)
+    db.add(quote)
+    db.flush()
+    db.add(QuoteLineItem(quote_id=quote.id, item_type="misc", description="svc",
+                         quantity=1, unit_price=100.0, qty_pending=0, qty_fulfilled=1))
+    invoice = Invoice(quote_id=quote.id, invoice_sequence=1, quote_version=1,
+                      current_version=1, status="Sent")
+    db.add(invoice)
+    db.flush()
+    db.add(InvoiceLineItem(invoice_id=invoice.id, quote_line_item_id=None, item_type="misc",
+                           description="svc", unit_price=100.0, qty_ordered=1,
+                           qty_fulfilled_this_invoice=1, qty_fulfilled_total=1, qty_pending_after=0))
+    isnap = InvoiceSnapshot(invoice_id=invoice.id, version=1, action_type="date_edit")
+    db.add(isnap)
+    db.flush()
+    db.add(InvoiceLineItemSnapshot(snapshot_id=isnap.id, item_type="misc", description="svc"))
+    # quote snapshot recording the invoice action; invoice_id here is a bare int (no FK).
+    qsnap = QuoteSnapshot(quote_id=quote.id, version=1, action_type="invoice", invoice_id=invoice.id)
+    db.add(qsnap)
+    db.flush()
+    db.add(QuoteLineItemSnapshot(snapshot_id=qsnap.id, item_type="misc", description="svc",
+                                 quantity=1, unit_price=100.0))
+    db.flush()
+    return quote, invoice, qsnap, isnap
+
+
+def _add_received_po(db, project, vendor):
+    """A PO with a line item, a receiving whose receiving-line-item references the PO line item,
+    the v0 'create' snapshot, and a 'receive' snapshot whose receiving_id points at the receiving.
+    Exercises BOTH delete-ordering dependencies on PO delete: po_snapshots -> po_receivings (the
+    new relationship) and po_receiving_line_items -> po_line_items (pre-existing relationship)."""
+    po = PurchaseOrder(project_id=project.id, vendor_id=vendor.id, po_sequence=1,
+                       current_version=1, status=POStatus.received)
+    db.add(po)
+    db.flush()
+    li = POLineItem(purchase_order_id=po.id, item_type="part", description="widget",
+                    quantity=10, unit_price=5.0, qty_pending=0, qty_received=10)
+    db.add(li)
+    db.flush()
+    receiving = POReceiving(purchase_order_id=po.id, received_date=datetime(2026, 6, 1, 12, 0, 0),
+                            notes="[TEST] receipt")
+    db.add(receiving)
+    db.flush()
+    db.add(POReceivingLineItem(receiving_id=receiving.id, po_line_item_id=li.id, item_type="part",
+                               description="widget", unit_price=5.0, actual_unit_price=5.0,
+                               qty_ordered=10, qty_received_this_receiving=10,
+                               qty_received_total=10, qty_pending_after=0))
+    create_snap = POSnapshot(purchase_order_id=po.id, version=0, action_type="create")
+    db.add(create_snap)
+    db.flush()
+    db.add(POLineItemSnapshot(snapshot_id=create_snap.id, item_type="part", quantity=10, unit_price=5.0))
+    recv_snap = POSnapshot(purchase_order_id=po.id, version=1, action_type="receive",
+                           receiving_id=receiving.id)
+    db.add(recv_snap)
+    db.flush()
+    db.add(POLineItemSnapshot(snapshot_id=recv_snap.id, item_type="part", quantity=10,
+                              unit_price=5.0, qty_received=10))
+    db.flush()
+    return po, receiving, create_snap, recv_snap
+
+
+def test_delete_invoiced_quote_returns_200_and_cascades(db):
+    suffix = _unique_suffix()
+    customer, project = _make_project(db, suffix)
+    quote, invoice, qsnap, isnap = _add_invoiced_quote(db, project)
+    db.commit()
+    quote_id, invoice_id, isnap_id = quote.id, invoice.id, isnap.id
+
+    r = client.delete(f"/quotes/{quote_id}")
+    assert r.status_code == 200, r.text
+
+    db.expire_all()
+    assert db.query(Quote).filter(Quote.id == quote_id).first() is None
+    assert db.query(Invoice).filter(Invoice.id == invoice_id).first() is None
+    assert db.query(InvoiceLineItem).filter(InvoiceLineItem.invoice_id == invoice_id).count() == 0
+    assert db.query(InvoiceSnapshot).filter(InvoiceSnapshot.id == isnap_id).first() is None
+    assert (
+        db.query(InvoiceLineItemSnapshot)
+        .filter(InvoiceLineItemSnapshot.snapshot_id == isnap_id)
+        .count()
+    ) == 0
+
+    db.delete(project)
+    db.delete(customer)
+    db.commit()
+
+
+def test_delete_received_po_returns_200_and_cascades(db):
+    suffix = _unique_suffix()
+    customer, project = _make_project(db, suffix)
+    vendor = _make_vendor(db, suffix)
+    po, receiving, create_snap, recv_snap = _add_received_po(db, project, vendor)
+    db.commit()
+    po_id, receiving_id = po.id, receiving.id
+
+    r = client.delete(f"/purchase-orders/{po_id}")
+    assert r.status_code == 200, r.text
+
+    db.expire_all()
+    assert db.query(PurchaseOrder).filter(PurchaseOrder.id == po_id).first() is None
+    assert db.query(POReceiving).filter(POReceiving.id == receiving_id).first() is None
+    assert (
+        db.query(POReceivingLineItem)
+        .filter(POReceivingLineItem.receiving_id == receiving_id)
+        .count()
+    ) == 0
+    assert db.query(POSnapshot).filter(POSnapshot.purchase_order_id == po_id).count() == 0
+    assert db.query(POLineItem).filter(POLineItem.purchase_order_id == po_id).count() == 0
+
+    db.delete(project)
+    db.delete(vendor)
+    db.delete(customer)
+    db.commit()
+
+
+def test_delete_project_with_invoiced_quote_and_received_po_cascades(db):
+    suffix = _unique_suffix()
+    customer, project = _make_project(db, suffix)
+    vendor = _make_vendor(db, suffix)
+    quote, invoice, qsnap, isnap = _add_invoiced_quote(db, project)
+    po, receiving, create_snap, recv_snap = _add_received_po(db, project, vendor)
+    db.commit()
+    project_id = project.id
+    quote_id, invoice_id, po_id, receiving_id = quote.id, invoice.id, po.id, receiving.id
+
+    r = client.delete(f"/projects/{project_id}")
+    assert r.status_code == 200, r.text
+
+    db.expire_all()
+    assert db.query(Project).filter(Project.id == project_id).first() is None
+    assert db.query(Quote).filter(Quote.id == quote_id).first() is None
+    assert db.query(Invoice).filter(Invoice.id == invoice_id).first() is None
+    assert db.query(PurchaseOrder).filter(PurchaseOrder.id == po_id).first() is None
+    assert db.query(POReceiving).filter(POReceiving.id == receiving_id).first() is None
 
     db.delete(vendor)
     db.delete(customer)


### PR DESCRIPTION
fixes the two sibling defects flagged in #160, the same delete-500 bug class that #158 fixed for snapshots. `Quote.invoices` and `PurchaseOrder.receivings` had no cascade, so `db.delete(parent)` tried to NULL the child's NOT NULL FK (`invoices.quote_id`, `po_receivings.purchase_order_id`) and raised `NotNullViolation`, a 500 the browser saw as "Failed to fetch". with this, deleting an invoiced quote, a received PO, or a project containing either works.

the quote side is a plain mirror of #158, adding `cascade="all, delete-orphan"` to `Quote.invoices`. the invoice's own children already cascade (`Invoice.line_items`, `Invoice.snapshots`), and `QuoteSnapshot.invoice_id` is a bare int with no FK, so nothing constrains delete order.

the PO side needed one more thing. `POSnapshot.receiving_id` is a real FK to `po_receivings`, and a "receive" snapshot points at the receiving it recorded. a bare FK column registers no delete-ordering dependency in SQLAlchemy's unit of work, so it emitted `DELETE FROM po_receivings` before the snapshots referencing it and tripped the constraint even with cascade in place. added a `POSnapshot.receiving` relationship (no cascade, just the dependency) so the snapshots delete first. verified on a FK-enforcing sqlite db - without the relationship the delete fails; with it the order is snapshots, then receivings, then PO.

test_delete_cascade.py gains three cases that delete through the real endpoints and assert the rows are gone. one covers an invoiced quote (quote + invoice + invoice line item + invoice snapshot + an "invoice" quote-snapshot); another a received PO (PO line item + receiving + receiving line item referencing the line item + create and receive snapshots, the receive one pointing at the receiving); the third a project containing both. the received-PO case exercises both inter-child orderings, snapshot to receiving and receiving-line-item to po-line-item.

pure ORM change, no migration.

Fixes #160