### PR TITLE
Quote print: category totals only (#174)

### DIFF
--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -59,6 +59,7 @@ import { Plus, Minus, Trash2, Wrench, Package, FileText, Pencil, ClipboardCheck,
 import { StatusBadge } from "@/components/ui/status-badge"
 import { formatDateTime } from "@/lib/format"
 import type { CompanySettings, Project, SystemRate } from '@/types'
+import type { QuotePrintMode } from "@/components/pdf/QuotePDF"
 import { QuoteAuditTrail } from "./QuoteAuditTrail"
 import { EditCreatedAtDialog } from "./EditCreatedAtDialog"
 import { PartForm } from "@/components/forms/PartForm"
@@ -2005,7 +2006,7 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
     }
   }
 
-  const runPrintQuote = async (includeBreakdown: boolean) => {
+  const runPrintQuote = async (mode: QuotePrintMode) => {
     if (!quote) return
     setPrintDialogOpen(false)
     setIsPrinting(true)
@@ -2021,7 +2022,7 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
           quote={quote}
           project={project}
           companySettings={companySettings}
-          includeBreakdown={includeBreakdown}
+          mode={mode}
         />
       ).toBlob()
       const url = URL.createObjectURL(blob)
@@ -3806,7 +3807,7 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
           <div className="space-y-3 pt-2">
             <button
               type="button"
-              onClick={() => runPrintQuote(true)}
+              onClick={() => runPrintQuote('full')}
               className="w-full text-left p-4 rounded-md border bg-background hover:bg-accent transition-colors"
             >
               <div className="font-medium">Include line-item breakdown</div>
@@ -3816,7 +3817,17 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
             </button>
             <button
               type="button"
-              onClick={() => runPrintQuote(false)}
+              onClick={() => runPrintQuote('category-totals')}
+              className="w-full text-left p-4 rounded-md border bg-background hover:bg-accent transition-colors"
+            >
+              <div className="font-medium">Category totals only</div>
+              <div className="text-sm text-muted-foreground mt-1">
+                Show each item's description and quantity, hide per-item unit prices and totals, but keep each category's subtotal and the final Subtotal, HST, and Total.
+              </div>
+            </button>
+            <button
+              type="button"
+              onClick={() => runPrintQuote('quantities')}
               className="w-full text-left p-4 rounded-md border bg-background hover:bg-accent transition-colors"
             >
               <div className="font-medium">Quantities only</div>

--- a/frontend/src/components/pdf/QuotePDF.tsx
+++ b/frontend/src/components/pdf/QuotePDF.tsx
@@ -12,11 +12,19 @@ import {
 } from '@/lib/pricing'
 import type { Quote, QuoteLineItem, Project, CompanySettings } from '@/types'
 
+/**
+ * How line items are priced on the printout:
+ *  - 'full'            — description, qty, unit price, per-line total, category subtotal
+ *  - 'category-totals' — description, qty, NO per-line pricing, but keep category subtotals (Issue #174)
+ *  - 'quantities'      — description, qty only; no per-line pricing and no category subtotals
+ */
+export type QuotePrintMode = 'full' | 'category-totals' | 'quantities'
+
 interface QuotePDFProps {
   quote: Quote
   project: Project
   companySettings: CompanySettings
-  includeBreakdown?: boolean
+  mode?: QuotePrintMode
 }
 
 function LineItemTable({
@@ -24,19 +32,29 @@ function LineItemTable({
   items,
   nonPmsTotal,
   useEffective,
-  showLineDetails,
+  mode,
 }: {
   title: string
   items: QuoteLineItem[]
   nonPmsTotal: number
   useEffective?: boolean
-  showLineDetails: boolean
+  mode: QuotePrintMode
 }) {
   if (items.length === 0) return null
 
-  // Quantities-only mode: list each item's description + qty, with no pricing
-  // and no section subtotal (only the final Subtotal/HST/Total appear at the bottom).
-  if (!showLineDetails) {
+  const showPricing = mode === 'full'
+  const showSubtotal = mode === 'full' || mode === 'category-totals'
+  const sectionTotal = showSubtotal
+    ? items.reduce(
+        (sum, item) =>
+          sum + (useEffective ? getEffectiveLineItemTotal(item, nonPmsTotal) : getLineItemTotal(item)),
+        0
+      )
+    : 0
+
+  // No-pricing layout (quantities-only or category-totals): description + qty only.
+  // A category subtotal row is appended for 'category-totals' but not 'quantities'.
+  if (!showPricing) {
     return (
       <>
         <Text style={styles.sectionTitle}>{title}</Text>
@@ -54,15 +72,17 @@ function LineItemTable({
             <Text style={styles.colQtyWide}>{item.quantity}</Text>
           </View>
         ))}
+        {showSubtotal && (
+          <View style={styles.tableFooterRow}>
+            <Text style={[styles.bold, { width: '70%' }]}>{title} Subtotal</Text>
+            <Text style={[styles.bold, { width: '30%', textAlign: 'right' }]}>
+              {formatCurrency(sectionTotal)}
+            </Text>
+          </View>
+        )}
       </>
     )
   }
-
-  const sectionTotal = items.reduce(
-    (sum, item) =>
-      sum + (useEffective ? getEffectiveLineItemTotal(item, nonPmsTotal) : getLineItemTotal(item)),
-    0
-  )
 
   return (
     <>
@@ -122,7 +142,7 @@ function getItemDescription(item: QuoteLineItem): string {
   return item.description || 'Unknown item'
 }
 
-export function QuotePDF({ quote, project, companySettings, includeBreakdown = true }: QuotePDFProps) {
+export function QuotePDF({ quote, project, companySettings, mode = 'full' }: QuotePDFProps) {
   const partItems = quote.line_items.filter(i => i.item_type === 'part')
   const laborItems = quote.line_items.filter(i => i.item_type === 'labor')
   const miscItems = quote.line_items.filter(i => i.item_type === 'misc')
@@ -193,9 +213,9 @@ export function QuotePDF({ quote, project, companySettings, includeBreakdown = t
         )}
 
         {/* Line Items by Section */}
-        <LineItemTable title="Parts" items={partItems} nonPmsTotal={nonPmsTotal} showLineDetails={includeBreakdown} />
-        <LineItemTable title="Labour" items={laborItems} nonPmsTotal={nonPmsTotal} useEffective showLineDetails={includeBreakdown} />
-        <LineItemTable title="Miscellaneous" items={miscItems} nonPmsTotal={nonPmsTotal} showLineDetails={includeBreakdown} />
+        <LineItemTable title="Parts" items={partItems} nonPmsTotal={nonPmsTotal} mode={mode} />
+        <LineItemTable title="Labour" items={laborItems} nonPmsTotal={nonPmsTotal} useEffective mode={mode} />
+        <LineItemTable title="Miscellaneous" items={miscItems} nonPmsTotal={nonPmsTotal} mode={mode} />
 
         {/* Totals */}
         <View style={styles.totalsBlock}>


### PR DESCRIPTION
Closes #173
Closes #174

> **Note:** #173 (filed by Jay with Dexter's screenshot) and #174 (my written-up restatement an hour later) are the same request. This PR closes both so neither is left open after merge.

**Stacked on #171 (labour-hours report)** — it edits the same quote Print dialog, so this branches off `feat/issue-162-labor-hours-report`. When #171 merges, GitHub retargets this to master.

> ⚠️ **CI has never run on this PR.** `ci.yml` triggers on `pull_request: branches: [master]`, and this PR targets a feature branch, so no run exists. Retargeting to master after #171 merges will *not* trigger it either (a base change fires `edited`, which isn't in the default trigger set). **Before merging:** once #171 has landed, push `git commit --allow-empty -m "chore: trigger CI"` to this branch to force a run and confirm it's green.
>
> Verified locally in the meantime on this branch's tip: `npx tsc -b` clean, production `vite build` succeeds, `npx vitest run` 21/21 pass, and the Dockerfile `VITE_` ARG check passes. `npm run lint` output is byte-identical to `master` (no lint problem added).
>
> ⚠️ **The `Closes #173` / `Closes #174` keywords above are currently inert.** GitHub only creates closing-issue links when a PR targets the default branch, and this one targets a feature branch — so as of now this PR has **no linked issues** and merging it would close nothing. Once #171 merges and the base retargets to master, confirm the two issues appear under "Development" in the sidebar; if they don't, re-save this description to force a re-parse, or close #173 and #174 by hand after merge.

## Request (Dexter, via Jay, 2026-07-22)
> remove the pricing for each line item and only leave the total at each category (Labor/Materials/Misc.)

On the quote printout, provide a way to show the item breakdown **without** per-line pricing, keeping only the category subtotals and the final totals.

## What changed (2 files)
The quote Print dialog already had two modes; this adds a third, so nothing existing changes.

- `frontend/src/components/pdf/QuotePDF.tsx` — replaced the `includeBreakdown: boolean` prop with a `mode: 'full' | 'category-totals' | 'quantities'`. `LineItemTable` now derives `showPricing`/`showSubtotal` from the mode:
  - **full** — description, qty, unit price, per-line total, category subtotal (unchanged behavior)
  - **category-totals** (new) — description, qty, **no per-line pricing**, but **keeps the category subtotal**
  - **quantities** — description, qty only, no pricing and no category subtotal (unchanged behavior)
- `frontend/src/components/editors/QuoteEditor.tsx` — `runPrintQuote` now takes the `mode`; added a **"Category totals only"** button to the print dialog.

## Why it's a third option, not an edit to an existing one
The existing "Include line-item breakdown" (full pricing) and "Quantities only" (no subtotals) are both still valid outputs other users rely on. Dexter's ask is a hybrid — item rows + category subtotals, no per-line prices — so it's added alongside, changing neither.

## How to verify
**Automated (passing):** `npx tsc -b` clean, `npx vitest run` → 21 pass.

**Manual UI — done, against a real quote (A3811):**
- Print → **Category totals only** → each item shows **description and quantity only**; the Unit Price and Total columns are gone from the line rows, exactly as asked.
- Category subtotals still print: **Parts $3,357.21**, **Labour $1,913.89**, **Miscellaneous $597.00**.
- Final block still prints: **Subtotal $5,868.10**, **HST $762.85**, **Total $6,630.96**.
- **Regression check on the other two modes:** "Include line-item breakdown" still shows full per-line pricing, and "Quantities only" still shows description + qty with no subtotals. Neither changed.

## Risk / degradation
Frontend-only, additive, read-only (renders a PDF). The prop rename (`includeBreakdown` → `mode`) is fully contained to `QuotePDF` + its one caller `QuoteEditor`; the PO printout has its own separate `LineItemTable` and is untouched.



Closes #174
Closes #173
