### PR TITLE
Staff profiles (#163 Phase 1)

### DIFF
--- a/backend/alembic/versions/20260721_025_add_staff_profile_type.py
+++ b/backend/alembic/versions/20260721_025_add_staff_profile_type.py
@@ -31,8 +31,12 @@ def upgrade():
 
 
 def downgrade():
-    # Restore the NOT NULL constraint. Any staff rows with a null pst must be
-    # cleaned up before downgrading; on an empty schema this is a no-op.
+    # Backfill NULL pst (staff rows) to '' BEFORE restoring NOT NULL, so a
+    # downgrade on a LIVE DB that already has staff profiles doesn't abort with
+    # "column pst contains null values". pst has no format/CHECK constraint, so
+    # '' satisfies the restored constraint. (The empty-schema CI job never has
+    # staff rows, so this path was previously untested.)
+    op.execute("UPDATE profiles SET pst = '' WHERE pst IS NULL")
     op.alter_column('profiles', 'pst', existing_type=sa.String(), nullable=False)
 
     # Note: Postgres cannot drop a single value from an enum without recreating

--- a/backend/alembic/versions/20260721_025_add_staff_profile_type.py
+++ b/backend/alembic/versions/20260721_025_add_staff_profile_type.py
@@ -1,0 +1,40 @@
+"""Add 'staff' to profiletype enum and make profiles.pst nullable
+
+Issue #163: UCA staff profiles. Staff become a third ProfileType alongside
+customer/vendor. Staff have no Provincial Tax Number, so profiles.pst is
+relaxed to nullable.
+
+Note: revision id kept short - alembic_version.version_num is VARCHAR(32).
+
+Revision ID: 025_staff_profile_type
+Revises: 024_invoice_versioning
+Create Date: 2026-07-21
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '025_staff_profile_type'
+down_revision = '024_invoice_versioning'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add the new enum value. Postgres 12+ permits ALTER TYPE ... ADD VALUE
+    # inside a transaction as long as the value is not *used* in the same
+    # transaction (it is only added here; application inserts use it later).
+    op.execute("ALTER TYPE profiletype ADD VALUE IF NOT EXISTS 'staff'")
+
+    # Staff have no Provincial Tax Number, so pst is no longer required.
+    op.alter_column('profiles', 'pst', existing_type=sa.String(), nullable=True)
+
+
+def downgrade():
+    # Restore the NOT NULL constraint. Any staff rows with a null pst must be
+    # cleaned up before downgrading; on an empty schema this is a no-op.
+    op.alter_column('profiles', 'pst', existing_type=sa.String(), nullable=False)
+
+    # Note: Postgres cannot drop a single value from an enum without recreating
+    # the type, so removing 'staff' is intentionally not attempted here. A full
+    # downgrade to base drops the profiletype enum entirely via the baseline.

--- a/backend/models.py
+++ b/backend/models.py
@@ -18,6 +18,7 @@ part_labor_link = Table(
 class ProfileType(str, enum.Enum):
     customer = "customer"
     vendor = "vendor"
+    staff = "staff"
 
 
 class PhoneType(str, enum.Enum):
@@ -49,7 +50,7 @@ class Profile(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, nullable=False)
     type = Column(Enum(ProfileType), nullable=False)
-    pst = Column(String, nullable=False)  # Provincial Tax Number
+    pst = Column(String, nullable=True)  # Provincial Tax Number (not applicable to staff)
     address = Column(String, nullable=False)
     postal_code = Column(String, nullable=False)
     default_discount_percent = Column(Float, nullable=True)  # Default vendor discount %

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -120,6 +120,12 @@ def update_profile(profile_id: int, profile_data: ProfileUpdate, db: Session = D
     if profile_data.default_discount_percent is not None:
         db_profile.default_discount_percent = profile_data.default_discount_percent
 
+    # Staff have no Provincial Tax Number: if a profile is (converted to) staff,
+    # clear any stale pst. The frontend omits pst for staff, so the guard above
+    # would otherwise leave the previous customer/vendor pst in place.
+    if db_profile.type == ModelProfileType.staff:
+        db_profile.pst = None
+
     db.commit()
     db.refresh(db_profile)
     return db_profile

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -23,6 +23,7 @@ class Paginated(BaseModel, Generic[T]):
 class ProfileType(str, Enum):
     customer = "customer"
     vendor = "vendor"
+    staff = "staff"
 
 
 # ===== Company Settings Schemas =====
@@ -361,7 +362,7 @@ class Contact(ContactBase):
 class ProfileBase(BaseModel):
     name: str
     type: ProfileType
-    pst: str
+    pst: Optional[str] = None  # Not applicable to staff profiles
     address: str
     postal_code: str
     default_discount_percent: Optional[float] = None

--- a/frontend/src/components/forms/ProfileForm.tsx
+++ b/frontend/src/components/forms/ProfileForm.tsx
@@ -76,7 +76,7 @@ export function ProfileForm({ profile, defaultType = "customer", onSuccess, onCa
     if (profile) {
       setName(profile.name)
       setType(profile.type)
-      setPst(profile.pst)
+      setPst(profile.pst || "")
       setAddress(profile.address)
       setPostalCode(profile.postal_code)
       setDefaultDiscountPercent(profile.default_discount_percent?.toString() || "")
@@ -150,7 +150,9 @@ export function ProfileForm({ profile, defaultType = "customer", onSuccess, onCa
 
   // Validation
   const isFormValid = () => {
-    if (!name.trim() || !pst.trim() || !address.trim() || !postalCode.trim()) return false
+    if (!name.trim() || !address.trim() || !postalCode.trim()) return false
+    // Staff have no Provincial Tax Number; PST is required only for customers/vendors.
+    if (type !== "staff" && !pst.trim()) return false
     if (contacts.length === 0) return false
     return contacts.every(c => c.name.trim() !== "")
   }
@@ -178,7 +180,7 @@ export function ProfileForm({ profile, defaultType = "customer", onSuccess, onCa
         await api.profiles.update(profile.id, {
           name: name.trim(),
           type,
-          pst: pst.trim(),
+          pst: type === "staff" ? undefined : pst.trim(),
           address: address.trim(),
           postal_code: postalCode.trim(),
           default_discount_percent: defaultDiscountPercent ? parseFloat(defaultDiscountPercent) : undefined,
@@ -218,7 +220,7 @@ export function ProfileForm({ profile, defaultType = "customer", onSuccess, onCa
         const profileData: ProfileCreate = {
           name: name.trim(),
           type,
-          pst: pst.trim(),
+          pst: type === "staff" ? undefined : pst.trim(),
           address: address.trim(),
           postal_code: postalCode.trim(),
           default_discount_percent: defaultDiscountPercent ? parseFloat(defaultDiscountPercent) : undefined,
@@ -251,7 +253,7 @@ export function ProfileForm({ profile, defaultType = "customer", onSuccess, onCa
 
         <div className="grid grid-cols-2 gap-4">
           <div className="space-y-2">
-            <Label htmlFor="name">{type === "customer" ? "Company Name" : "Supplier Name"} *</Label>
+            <Label htmlFor="name">{type === "customer" ? "Company Name" : type === "vendor" ? "Supplier Name" : "Staff Name"} *</Label>
             <Input
               id="name"
               value={name}
@@ -270,21 +272,25 @@ export function ProfileForm({ profile, defaultType = "customer", onSuccess, onCa
               <SelectContent>
                 <SelectItem value="customer">Customer</SelectItem>
                 <SelectItem value="vendor">Vendor</SelectItem>
+                <SelectItem value="staff">Staff</SelectItem>
               </SelectContent>
             </Select>
           </div>
         </div>
 
-        <div className="space-y-2">
-          <Label htmlFor="pst">PST (Provincial Tax Number) *</Label>
-          <Input
-            id="pst"
-            value={pst}
-            onChange={(e) => setPst(e.target.value)}
-            placeholder="e.g., PST-1234567"
-            required
-          />
-        </div>
+        {/* PST — not applicable to staff (they have no Provincial Tax Number) */}
+        {type !== "staff" && (
+          <div className="space-y-2">
+            <Label htmlFor="pst">PST (Provincial Tax Number) *</Label>
+            <Input
+              id="pst"
+              value={pst}
+              onChange={(e) => setPst(e.target.value)}
+              placeholder="e.g., PST-1234567"
+              required
+            />
+          </div>
+        )}
 
         <div className="space-y-2">
           <Label htmlFor="address">Address *</Label>

--- a/frontend/src/pages/ProfilesPage.tsx
+++ b/frontend/src/pages/ProfilesPage.tsx
@@ -24,12 +24,12 @@ import { Input } from "@/components/ui/input"
 import { api } from "@/api/client"
 import type { Profile, Part, PricebookImportResult } from "@/types"
 import {
-  Plus, Trash2, Pencil, Users, Building, Phone, Mail, MapPin, Upload, Search,
+  Plus, Trash2, Pencil, Users, Building, User, Phone, Mail, MapPin, Upload, Search,
 } from "lucide-react"
 import { EMPTY_VALUE } from "@/lib/format"
 import { VirtualizedTable, headerCellClass, cellClass } from "@/components/ui/virtualized-table"
 
-type ProfileTab = "customers" | "vendors"
+type ProfileTab = "customers" | "vendors" | "staff"
 
 function getPrimaryPhone(profile: Profile): string | null {
   const phone = profile.contacts?.[0]?.phone_numbers?.[0]?.number
@@ -48,6 +48,7 @@ export function ProfilesPage() {
   const [activeTab, setActiveTab] = useState<ProfileTab>("customers")
   const [customerSearch, setCustomerSearch] = useState("")
   const [vendorSearch, setVendorSearch] = useState("")
+  const [staffSearch, setStaffSearch] = useState("")
 
   // Pricebook state (vendor detail view)
   const [vendorParts, setVendorParts] = useState<Part[]>([])
@@ -138,6 +139,7 @@ export function ProfilesPage() {
 
   const customers = useMemo(() => profiles.filter((p) => p.type === "customer"), [profiles])
   const vendors = useMemo(() => profiles.filter((p) => p.type === "vendor"), [profiles])
+  const staff = useMemo(() => profiles.filter((p) => p.type === "staff"), [profiles])
 
   const filteredCustomers = useMemo(() => {
     const n = customerSearch.trim().toLowerCase()
@@ -167,12 +169,26 @@ export function ProfilesPage() {
     })
   }, [vendors, vendorSearch])
 
+  const filteredStaff = useMemo(() => {
+    const n = staffSearch.trim().toLowerCase()
+    if (!n) return staff
+    return staff.filter((p) => {
+      const hay = [
+        p.name,
+        p.address,
+        p.postal_code,
+        ...p.contacts.flatMap((c) => [c.name, c.email ?? "", ...c.phone_numbers.map((ph) => ph.number)]),
+      ].join(" ").toLowerCase()
+      return hay.includes(n)
+    })
+  }, [staff, staffSearch])
+
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
           <h1 className="text-2xl font-bold">Profiles</h1>
-          <p className="text-muted-foreground">Manage customers and vendors</p>
+          <p className="text-muted-foreground">Manage customers, vendors, and staff</p>
         </div>
         <Button onClick={handleAdd} className="gap-2">
           <Plus className="h-4 w-4" />
@@ -198,6 +214,10 @@ export function ProfilesPage() {
             <TabsTrigger value="vendors" className="gap-2">
               <Building className="h-4 w-4" />
               Vendors ({vendors.length})
+            </TabsTrigger>
+            <TabsTrigger value="staff" className="gap-2">
+              <User className="h-4 w-4" />
+              Staff ({staff.length})
             </TabsTrigger>
           </TabsList>
 
@@ -238,6 +258,25 @@ export function ProfilesPage() {
               onDelete={handleDelete}
             />
           </TabsContent>
+
+          <TabsContent value="staff" className="space-y-4">
+            <div className="relative max-w-md">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Search staff by name, address, contact..."
+                value={staffSearch}
+                onChange={(e) => setStaffSearch(e.target.value)}
+                className="pl-9"
+              />
+            </div>
+            <ProfileTable
+              profiles={filteredStaff}
+              emptyMessage={staffSearch ? "No staff match your search." : "No staff yet. Add your first staff profile."}
+              onRowClick={handleRowClick}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
+            />
+          </TabsContent>
         </Tabs>
       )}
 
@@ -247,11 +286,12 @@ export function ProfilesPage() {
           <DialogHeader>
             <DialogTitle>{editingProfile ? "Edit Profile" : "Add New Profile"}</DialogTitle>
             <DialogDescription>
-              {editingProfile ? "Update the profile details below." : "Create a new customer or vendor with at least one contact."}
+              {editingProfile ? "Update the profile details below." : "Create a new customer, vendor, or staff profile with at least one contact."}
             </DialogDescription>
           </DialogHeader>
           <ProfileForm
             profile={editingProfile ?? undefined}
+            defaultType={activeTab === "staff" ? "staff" : activeTab === "vendors" ? "vendor" : "customer"}
             onSuccess={() => {
               handleEditDialogClose(false)
               fetchData()
@@ -268,6 +308,8 @@ export function ProfilesPage() {
             <DialogTitle className="flex items-center gap-2">
               {viewingProfile?.type === 'customer' ? (
                 <Users className="h-5 w-5" />
+              ) : viewingProfile?.type === 'staff' ? (
+                <User className="h-5 w-5" />
               ) : (
                 <Building className="h-5 w-5" />
               )}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -249,7 +249,7 @@ export interface Profile {
   id: number;
   name: string;
   type: ProfileType;
-  pst?: string;
+  pst?: string | null;
   address: string;
   postal_code: string;
   default_discount_percent?: number;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -243,13 +243,13 @@ export interface ContactUpdate {
 }
 
 // ===== Profiles =====
-export type ProfileType = 'customer' | 'vendor';
+export type ProfileType = 'customer' | 'vendor' | 'staff';
 
 export interface Profile {
   id: number;
   name: string;
   type: ProfileType;
-  pst: string;
+  pst?: string;
   address: string;
   postal_code: string;
   default_discount_percent?: number;
@@ -259,7 +259,7 @@ export interface Profile {
 export interface ProfileCreate {
   name: string;
   type: ProfileType;
-  pst: string;
+  pst?: string;
   address: string;
   postal_code: string;
   default_discount_percent?: number;


### PR DESCRIPTION
Refs #163 — Phase 2 (staff logins) kept open. This PR = **Phase 1: staff directory**.

Adds `staff` as a third `ProfileType` (customer/vendor/staff) so UCA staff are a first-class profile you can create/view/edit/delete/search. `/profiles` CRUD is already type-generic → **no new endpoints**; the change threads one enum value + makes `pst` nullable (staff have no PST). Migration `025`: `ALTER TYPE profiletype ADD VALUE 'staff'` + drop `pst` NOT NULL — **the migration is required** (the DB enum is real; adding the value in Python alone would 500 the first staff insert). Phase 2 (Clerk login provisioning) is deliberately not here. **Staff is server-filtered out of the existing customer/vendor pickers** (ProjectForm/POEditor/PartForm) — no leak into those dropdowns.

**Test** (post-deploy — the enum insert needs the migration live): create a `[TEST]` staff profile → saves, shows under Staff only, edits, deletes. Existing customers/vendors unchanged (PST still required in the UI).

Notes: making `pst` nullable drops the DB NOT NULL for all profiles (a server-side PST validator for customer/vendor is a possible follow-up). Downgrade backfills `pst=''` before restoring NOT NULL, so a rollback on a live DB with staff rows doesn't abort.
