### PR TITLE
Labour-hours report on quotes (#162)

### DIFF
--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -2033,6 +2033,33 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
     }
   }
 
+  const runPrintLaborHours = async () => {
+    if (!quote) return
+    setPrintDialogOpen(false)
+    setIsPrinting(true)
+    try {
+      const [project, companySettings, { pdf }, { LaborHoursPDF }] = await Promise.all([
+        api.projects.get(quote.project_id) as Promise<Project>,
+        api.companySettings.get(),
+        import('@react-pdf/renderer'),
+        import('@/components/pdf/LaborHoursPDF'),
+      ])
+      const blob = await pdf(
+        <LaborHoursPDF
+          quote={quote}
+          project={project}
+          companySettings={companySettings}
+        />
+      ).toBlob()
+      const url = URL.createObjectURL(blob)
+      window.open(url, '_blank')
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to generate PDF")
+    } finally {
+      setIsPrinting(false)
+    }
+  }
+
   if (loading) {
     return <div className="p-8 text-center text-muted-foreground">Loading...</div>
   }
@@ -3773,7 +3800,7 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
               Print Quote
             </DialogTitle>
             <DialogDescription>
-              Choose how line items appear in the printout.
+              Choose what to print for this quote.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-3 pt-2">
@@ -3795,6 +3822,16 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
               <div className="font-medium">Quantities only</div>
               <div className="text-sm text-muted-foreground mt-1">
                 Show each item's description and quantity, but hide all unit prices, line totals, and section subtotals. Only the final Subtotal, HST, and Total are shown.
+              </div>
+            </button>
+            <button
+              type="button"
+              onClick={runPrintLaborHours}
+              className="w-full text-left p-4 rounded-md border bg-background hover:bg-accent transition-colors"
+            >
+              <div className="font-medium">Labour hours report</div>
+              <div className="text-sm text-muted-foreground mt-1">
+                Show the calculated labour time for each item and the total labour hours for the quote, with the estimated labour cost before markup.
               </div>
             </button>
           </div>

--- a/frontend/src/components/pdf/LaborHoursPDF.tsx
+++ b/frontend/src/components/pdf/LaborHoursPDF.tsx
@@ -1,0 +1,173 @@
+import { Document, Page, View, Text, StyleSheet } from '@react-pdf/renderer'
+import { styles } from './styles'
+import { PDFHeader } from './PDFHeader'
+import { PDFFooter } from './PDFFooter'
+import { formatCurrency } from '@/lib/pricing'
+import { computeLaborHoursReport } from '@/lib/laborHours'
+import type { Quote, Project, CompanySettings } from '@/types'
+
+interface LaborHoursPDFProps {
+  quote: Quote
+  project: Project
+  companySettings: CompanySettings
+}
+
+/** Column widths for this report only; the shared quote/invoice columns don't fit it. */
+const lh = StyleSheet.create({
+  colDescription: { width: '52%' },
+  colQty: { width: '10%', textAlign: 'right' },
+  colHrsPerUnit: { width: '14%', textAlign: 'right' },
+  colTime: { width: '12%', textAlign: 'right' },
+  colCost: { width: '12%', textAlign: 'right' },
+  summaryHeader: { width: '28%' },
+  summaryCol: { width: '24%', textAlign: 'right' },
+  note: {
+    marginTop: 10,
+    fontSize: 7,
+    color: '#666666',
+    lineHeight: 1.4,
+  },
+})
+
+function formatHours(hours: number): string {
+  return `${hours.toFixed(1)} hr.`
+}
+
+export function LaborHoursPDF({ quote, project, companySettings }: LaborHoursPDFProps) {
+  const { rows, total_hours, estimated_cost, rate_display, unresolved_count } =
+    computeLaborHoursReport(quote.line_items)
+
+  const formattedDate = new Date(quote.created_at).toLocaleDateString('en-CA', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  })
+
+  return (
+    <Document>
+      <Page size="LETTER" style={styles.page}>
+        <PDFHeader companySettings={companySettings} title="LABOUR HOURS">
+          <View>
+            <View style={styles.metaRow}>
+              <Text style={styles.metaLabel}>Quotation #:</Text>
+              <Text style={styles.metaValue}>{quote.quote_number}</Text>
+            </View>
+            <View style={styles.metaRow}>
+              <Text style={styles.metaLabel}>Client PO #:</Text>
+              <Text style={styles.metaValue}>{quote.client_po_number || '—'}</Text>
+            </View>
+            <View style={styles.metaRow}>
+              <Text style={styles.metaLabel}>Date:</Text>
+              <Text style={styles.metaValue}>{formattedDate}</Text>
+            </View>
+          </View>
+        </PDFHeader>
+
+        {/* Customer */}
+        <View style={styles.customerSection}>
+          <Text style={styles.customerLabel}>CUSTOMER:</Text>
+          <Text style={styles.customerName}>{project.customer.name}</Text>
+          <Text style={styles.customerAddress}>{project.customer.address}</Text>
+          <Text style={styles.customerAddress}>{project.customer.postal_code}</Text>
+        </View>
+
+        {/* Project Info */}
+        <View style={styles.projectRow}>
+          <View style={styles.projectField}>
+            <Text style={styles.bold}>UCA #:</Text>
+            <Text>{project.uca_project_number}</Text>
+          </View>
+          <View style={styles.projectField}>
+            <Text style={styles.bold}>Project:</Text>
+            <Text>{project.name}</Text>
+          </View>
+          <View style={styles.projectField}>
+            <Text style={styles.bold}>Date:</Text>
+            <Text>{formattedDate}</Text>
+          </View>
+        </View>
+
+        {/* Per-item time */}
+        <Text style={styles.sectionTitle}>Calculated Labour Hours by Item</Text>
+        <View style={styles.tableHeader}>
+          <Text style={[styles.colHeaderText, lh.colDescription]}>Description</Text>
+          <Text style={[styles.colHeaderText, lh.colQty]}>Qty</Text>
+          <Text style={[styles.colHeaderText, lh.colHrsPerUnit]}>Hrs / Unit</Text>
+          <Text style={[styles.colHeaderText, lh.colTime]}>Time</Text>
+          <Text style={[styles.colHeaderText, lh.colCost]}>Est. Cost</Text>
+        </View>
+
+        {rows.map((row, idx) => (
+          <View
+            key={row.id}
+            style={[styles.tableRow, idx % 2 === 1 ? styles.tableRowAlt : {}]}
+            wrap={false}
+          >
+            <Text style={lh.colDescription}>
+              {row.description}
+              {row.unresolved ? ' *' : ''}
+            </Text>
+            <Text style={lh.colQty}>{row.quantity}</Text>
+            <Text style={lh.colHrsPerUnit}>{row.unresolved ? '—' : row.hours_per_unit.toFixed(1)}</Text>
+            <Text style={lh.colTime}>{row.unresolved ? '—' : formatHours(row.time)}</Text>
+            <Text style={lh.colCost}>{row.unresolved ? '—' : formatCurrency(row.cost)}</Text>
+          </View>
+        ))}
+
+        {/* Total row */}
+        <View style={styles.tableFooterRow}>
+          <Text style={[lh.colDescription, styles.bold]}>Total Calculated Labour Hours</Text>
+          <Text style={lh.colQty} />
+          <Text style={lh.colHrsPerUnit} />
+          <Text style={[lh.colTime, styles.bold]}>{formatHours(total_hours)}</Text>
+          <Text style={[lh.colCost, styles.bold]}>{formatCurrency(estimated_cost)}</Text>
+        </View>
+
+        {/* Estimate / Actual / Variance summary */}
+        <Text style={styles.sectionTitle}>Labour Summary</Text>
+        <View style={styles.tableHeader}>
+          <Text style={[styles.colHeaderText, lh.summaryHeader]} />
+          <Text style={[styles.colHeaderText, lh.summaryCol]}>Estimate</Text>
+          <Text style={[styles.colHeaderText, lh.summaryCol]}>Actual</Text>
+          <Text style={[styles.colHeaderText, lh.summaryCol]}>Variance</Text>
+        </View>
+        <View style={styles.tableRow}>
+          <Text style={[lh.summaryHeader, styles.bold]}>Labour Hours</Text>
+          <Text style={lh.summaryCol}>{formatHours(total_hours)}</Text>
+          <Text style={lh.summaryCol}>—</Text>
+          <Text style={lh.summaryCol}>—</Text>
+        </View>
+        <View style={[styles.tableRow, styles.tableRowAlt]}>
+          <Text style={[lh.summaryHeader, styles.bold]}>Rate</Text>
+          <Text style={lh.summaryCol}>{rate_display}</Text>
+          <Text style={lh.summaryCol}>—</Text>
+          <Text style={lh.summaryCol}>—</Text>
+        </View>
+        <View style={styles.tableRow}>
+          <Text style={[lh.summaryHeader, styles.bold]}>Cost (Estimated)</Text>
+          <Text style={lh.summaryCol}>{formatCurrency(estimated_cost)}</Text>
+          <Text style={lh.summaryCol}>—</Text>
+          <Text style={lh.summaryCol}>—</Text>
+        </View>
+
+        <View style={lh.note}>
+          <Text>
+            Time = Qty x Hrs / Unit. Only labour items carry hours; parts and miscellaneous
+            items show 0.0 hr. Est. Cost is the labour cost before markup (Time x Rate).
+          </Text>
+          <Text>
+            Actual and Variance are not tracked in UC Velocity and are left blank for manual entry.
+          </Text>
+          {unresolved_count > 0 && (
+            <Text>
+              * {unresolved_count} labour line{unresolved_count === 1 ? '' : 's'} could not be
+              resolved to a labour record; hours are unknown and are excluded from the totals above.
+            </Text>
+          )}
+        </View>
+
+        <PDFFooter />
+      </Page>
+    </Document>
+  )
+}

--- a/frontend/src/lib/laborHours.ts
+++ b/frontend/src/lib/laborHours.ts
@@ -1,0 +1,114 @@
+import type { QuoteLineItem } from '@/types'
+import { formatCurrency } from '@/lib/format'
+
+/**
+ * Labour-hours report math (Issue #162).
+ *
+ * The report answers one question: how many labour hours does a quote represent,
+ * per item and in total? All the data needed is already embedded in the quote's
+ * line items when it loads — each labour line carries its linked `labor` record
+ * with `hours` and `rate`. This module is the pure calculation; the PDF component
+ * only renders what it returns.
+ *
+ * Line-item taxonomy for `item_type === 'labor'`:
+ *  - normal labour: has a `labor` record -> real hours (quantity x labor.hours)
+ *  - PMS line: `is_pms`, no `labor` record -> 0 hours by design (priced by a
+ *    percentage or flat amount, not by hours)
+ *  - orphaned labour: a non-PMS labour line whose `labor` record didn't load
+ *    (deleted inventory row / migration artifact) -> hours genuinely unknown
+ *
+ * Parts and miscellaneous lines never carry hours, so they contribute 0.
+ */
+
+export interface LaborHoursRow {
+  id: number
+  description: string
+  quantity: number
+  hours_per_unit: number
+  /** quantity x hours_per_unit */
+  time: number
+  /** time x rate (labour cost before markup) */
+  cost: number
+  /** True for a non-PMS labour line whose labour record is missing. */
+  unresolved: boolean
+}
+
+export interface LaborHoursReport {
+  rows: LaborHoursRow[]
+  total_hours: number
+  estimated_cost: number
+  /** "$80.00/hr" when every contributing line agrees, "Variable" when they differ, "—" when none. */
+  rate_display: string
+  /** Count of non-PMS labour lines whose hours couldn't be resolved. */
+  unresolved_count: number
+}
+
+export function getLaborItemDescription(item: QuoteLineItem): string {
+  if (item.item_type === 'labor' && item.labor) return item.labor.description
+  if (item.item_type === 'part' && item.part)
+    return `${item.part.part_number} - ${item.part.description}`
+  if (item.item_type === 'misc' && item.miscellaneous) return item.miscellaneous.description
+  return item.description || 'Unknown item'
+}
+
+/** Hours per single unit. Only labour lines with a resolved record carry hours. */
+export function hoursPerUnit(item: QuoteLineItem): number {
+  if (item.item_type === 'labor' && item.labor) return item.labor.hours
+  return 0
+}
+
+/**
+ * A genuine labour line whose `labor` record didn't come back with the quote.
+ * PMS lines are excluded: they are labour-typed but carry no record and no hours
+ * by design, so they are legitimately 0.0 hr., not "unknown".
+ */
+export function isUnresolvedLabor(item: QuoteLineItem): boolean {
+  return item.item_type === 'labor' && !item.is_pms && !item.labor
+}
+
+export function computeLaborHoursReport(items: QuoteLineItem[]): LaborHoursReport {
+  const rows: LaborHoursRow[] = items.map(item => {
+    const unresolved = isUnresolvedLabor(item)
+    const perUnit = hoursPerUnit(item)
+    const time = item.quantity * perUnit
+    return {
+      id: item.id,
+      description: getLaborItemDescription(item),
+      quantity: item.quantity,
+      hours_per_unit: perUnit,
+      time,
+      cost: time * (item.labor?.rate ?? 0),
+      unresolved,
+    }
+  })
+
+  // Only labour lines with a resolved record contribute to the totals.
+  const resolvedLabor = items.filter(i => i.item_type === 'labor' && i.labor)
+
+  const total_hours = resolvedLabor.reduce(
+    (sum, item) => sum + item.quantity * hoursPerUnit(item),
+    0
+  )
+  const estimated_cost = resolvedLabor.reduce(
+    (sum, item) => sum + item.quantity * hoursPerUnit(item) * (item.labor?.rate ?? 0),
+    0
+  )
+
+  // UC Velocity has no single company labour rate — each labour record carries
+  // its own. Show one rate only when every hour-bearing line agrees.
+  const contributingRates = new Set(
+    resolvedLabor
+      .filter(item => item.quantity * hoursPerUnit(item) > 0)
+      .map(item => item.labor?.rate ?? 0)
+  )
+  const rate_display =
+    contributingRates.size === 1
+      ? `${formatCurrency([...contributingRates][0])}/hr`
+      : contributingRates.size === 0
+        ? '—'
+        : 'Variable'
+
+  const unresolved_count = items.filter(isUnresolvedLabor).length
+
+  return { rows, total_hours, estimated_cost, rate_display, unresolved_count }
+}

--- a/frontend/src/test/labor-hours.test.ts
+++ b/frontend/src/test/labor-hours.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import { computeLaborHoursReport } from '@/lib/laborHours'
+import type { QuoteLineItem, Labor } from '@/types'
+
+/** Build a labour record with sane defaults. */
+function labor(overrides: Partial<Labor> = {}): Labor {
+  return {
+    id: 1,
+    description: 'Labour',
+    hours: 1,
+    rate: 80,
+    markup_percent: 50,
+    ...overrides,
+  }
+}
+
+let nextId = 1
+/** Build a quote line item with sane defaults; only set what a test cares about. */
+function lineItem(overrides: Partial<QuoteLineItem> = {}): QuoteLineItem {
+  return {
+    id: nextId++,
+    quote_id: 1,
+    item_type: 'labor',
+    quantity: 1,
+    qty_pending: 0,
+    qty_fulfilled: 0,
+    is_pms: false,
+    ...overrides,
+  }
+}
+
+describe('computeLaborHoursReport', () => {
+  it('sums labour hours and estimated cost at a uniform rate (Dexter template: 15.0 hr / $1,200)', () => {
+    const items = [
+      lineItem({ item_type: 'labor', quantity: 1, labor: labor({ hours: 5, rate: 80 }) }), // 5 hr, $400
+      lineItem({ item_type: 'labor', quantity: 2, labor: labor({ hours: 5, rate: 80 }) }), // 10 hr, $800
+      lineItem({ item_type: 'part', quantity: 3, part: { id: 9, part_number: 'P-1', description: 'Bracket', cost: 12, markup_percent: 0 } }),
+    ]
+
+    const report = computeLaborHoursReport(items)
+
+    expect(report.total_hours).toBe(15)
+    expect(report.estimated_cost).toBe(1200)
+    expect(report.rate_display).toBe('$80.00/hr')
+    expect(report.unresolved_count).toBe(0)
+  })
+
+  it('gives parts and miscellaneous lines 0.0 hours', () => {
+    const items = [
+      lineItem({ item_type: 'part', quantity: 4, part: { id: 2, part_number: 'P-2', description: 'Widget', cost: 5, markup_percent: 0 } }),
+      lineItem({ item_type: 'misc', quantity: 1, miscellaneous: { id: 3, description: 'Freight', unit_price: 50, markup_percent: 0, is_system_item: false } }),
+    ]
+
+    const report = computeLaborHoursReport(items)
+
+    expect(report.total_hours).toBe(0)
+    expect(report.rows.every(r => r.time === 0)).toBe(true)
+    expect(report.rate_display).toBe('—')
+  })
+
+  it('shows "Variable" when labour lines carry different rates', () => {
+    const items = [
+      lineItem({ item_type: 'labor', quantity: 1, labor: labor({ hours: 2, rate: 80 }) }),
+      lineItem({ item_type: 'labor', quantity: 1, labor: labor({ hours: 2, rate: 120 }) }),
+    ]
+
+    const report = computeLaborHoursReport(items)
+
+    expect(report.total_hours).toBe(4)
+    expect(report.estimated_cost).toBe(400) // 2*80 + 2*120
+    expect(report.rate_display).toBe('Variable')
+  })
+
+  it('treats a PMS line as 0 hours and NOT as unresolved', () => {
+    const items = [
+      lineItem({ item_type: 'labor', quantity: 1, labor: labor({ hours: 10, rate: 80 }) }),
+      // PMS: labour-typed, is_pms, no labor record, priced by percentage
+      lineItem({ item_type: 'labor', quantity: 1, is_pms: true, pms_percent: 15, description: 'Project Management Services' }),
+    ]
+
+    const report = computeLaborHoursReport(items)
+
+    const pmsRow = report.rows.find(r => r.description === 'Project Management Services')!
+    expect(pmsRow.time).toBe(0)
+    expect(pmsRow.unresolved).toBe(false)
+    expect(report.unresolved_count).toBe(0)
+    // PMS must not disturb the real labour totals
+    expect(report.total_hours).toBe(10)
+    expect(report.estimated_cost).toBe(800)
+    expect(report.rate_display).toBe('$80.00/hr')
+  })
+
+  it('flags a non-PMS labour line with no labour record as unresolved and excludes it from totals', () => {
+    const items = [
+      lineItem({ item_type: 'labor', quantity: 1, labor: labor({ hours: 10, rate: 80 }) }),
+      // Orphaned: had a labor_id but the record did not load (deleted/migrated)
+      lineItem({ item_type: 'labor', quantity: 2, labor_id: 999, description: 'Electrical' }),
+    ]
+
+    const report = computeLaborHoursReport(items)
+
+    const orphan = report.rows.find(r => r.description === 'Electrical')!
+    expect(orphan.unresolved).toBe(true)
+    expect(report.unresolved_count).toBe(1)
+    // Only the resolved 10 hr line counts
+    expect(report.total_hours).toBe(10)
+    expect(report.estimated_cost).toBe(800)
+    expect(report.rate_display).toBe('$80.00/hr')
+  })
+
+  it('handles an empty quote without throwing', () => {
+    const report = computeLaborHoursReport([])
+    expect(report.total_hours).toBe(0)
+    expect(report.estimated_cost).toBe(0)
+    expect(report.rate_display).toBe('—')
+    expect(report.rows).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Closes #162

## Issue & root cause
The issue asks for a report showing per-item and total calculated labour hours for a quote (the annotated template circled Estimate 15.0 hr and Cost $1,200). No such report existed; the quote "Print" dialog only offered a priced or quantities-only quote.

## What I did
1. Confirmed the labour hours needed are already embedded in each quote line item (`labor.hours`, `labor.rate`) — the frontend already uses them for pricing. So this is **frontend-only**: no endpoint, schema, or migration change.
2. Added `lib/laborHours.ts` — pure calculation (per-item time, totals, blended/variable rate).
3. Added `pdf/LaborHoursPDF.tsx` — renders that calculation to a client-side PDF, matching the existing quote-PDF style.
4. Added a third option, "Labour hours report", to the existing Print dialog in `QuoteEditor.tsx` (same dynamic-import PDF flow as the other print options).
5. Added `test/labor-hours.test.ts` — 6 unit tests.

## Before → after
- QuoteEditor Print dialog: 2 options → 3 (adds "Labour hours report").
- New `runPrintLaborHours()` mirrors `runPrintQuote()`: fetch project + company settings, dynamic-import react-pdf + the report, open the blob in a new tab.

## How it works (data flow)
Click "Labour hours report" → `GET /projects/{id}` + `GET /company-settings` (letterhead) → read the in-memory quote's line items → compute in the browser → render PDF → open in a new tab. **Nothing is written to the DB.**
- Time per item = quantity × labour hours-per-unit. Parts / misc / PMS contribute 0.
- Total hours and Est. cost sum only resolved labour lines. Est. cost is labour cost **before markup** (Time × Rate).
- Rate shows one value when every labour line agrees, otherwise "Variable" (Velocity has no single company rate; each labour record carries its own).
- Actual / Variance columns render blank (not tracked in Velocity; left for manual entry).
- A PMS line (labour-typed, `is_pms`, no labour record) is a genuine 0.0 hr. A **non-PMS** labour line whose record is missing is "unknown" (—) and is excluded from the totals — never silently zeroed.

## How to verify
**Automated (passing):** `cd frontend && npx vitest run src/test/labor-hours.test.ts` → 6 pass. Asserts the 15.0 hr / $1,200 case, "Variable" on mixed rates, PMS = 0 and not flagged, orphan line excluded, parts = 0, empty quote. `npx tsc -b` and `npx vite build` are clean.

**Manual UI — done, against a real quote (A3811):**
- Print → "Labour hours report" → the report totalled **15.0 hr**, which matches the **Estimate 15.0** circled on the annotated template in the issue. That total is the whole point of the report and it reconciles exactly.
- Rate rendered `$68.00/hr` and Est. Cost `$1,020.00`. The template's $1,200 was an illustrative figure at $80/hr; this quote's labour records are $68/hr, so the cost differs while the **hours match** — hours are what the issue asked for, and the cost column is derived from whatever rate each labour record actually carries.
- The quote's **PMS line rendered `0.0 hr.` with no "unresolved" footnote**, which is the intended treatment (PMS is priced by percentage, not by hours). An earlier revision of this branch wrongly flagged PMS lines as unresolved; that is fixed and this was the specific case re-checked.

## Risk / degradation
Read-only: renders client-side, writes nothing to the DB, adds no endpoint or migration. Worst case if a labour record is missing: that line shows "—" and is left out of the total, with a footnote counting such lines — it never silently reports a fake 0.
