### PR TITLE
Reopen migrated quotes — single, per-project, and global bulk (#164)

### DIFF
--- a/backend/routes/quotes.py
+++ b/backend/routes/quotes.py
@@ -1,13 +1,13 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy.orm import Session, joinedload
-from sqlalchemy import func
+from sqlalchemy.orm import Session, joinedload, selectinload
+from sqlalchemy import func, and_
 from typing import List, Optional
 
 from database import get_db
 from auth import current_actor
 from utils import to_naive_utc
 from models import (
-    Quote, QuoteLineItem, Project, Labor, Part, Miscellaneous,
+    Quote, QuoteLineItem, Project, Profile, Labor, Part, Miscellaneous,
     QuoteSnapshot, QuoteLineItemSnapshot, Invoice, InvoiceLineItem, CostCode
 )
 from datetime import datetime
@@ -19,7 +19,8 @@ from schemas import (
     QuoteSnapshot as QuoteSnapshotSchema,
     Invoice as InvoiceSchema, InvoiceCreate,
     RevertPreview, MarkupControlToggleRequest, MarkupControlToggleResponse,
-    CommitEditsRequest, CommitEditsResponse, CreatedAtUpdate
+    CommitEditsRequest, CommitEditsResponse, CreatedAtUpdate,
+    ReopenableQuote, BulkReopenRequest, BulkReopenResult, BulkReopenResponse
 )
 
 DEFAULT_LIMIT = 50
@@ -311,6 +312,63 @@ def populate_invoice_number(invoice: Invoice, db: Session) -> InvoiceSchema:
     return response
 
 
+# Cap on how many quotes one bulk-reopen call may touch. Keeps the single
+# transaction (and its row locks) bounded on the live DB - the UI batches larger
+# selections. Chosen well above a normal per-project selection, well below the
+# ~4,200 total migrated rows, so a full cleanup is a handful of batches, not one
+# table-wide write.
+BULK_REOPEN_MAX = 500
+
+
+def _reopen_eligibility(quote: Quote) -> Optional[str]:
+    """Check whether a quote may be reopened, returning the blocking reason.
+
+    Args:
+        quote: Quote to test; its `invoices` relationship must be accessible.
+
+    Returns:
+        A human-readable reason string when the quote is NOT eligible, or None
+        when it is. Used by both the single and bulk reopen paths so the rules
+        stay identical.
+    """
+    if not quote.legacy_imported:                 # only migrated rows may be un-frozen
+        return "Not a migrated (legacy-imported) quote."
+    if quote.invoices:                            # real Velocity invoicing must not be reset
+        return "Quote has invoices - its fulfillment reflects real invoicing."
+    return None
+
+
+def _apply_reopen(db: Session, quote: Quote) -> int:
+    """Reset a migrated quote's line fulfillment and snapshot the change.
+
+    Clears every line to fully-pending so the quote recomputes off "Closed"
+    (to "Work Order" if it has a client PO, else "Draft"). Does NOT commit -
+    the caller owns the transaction boundary so bulk callers commit once.
+
+    Args:
+        db: Active database session.
+        quote: An eligible migrated quote (guards already applied).
+
+    Returns:
+        Count of line items whose fulfillment was actually changed.
+    """
+    reset_count = 0
+    for li in quote.line_items:                   # walk every line on the quote
+        if li.qty_fulfilled != 0 or li.qty_pending != li.quantity:  # skip already-pending lines
+            li.qty_pending = li.quantity          # all quantity back to pending
+            li.qty_fulfilled = 0                  # nothing fulfilled -> not "Closed"
+            reset_count += 1                      # count only lines actually touched
+    if reset_count == 0:                          # already fully pending (Draft/Work Order or re-run)
+        return 0                                  # no real change -> no snapshot, no version bump
+    create_snapshot(                              # audit-trail entry for the reopen
+        db,
+        quote,
+        action_type="reopen",
+        action_description=f"Reopened migrated quote - reset fulfillment on {reset_count} line item(s)",
+    )
+    return reset_count
+
+
 router = APIRouter(prefix="/quotes", tags=["quotes"])
 
 
@@ -339,6 +397,144 @@ def get_all_quotes(
     items = [populate_quote_number(quote, quote.project.uca_project_number) for quote in quotes]
     return Paginated[QuoteSchema](
         items=items, total=total, limit=limit, offset=effective_offset
+    )
+
+
+@router.get("/reopenable", response_model=Paginated[ReopenableQuote])
+def list_reopenable_quotes(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(DEFAULT_LIMIT, ge=0, le=MAX_LIMIT),
+    search: Optional[str] = Query(None, description="Filter by UCA project number or customer name"),
+    db: Session = Depends(get_db),
+):
+    """List migrated quotes currently eligible to be reopened (Issue #164).
+
+    Powers the bulk-reopen tool's checklist. Eligibility mirrors the single-reopen
+    guards plus the "Closed" branch of compute_quote_status, expressed in SQL so we
+    don't have to load every line item just to filter: legacy-imported, no Velocity
+    invoices, has >=1 line, no line still pending, and >=1 line fulfilled. A quote
+    that was already reopened has pending lines and so drops out automatically.
+
+    Args:
+        offset: Rows to skip (pagination).
+        limit: Max rows to return; 0 returns all matches.
+        search: Optional case-insensitive filter on UCA number or customer name.
+        db: Database session.
+
+    Returns:
+        Paginated[ReopenableQuote] grouped by project, each row carrying the
+        guidance fields (client-PO -> projected status) the UI shows.
+    """
+    # SQL mirror of compute_quote_status()'s "Closed" test. KEEP IN SYNC with that
+    # function: Closed == has line(s) AND none pending AND some fulfilled.
+    closed_and_migrated = and_(
+        Quote.legacy_imported.is_(True),                       # migrated rows only
+        ~Quote.invoices.any(),                                 # no real Velocity invoices
+        Quote.line_items.any(),                                # has at least one line
+        ~Quote.line_items.any(QuoteLineItem.qty_pending > 0),  # nothing still pending
+        Quote.line_items.any(QuoteLineItem.qty_fulfilled > 0), # something fulfilled
+    )
+    base = (
+        db.query(Quote)
+        .filter(closed_and_migrated)
+        .options(
+            joinedload(Quote.project).joinedload(Project.customer),  # project + customer for each row
+            joinedload(Quote.line_items),                            # count lines from memory, no extra query
+        )
+    )
+    if search:                                                 # optional text filter via EXISTS subqueries
+        term = f"%{search.strip()}%"                           # (avoids join clashes with the eager loads)
+        base = base.filter(
+            Quote.project.has(                                 # match project's UCA number...
+                Project.uca_project_number.ilike(term)
+                | Project.customer.has(Profile.name.ilike(term))  # ...or its customer's name
+            )
+        )
+    total = base.with_entities(Quote.id).count()               # total matches, independent of pagination
+    q = base.order_by(Quote.project_id, Quote.quote_sequence).offset(offset)  # group a project's quotes together
+    if limit > 0:
+        q = q.limit(limit)
+    rows = q.all()
+    items = []
+    for quote in rows:                                         # build the slim guidance DTO per row
+        has_po = bool(quote.client_po_number and quote.client_po_number.strip())  # drives projected status
+        items.append(ReopenableQuote(
+            id=quote.id,
+            quote_number=format_quote_number(                  # display id from project + sequence + version
+                quote.project.uca_project_number, quote.quote_sequence, quote.current_version
+            ),
+            uca_project_number=quote.project.uca_project_number,
+            project_id=quote.project_id,
+            project_name=quote.project.name,
+            customer_name=quote.project.customer.name if quote.project.customer else None,
+            created_at=quote.created_at,
+            line_item_count=len(quote.line_items),             # how many lines reopen will reset
+            has_client_po=has_po,
+            projected_status="Work Order" if has_po else "Draft",  # what the quote becomes after reopen
+        ))
+    return Paginated[ReopenableQuote](items=items, total=total, limit=limit, offset=offset)
+
+
+@router.post("/reopen-bulk", response_model=BulkReopenResponse)
+def reopen_quotes_bulk(payload: BulkReopenRequest, db: Session = Depends(get_db)):
+    """Reopen many migrated quotes in one call, skipping ineligible ones (Issue #164).
+
+    Applies the same per-quote guards as the single reopen (migrated + no invoices);
+    a missing or ineligible id is reported as skipped-with-reason rather than failing
+    the whole batch. All resets share one transaction, so the call commits every
+    reset together or, on error, none. The batch is capped (BULK_REOPEN_MAX) so that
+    single transaction stays bounded on the live DB.
+
+    Args:
+        payload: BulkReopenRequest with the quote ids to attempt.
+        db: Database session.
+
+    Returns:
+        BulkReopenResponse: reopened/skipped counts plus a per-id result (reopened,
+        or skipped with a reason), in the order the ids were sent.
+
+    Raises:
+        HTTPException: 400 if no ids are given, or more than BULK_REOPEN_MAX.
+    """
+    ids = list(dict.fromkeys(payload.quote_ids))               # de-dup, keep first-seen order
+    if not ids:
+        raise HTTPException(status_code=400, detail="No quote ids provided.")
+    if len(ids) > BULK_REOPEN_MAX:                             # keep the transaction bounded
+        raise HTTPException(
+            status_code=400,
+            detail=f"Too many quotes in one request (max {BULK_REOPEN_MAX}). Reopen in smaller batches.",
+        )
+    quotes = (                                                 # one query for every requested row
+        db.query(Quote)
+        # line_items via joinedload; invoices via selectinload so two sibling collections
+        # don't cross-join into a cartesian product per quote (efficiency, not correctness).
+        .options(joinedload(Quote.line_items), selectinload(Quote.invoices))
+        .filter(Quote.id.in_(ids))
+        .all()
+    )
+    by_id = {q.id: q for q in quotes}                          # id -> quote, for order-preserving lookup
+    results: List[BulkReopenResult] = []
+    reopened = 0
+    for qid in ids:                                            # process in the caller's order
+        quote = by_id.get(qid)
+        if quote is None:                                      # id not found in DB
+            results.append(BulkReopenResult(quote_id=qid, reopened=False, reason="Quote not found."))
+            continue
+        reason = _reopen_eligibility(quote)                    # shared guard (migrated + no invoices)
+        if reason:                                             # ineligible -> record and skip
+            results.append(BulkReopenResult(quote_id=qid, reopened=False, reason=reason))
+            continue
+        reset = _apply_reopen(db, quote)                       # reset fulfillment + snapshot (no commit)
+        if reset == 0:                                         # already open -> nothing changed, not a reopen
+            results.append(BulkReopenResult(quote_id=qid, reopened=False, reason="Already open - nothing to reset."))
+            continue
+        results.append(BulkReopenResult(quote_id=qid, reopened=True))
+        reopened += 1
+    db.commit()                                                # commit all resets atomically
+    return BulkReopenResponse(
+        reopened_count=reopened,
+        skipped_count=len(ids) - reopened,
+        results=results,
     )
 
 
@@ -492,34 +688,11 @@ def reopen_quote(quote_id: int, db: Session = Depends(get_db)):
     if not db_quote:
         raise HTTPException(status_code=404, detail="Quote not found")
 
-    if not db_quote.legacy_imported:
-        raise HTTPException(
-            status_code=400,
-            detail="Only migrated (legacy-imported) quotes can be reopened this way.",
-        )
+    reason = _reopen_eligibility(db_quote)         # shared guards (migrated + no invoices)
+    if reason:
+        raise HTTPException(status_code=400, detail=reason)
 
-    # A migrated quote genuinely invoiced inside Velocity has real invoice records;
-    # resetting its fulfillment would desync those. Block that case.
-    if db_quote.invoices:
-        raise HTTPException(
-            status_code=400,
-            detail="This quote has invoices and cannot be reopened - its fulfillment reflects real invoicing.",
-        )
-
-    reset_count = 0
-    for li in db_quote.line_items:
-        if li.qty_fulfilled != 0 or li.qty_pending != li.quantity:
-            li.qty_pending = li.quantity
-            li.qty_fulfilled = 0
-            reset_count += 1
-
-    create_snapshot(
-        db,
-        db_quote,
-        action_type="reopen",
-        action_description=f"Reopened migrated quote - reset fulfillment on {reset_count} line item(s)",
-    )
-
+    _apply_reopen(db, db_quote)                    # shared reset of fulfillment + snapshot
     db.commit()
     db.refresh(db_quote)
 

--- a/backend/routes/quotes.py
+++ b/backend/routes/quotes.py
@@ -466,6 +466,65 @@ def update_quote_created_at(quote_id: int, payload: CreatedAtUpdate, db: Session
     return populate_quote_number(db_quote, db_quote.project.uca_project_number)
 
 
+@router.post("/{quote_id}/reopen", response_model=QuoteSchema)
+def reopen_quote(quote_id: int, db: Session = Depends(get_db)):
+    """
+    Reopen a migrated ('Closed') quote by clearing its line-item fulfillment.
+
+    Migrated quotes were imported with every line marked fully fulfilled
+    (qty_fulfilled = quantity, qty_pending = 0), so they all derive to "Closed"
+    even when the real work order is still ongoing (Issue #164). This resets each
+    line to unfulfilled (qty_pending = quantity, qty_fulfilled = 0) so the quote
+    recomputes to "Work Order" (has a client PO) or "Draft", and staff can invoice
+    it going forward. The change is snapshotted into the audit trail.
+
+    Scoped to legacy-imported quotes on purpose: the normal edit path blocks a
+    frozen (invoiced) quote, and every migrated quote looks frozen, so this
+    endpoint is the one sanctioned way to un-freeze - and only for migrated rows.
+    """
+    db_quote = (
+        db.query(Quote)
+        .options(joinedload(Quote.project), joinedload(Quote.line_items))
+        .filter(Quote.id == quote_id)
+        .first()
+    )
+    if not db_quote:
+        raise HTTPException(status_code=404, detail="Quote not found")
+
+    if not db_quote.legacy_imported:
+        raise HTTPException(
+            status_code=400,
+            detail="Only migrated (legacy-imported) quotes can be reopened this way.",
+        )
+
+    # A migrated quote genuinely invoiced inside Velocity has real invoice records;
+    # resetting its fulfillment would desync those. Block that case.
+    if db_quote.invoices:
+        raise HTTPException(
+            status_code=400,
+            detail="This quote has invoices and cannot be reopened - its fulfillment reflects real invoicing.",
+        )
+
+    reset_count = 0
+    for li in db_quote.line_items:
+        if li.qty_fulfilled != 0 or li.qty_pending != li.quantity:
+            li.qty_pending = li.quantity
+            li.qty_fulfilled = 0
+            reset_count += 1
+
+    create_snapshot(
+        db,
+        db_quote,
+        action_type="reopen",
+        action_description=f"Reopened migrated quote - reset fulfillment on {reset_count} line item(s)",
+    )
+
+    db.commit()
+    db.refresh(db_quote)
+
+    return populate_quote_number(db_quote, db_quote.project.uca_project_number)
+
+
 @router.delete("/{quote_id}")
 def delete_quote(quote_id: int, db: Session = Depends(get_db)):
     """Delete a quote and all its line items."""

--- a/backend/routes/quotes.py
+++ b/backend/routes/quotes.py
@@ -39,7 +39,8 @@ def create_snapshot(
     Args:
         db: Database session
         quote: The quote to snapshot
-        action_type: Type of action ("create", "edit", "delete", "invoice", "revert")
+        action_type: Type of action ("create", "edit", "delete", "invoice",
+            "revert", "date_edit", "reopen")
         action_description: Human-readable description of the action
         invoice_id: Optional invoice ID if action_type is "invoice"
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -125,6 +125,45 @@ class BacklogQuoteItem(BaseModel):
     line_items: List[BacklogLineItem] = []
 
 
+# ===== Reopen Migrated Quotes (Issue #164) =====
+class ReopenableQuote(BaseModel):
+    """One migrated quote eligible to be reopened, plus fields to guide the choice.
+
+    Surfaced by the bulk-reopen tool so staff can pick which ongoing work orders to
+    reopen. `has_client_po`/`projected_status` tell them what the quote becomes once
+    reopened (a quote with a client PO recomputes to "Work Order", otherwise "Draft").
+    """
+    id: int
+    quote_number: str          # display id, e.g. A2132-0001-1
+    uca_project_number: str    # owning project's UCA number
+    project_id: int            # for linking through to the project
+    project_name: str          # human context for the row
+    customer_name: Optional[str] = None  # owning project's customer, if set
+    created_at: datetime       # import/creation date, helps date-scope a cleanup
+    line_item_count: int       # how many lines get reset on reopen
+    has_client_po: bool        # true -> reopens to "Work Order", false -> "Draft"
+    projected_status: str      # the status it will show after reopen
+
+
+class BulkReopenRequest(BaseModel):
+    """Payload for reopening several migrated quotes in one call."""
+    quote_ids: List[int]       # quotes to attempt to reopen
+
+
+class BulkReopenResult(BaseModel):
+    """Per-quote outcome inside a bulk reopen response."""
+    quote_id: int
+    reopened: bool             # true if this quote's fulfillment was reset
+    reason: Optional[str] = None  # why it was skipped, when reopened is False
+
+
+class BulkReopenResponse(BaseModel):
+    """Aggregate result of a bulk reopen call, with a per-quote breakdown."""
+    reopened_count: int        # how many were actually reopened
+    skipped_count: int         # how many were skipped (not found / ineligible)
+    results: List[BulkReopenResult]  # one entry per requested id, in request order
+
+
 # ===== Inventory Health (UX-7) =====
 class InventoryHealthIssue(BaseModel):
     """A single quality issue against an inventory part."""

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,6 +51,9 @@ const SettingsPage = lazy(() =>
 const MigrationPage = lazy(() =>
   import("@/pages/MigrationPage").then((m) => ({ default: m.MigrationPage }))
 )
+const ReopenMigratedQuotesPage = lazy(() =>
+  import("@/pages/ReopenMigratedQuotesPage").then((m) => ({ default: m.ReopenMigratedQuotesPage }))
+)
 
 function PageFallback() {
   return (
@@ -72,12 +75,13 @@ import {
   BarChart3,
   Settings,
   DatabaseZap,
+  Unlock,
   Menu,
   X,
 } from "lucide-react"
 import { Toaster } from "@/components/ui/toaster"
 
-type AppView = "profiles" | "projects" | "project-details" | "inventory" | "reports" | "settings" | "migration"
+type AppView = "profiles" | "projects" | "project-details" | "inventory" | "reports" | "settings" | "migration" | "reopen-quotes"
 
 type ParsedRoute =
   | { view: Exclude<AppView, "project-details"> }
@@ -93,6 +97,7 @@ function parseRoute(pathname: string): ParsedRoute {
   if (pathname === "/reports") return { view: "reports" }
   if (pathname === "/settings") return { view: "settings" }
   if (pathname === "/admin/migration") return { view: "migration" }
+  if (pathname === "/reopen-migrated-quotes") return { view: "reopen-quotes" }
   // /projects/:id, /projects/:id/quotes|pos|invoices/:docId
   const projMatch = pathname.match(/^\/projects\/(\d+)(?:\/(quotes|pos|invoices)\/(\d+))?$/)
   if (projMatch) {
@@ -122,10 +127,12 @@ function App() {
   // Projects page search term — lifted here so it survives drilling into a project and coming back.
   const [projectSearchTerm, setProjectSearchTerm] = useState("")
 
-  // Migration is an admin-only destructive surface; non-admins shouldn't see it.
+  // Migration and the global reopen tool are admin-only surfaces (bulk/destructive on live
+  // data); non-admins shouldn't see or land on them. (Gating is client-side only, matching the
+  // app norm - the backend does not enforce admin - so this controls UI exposure, not the API.)
   const isAdmin = useIsAdmin()
   useEffect(() => {
-    if (currentView === "migration" && !isAdmin) {
+    if ((currentView === "migration" || currentView === "reopen-quotes") && !isAdmin) {
       navigate("/projects", { replace: true })
     }
   }, [currentView, isAdmin, navigate])
@@ -368,6 +375,12 @@ function App() {
         // (the useEffect above will then redirect to projects on the next tick).
         if (!isAdmin) return null
         return <MigrationPage />
+
+      case "reopen-quotes":
+        // Defensive gate: bulk cross-project reopen is admin-only (the effect above
+        // also redirects non-admins who somehow land here).
+        if (!isAdmin) return null
+        return <ReopenMigratedQuotesPage />
 
       case "project-details":
         if (selectedProjectId === null) {
@@ -698,6 +711,16 @@ function App() {
         <BarChart3 className="h-4 w-4" />
         Reports
       </Button>
+      {isAdmin && (
+        <Button
+          variant={currentView === "reopen-quotes" ? "secondary" : "ghost"}
+          className="w-full justify-start gap-2"
+          onClick={() => guardedNavigate("/reopen-migrated-quotes")}
+        >
+          <Unlock className="h-4 w-4" />
+          Reopen Quotes
+        </Button>
+      )}
       <Button
         variant={currentView === "settings" ? "secondary" : "ghost"}
         className="w-full justify-start gap-2"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -230,6 +230,9 @@ export const api = {
     // `iso` is a UTC ISO-8601 string (e.g. from new Date(localValue).toISOString()).
     updateCreatedAt: (id: number, iso: string) =>
       request<Quote>(`/quotes/${id}/created-at`, { method: 'PUT', body: JSON.stringify({ created_at: iso }) }),
+    // Reopen a migrated ('Closed') quote: clears line-item fulfillment so it recomputes to Work Order/Draft.
+    reopen: (id: number) =>
+      request<Quote>(`/quotes/${id}/reopen`, { method: 'POST' }),
     delete: (id: number) =>
       request<{ message: string }>(`/quotes/${id}`, { method: 'DELETE' }),
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -8,6 +8,7 @@ import type {
   Contact, ContactCreate, ContactUpdate,
   Project, ProjectCreate, ProjectFull, ProjectListView, ProjectSearchResult,
   Quote, QuoteCreate, QuoteUpdate, QuoteLineItem, QuoteLineItemCreate, QuoteLineItemUpdate,
+  ReopenableQuote, BulkReopenResponse,
   PurchaseOrder, PurchaseOrderCreate, PurchaseOrderUpdate, POLineItem, POLineItemCreate,
   POReceiving, POReceivingCreate, POSnapshot, PORevertPreview,
   POCommitEditsRequest, POCommitEditsResponse,
@@ -233,6 +234,15 @@ export const api = {
     // Reopen a migrated ('Closed') quote: clears line-item fulfillment so it recomputes to Work Order/Draft.
     reopen: (id: number) =>
       request<Quote>(`/quotes/${id}/reopen`, { method: 'POST' }),
+    // Reopen many migrated quotes at once; ineligible ids come back skipped-with-reason, not as an error.
+    reopenBulk: (quoteIds: number[]) =>
+      request<BulkReopenResponse>('/quotes/reopen-bulk', {
+        method: 'POST',
+        body: JSON.stringify({ quote_ids: quoteIds }),
+      }),
+    // Paginated list of migrated quotes currently eligible to reopen (drives the global reopen tool).
+    listReopenable: (params: { offset?: number; limit?: number; search?: string } = {}) =>
+      request<Paginated<ReopenableQuote>>(`/quotes/reopenable${buildQuery(params)}`),
     delete: (id: number) =>
       request<{ message: string }>(`/quotes/${id}`, { method: 'DELETE' }),
 

--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -55,7 +55,7 @@ import type {
   InvoiceCreate, QuoteEditorMode, StagedEdit, StagedAdd,
   StagedLineItemChange, CommitEditsRequest
 } from "@/types"
-import { Plus, Minus, Trash2, Wrench, Package, FileText, Pencil, ClipboardCheck, Receipt, Percent, Info, Copy, Car, MapPin, X, Lock, GitCommit, Eye, AlertTriangle, Check, CheckCircle2, Printer, Loader2, Hash, ChevronUp, ChevronDown, ArrowLeft } from "lucide-react"
+import { Plus, Minus, Trash2, Wrench, Package, FileText, Pencil, ClipboardCheck, Receipt, Percent, Info, Copy, Car, MapPin, X, Lock, Unlock, GitCommit, Eye, AlertTriangle, Check, CheckCircle2, Printer, Loader2, Hash, ChevronUp, ChevronDown, ArrowLeft } from "lucide-react"
 import { StatusBadge } from "@/components/ui/status-badge"
 import { formatDateTime } from "@/lib/format"
 import type { CompanySettings, Project, SystemRate } from '@/types'
@@ -174,6 +174,8 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
   // Print PDF state
   const [isPrinting, setIsPrinting] = useState(false)
   const [printDialogOpen, setPrintDialogOpen] = useState(false)
+  const [reopenDialogOpen, setReopenDialogOpen] = useState(false)
+  const [isReopening, setIsReopening] = useState(false)
 
   // Company settings (for HST rate display)
   const [companySettings, setCompanySettings] = useState<CompanySettings | null>(null)
@@ -2038,6 +2040,21 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
     }
   }
 
+  const runReopen = async () => {
+    if (!quote) return
+    setReopenDialogOpen(false)
+    setIsReopening(true)
+    try {
+      await api.quotes.reopen(quote.id)
+      await fetchQuote()
+      onUpdate?.()
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to reopen quote")
+    } finally {
+      setIsReopening(false)
+    }
+  }
+
   if (loading) {
     return <div className="p-8 text-center text-muted-foreground">Loading...</div>
   }
@@ -3379,6 +3396,19 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
                 <Copy className="h-4 w-4" />
                 {isCloning ? "Cloning..." : "Clone"}
               </Button>
+              {quote.legacy_imported && quote.status === "Closed" && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setReopenDialogOpen(true)}
+                  disabled={isReopening}
+                  className="shadow-md gap-2 bg-background"
+                  title="Reopen this migrated quote (reset fulfillment so it is no longer Closed)"
+                >
+                  <Unlock className="h-4 w-4" />
+                  {isReopening ? "Reopening..." : "Reopen"}
+                </Button>
+              )}
             </div>
           )}
 
@@ -3860,6 +3890,31 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
           <DialogFooter>
             <Button variant="outline" onClick={() => setPrintDialogOpen(false)}>
               Cancel
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Reopen Confirmation Dialog (migrated quotes only) */}
+      <Dialog open={reopenDialogOpen} onOpenChange={setReopenDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Unlock className="h-4 w-4" />
+              Reopen migrated quote
+            </DialogTitle>
+            <DialogDescription>
+              This quote was imported from UC Vision as fully fulfilled, which is why it shows as Closed.
+              Reopening resets every line item to unfulfilled so the quote becomes an open Work Order again,
+              and staff can invoice the remaining work going forward. The change is recorded in the audit trail.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setReopenDialogOpen(false)} disabled={isReopening}>
+              Cancel
+            </Button>
+            <Button onClick={runReopen} disabled={isReopening}>
+              {isReopening ? "Reopening..." : "Reopen quote"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/pages/ProjectDetailsPage.tsx
+++ b/frontend/src/pages/ProjectDetailsPage.tsx
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogDescription,
+  DialogFooter,
 } from "@/components/ui/dialog"
 import {
   AlertDialog,
@@ -59,6 +60,7 @@ import {
   ChevronRight,
   Clock,
   Search,
+  Unlock,
 } from "lucide-react"
 
 const QuoteEditor = lazy(() =>
@@ -184,6 +186,12 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
   const [poDialogOpen, setPoDialogOpen] = useState(false)
   const [vendors, setVendors] = useState<Profile[]>([])
   const [selectedVendorId, setSelectedVendorId] = useState<string>("")
+
+  // Per-project bulk-reopen (Issue #164): open state, the ids the user has ticked,
+  // and an in-flight guard so the confirm button can't be double-fired.
+  const [reopenDialogOpen, setReopenDialogOpen] = useState(false)
+  const [reopenSelectedIds, setReopenSelectedIds] = useState<Set<number>>(new Set())
+  const [reopenBusy, setReopenBusy] = useState(false)
 
   // Invoices from all quotes
   const [invoices, setInvoices] = useState<(Invoice & { quoteId: number; quoteNumber: string })[]>([])
@@ -417,6 +425,65 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
     })
   }, [project, debouncedFilter])
 
+  // Quote ids that already have real Velocity invoices. The backend refuses to reopen
+  // these (fulfillment reflects real invoicing), so excluding them keeps the banner count
+  // and the pre-ticked set honest instead of silently over-counting.
+  const quoteIdsWithInvoices = useMemo(
+    () => new Set(invoices.map((inv) => inv.quoteId)),
+    [invoices],
+  )
+
+  // Migrated quotes in THIS project that still show Closed AND have no invoices - i.e. the
+  // ones the backend will actually reopen. project.quotes carries computed status + the flag.
+  const migratedClosedQuotes = useMemo(
+    () =>
+      (project?.quotes ?? []).filter(
+        (q) => q.legacy_imported && q.status === "Closed" && !quoteIdsWithInvoices.has(q.id),
+      ),
+    [project, quoteIdsWithInvoices],
+  )
+
+  // Open the reopen dialog with every candidate pre-ticked (common case: reopen them
+  // all; the user unticks any that genuinely are finished).
+  const openReopenDialog = () => {
+    setReopenSelectedIds(new Set(migratedClosedQuotes.map((q) => q.id)))
+    setReopenDialogOpen(true)
+  }
+
+  // Add/remove one quote id from the ticked selection.
+  const toggleReopenId = (id: number) => {
+    setReopenSelectedIds((prev) => {
+      const next = new Set(prev)          // clone so React sees a new Set
+      if (next.has(id)) next.delete(id)   // untick -> drop
+      else next.add(id)                   // tick -> add
+      return next
+    })
+  }
+
+  // Reopen every ticked quote in one bulk request, then refresh and report.
+  const runBulkReopen = async () => {
+    const ids = [...reopenSelectedIds]    // Set -> array for the payload
+    if (ids.length === 0) return          // nothing ticked, no-op
+    setReopenBusy(true)                   // guard against a double click
+    try {
+      const res = await api.quotes.reopenBulk(ids)  // one atomic bulk call
+      toast({
+        title: "Reopen complete",
+        description: `Reopened ${res.reopened_count}${res.skipped_count ? `, skipped ${res.skipped_count}` : ""}.`,
+      })
+      setReopenDialogOpen(false)
+      await fetchProject()                // reload so the quote statuses refresh in the list
+    } catch (err) {
+      toast({
+        variant: "destructive",
+        title: "Reopen failed",
+        description: err instanceof Error ? err.message : "Could not reopen quotes.",
+      })
+    } finally {
+      setReopenBusy(false)
+    }
+  }
+
   const filteredPOs = useMemo(() => {
     if (!project) return []
     const n = debouncedFilter.trim().toLowerCase()
@@ -638,6 +705,22 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
                     list couldn't bound or overflow — hence no scrollbar.) */}
                 <div className="flex-1 min-h-0 px-3 pb-3 overflow-y-auto" onKeyDown={onSidebarKeyDown}>
                     <div className="space-y-1 pr-2">
+                      {/* Reopen banner: only on the Quotes tab, only when this project has
+                          migrated quotes still stuck at Closed (Issue #164). Opens the picker. */}
+                      {activeTab === "quotes" && migratedClosedQuotes.length > 0 && (
+                        <button
+                          type="button"
+                          onClick={openReopenDialog}
+                          className="w-full flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-300 hover:bg-amber-500/20 transition-colors"
+                          title="Reopen migrated quotes that were imported as Closed"
+                        >
+                          <Unlock className="h-3.5 w-3.5 flex-none" />
+                          <span className="text-left">
+                            Reopen {migratedClosedQuotes.length} migrated{" "}
+                            {migratedClosedQuotes.length === 1 ? "quote" : "quotes"}
+                          </span>
+                        </button>
+                      )}
                       {activeTab === "quotes" && (
                         filteredQuotes.length === 0 ? (
                           <EmptyListMessage
@@ -736,6 +819,82 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
           )}
         </div>
       </div>
+
+      {/* Reopen Migrated Quotes Dialog (per-project, Issue #164) */}
+      <Dialog open={reopenDialogOpen} onOpenChange={(o) => !reopenBusy && setReopenDialogOpen(o)}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Unlock className="h-4 w-4" />
+              Reopen migrated quotes
+            </DialogTitle>
+            <DialogDescription>
+              These quotes were imported from UC Vision as fully fulfilled, so they show as Closed.
+              Reopening resets each to unfulfilled, so it becomes an open Work Order (or Draft) again.
+              Untick any that genuinely are finished. Each reopen is recorded in the quote's audit trail.
+            </DialogDescription>
+          </DialogHeader>
+
+          {/* Select-all row: header checkbox + running count of what's ticked. */}
+          <div className="flex items-center justify-between border-b pb-2 text-sm">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                className="h-4 w-4 accent-primary"
+                // checked only when every candidate is ticked
+                checked={reopenSelectedIds.size === migratedClosedQuotes.length && migratedClosedQuotes.length > 0}
+                // show the dash state when some-but-not-all are ticked
+                ref={(el) => {
+                  if (el)
+                    el.indeterminate =
+                      reopenSelectedIds.size > 0 && reopenSelectedIds.size < migratedClosedQuotes.length
+                }}
+                // tick -> select every candidate; untick -> clear
+                onChange={(e) =>
+                  setReopenSelectedIds(
+                    e.target.checked ? new Set(migratedClosedQuotes.map((q) => q.id)) : new Set(),
+                  )
+                }
+              />
+              <span className="font-medium">Select all</span>
+            </label>
+            <span className="text-muted-foreground">{reopenSelectedIds.size} selected</span>
+          </div>
+
+          {/* One ticky row per candidate; the far label previews what it becomes on reopen. */}
+          <div className="max-h-72 overflow-y-auto space-y-1 pr-1">
+            {migratedClosedQuotes.map((q) => {
+              const hasPo = !!(q.client_po_number && q.client_po_number.trim())  // -> Work Order vs Draft
+              return (
+                <label
+                  key={q.id}
+                  className="flex items-center gap-2 rounded-md border px-2 py-1.5 text-sm cursor-pointer hover:bg-muted/50"
+                >
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 accent-primary"
+                    checked={reopenSelectedIds.has(q.id)}
+                    onChange={() => toggleReopenId(q.id)}
+                  />
+                  <span className="font-medium">{q.quote_number}</span>
+                  <span className="ml-auto text-xs text-muted-foreground">
+                    → {hasPo ? "Work Order" : "Draft"}
+                  </span>
+                </label>
+              )
+            })}
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setReopenDialogOpen(false)} disabled={reopenBusy}>
+              Cancel
+            </Button>
+            <Button onClick={runBulkReopen} disabled={reopenBusy || reopenSelectedIds.size === 0}>
+              {reopenBusy ? "Reopening..." : `Reopen ${reopenSelectedIds.size} selected`}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Create Quote Dialog */}
       <Dialog open={quoteDialogOpen} onOpenChange={setQuoteDialogOpen}>

--- a/frontend/src/pages/ReopenMigratedQuotesPage.tsx
+++ b/frontend/src/pages/ReopenMigratedQuotesPage.tsx
@@ -1,0 +1,301 @@
+import { useState, useEffect, useCallback, useRef } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { api } from "@/api/client"
+import { toast } from "@/hooks/use-toast"
+import type { ReopenableQuote } from "@/types"
+import { Unlock, Search, ChevronLeft, ChevronRight, Loader2 } from "lucide-react"
+import { formatDate } from "@/lib/format"
+
+const PAGE_SIZE = 50 // rows fetched per page from the server
+const REOPEN_CHUNK = 500 // must stay <= the backend's BULK_REOPEN_MAX per call
+
+/**
+ * Global cross-project tool to reopen migrated quotes stuck at "Closed" (Issue #164).
+ *
+ * The UC Vision importer marked every migrated line fully fulfilled, so every migrated
+ * quote computes to Closed - including jobs that are still ongoing. This page lists the
+ * quotes currently eligible to reopen (GET /quotes/reopenable), lets staff search and
+ * tick the ones that are actually ongoing, and reopens them in bulk
+ * (POST /quotes/reopen-bulk). Selecting a quote resets its fulfillment so it recomputes
+ * to Work Order (has a client PO) or Draft. Reopened quotes fall out of the list.
+ *
+ * Access: admin-only. App.tsx gates the route/nav via useIsAdmin (client-side, matching the
+ * Migration surface); the per-project and per-quote reopen paths stay open to all staff.
+ *
+ * @returns The reopen-migrated-quotes admin view.
+ */
+export function ReopenMigratedQuotesPage() {
+  // Current page of eligible quotes + the unfiltered total (for the "x of y" footer).
+  const [rows, setRows] = useState<ReopenableQuote[]>([])
+  const [total, setTotal] = useState(0)
+  const [offset, setOffset] = useState(0)
+  const [loading, setLoading] = useState(true)
+
+  // Search box + its debounced value (the value actually sent to the server).
+  const [search, setSearch] = useState("")
+  const [debouncedSearch, setDebouncedSearch] = useState("")
+
+  // Ticked quote ids - a Set so selection survives paging - plus an in-flight guard.
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
+  const [busy, setBusy] = useState(false)
+
+  // Monotonic request id: only the latest fetch is allowed to apply its result, so
+  // overlapping fetches (e.g. a search-while-paged double-fire) can't land out of order.
+  const reqSeq = useRef(0)
+
+  // Debounce the search input so typing doesn't fire a request per keystroke.
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search), 300) // settle after 300ms idle
+    return () => clearTimeout(t) // cancel a pending settle on the next keystroke
+  }, [search])
+
+  // A new search term always restarts at the first page.
+  useEffect(() => {
+    setOffset(0)
+  }, [debouncedSearch])
+
+  /**
+   * Load the current page of eligible quotes from the server.
+   *
+   * Reads the paginated /quotes/reopenable endpoint for the active offset and search
+   * term, replacing the visible rows and total. Errors surface as a toast.
+   *
+   * @returns Promise that resolves once the page state is updated.
+   */
+  const fetchPage = useCallback(async () => {
+    const seq = ++reqSeq.current // claim this as the newest in-flight request
+    setLoading(true) // show the loading row while the request is out
+    try {
+      const res = await api.quotes.listReopenable({
+        offset,
+        limit: PAGE_SIZE,
+        search: debouncedSearch || undefined, // omit empty search entirely
+      })
+      if (seq !== reqSeq.current) return // a newer request started -> drop this stale result
+      setRows(res.items) // this page's rows
+      setTotal(res.total) // total matches across all pages
+    } catch (err) {
+      if (seq !== reqSeq.current) return // stale failure -> ignore
+      toast({
+        variant: "destructive",
+        title: "Failed to load quotes",
+        description: err instanceof Error ? err.message : "Could not load reopenable quotes.",
+      })
+    } finally {
+      if (seq === reqSeq.current) setLoading(false) // only the latest request clears loading
+    }
+  }, [offset, debouncedSearch])
+
+  // Refetch whenever the page or the search term changes.
+  useEffect(() => {
+    fetchPage()
+  }, [fetchPage])
+
+  /**
+   * Add or remove one quote id from the ticked selection.
+   *
+   * @param id - The quote id whose checkbox was toggled.
+   */
+  const toggle = (id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev) // clone so React re-renders
+      if (next.has(id)) next.delete(id) // untick -> drop
+      else next.add(id) // tick -> add
+      return next
+    })
+  }
+
+  // Ids on the visible page, and whether every one of them is already ticked.
+  const pageIds = rows.map((r) => r.id)
+  const allOnPageSelected = pageIds.length > 0 && pageIds.every((id) => selectedIds.has(id))
+
+  /**
+   * Tick or untick every row on the current page at once.
+   *
+   * @param checked - True to select all visible rows, false to deselect them.
+   */
+  const toggleAllOnPage = (checked: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (checked) pageIds.forEach((id) => next.add(id)) // select the visible page
+      else pageIds.forEach((id) => next.delete(id)) // clear the visible page
+      return next
+    })
+  }
+
+  /**
+   * Reopen every ticked quote, then refresh the page.
+   *
+   * Splits the selection into chunks no larger than the backend's per-call cap and
+   * reopens each chunk, aggregating the reopened/skipped counts for one summary toast.
+   * Reopened quotes stop being eligible, so they drop off the refreshed list.
+   *
+   * @returns Promise that resolves once all chunks are processed and the page reloads.
+   */
+  const reopenSelected = async () => {
+    const ids = [...selectedIds] // Set -> array for chunking
+    if (ids.length === 0) return // nothing ticked
+    setBusy(true) // guard the button
+    let reopened = 0
+    let skipped = 0
+    try {
+      for (let i = 0; i < ids.length; i += REOPEN_CHUNK) {
+        const chunk = ids.slice(i, i + REOPEN_CHUNK) // one <= 500-id batch
+        const res = await api.quotes.reopenBulk(chunk)
+        reopened += res.reopened_count // tally across chunks
+        skipped += res.skipped_count
+      }
+      toast({
+        title: "Reopen complete",
+        description: `Reopened ${reopened}${skipped ? `, skipped ${skipped}` : ""}.`,
+      })
+      setSelectedIds(new Set()) // clear the (now-reopened) selection
+      // Reopened rows drop out of the eligible list, shrinking the total. Return to page 1 so
+      // the offset can't land past the new total (which would show a false empty state).
+      if (offset === 0) {
+        await fetchPage() // already on page 1: setOffset won't refire the effect, so refetch here
+      } else {
+        setOffset(0) // moving to page 1 refires the fetch effect at offset 0
+      }
+    } catch (err) {
+      toast({
+        variant: "destructive",
+        title: "Reopen failed",
+        description: err instanceof Error ? err.message : "Could not reopen the selected quotes.",
+      })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  // Footer "x-y of total" bounds for the current page.
+  const pageStart = total === 0 ? 0 : offset + 1
+  const pageEnd = Math.min(offset + PAGE_SIZE, total)
+
+  return (
+    <div className="p-6 space-y-4">
+      {/* Heading + explanation of why these quotes look Closed. */}
+      <div>
+        <h1 className="text-2xl font-bold flex items-center gap-2">
+          <Unlock className="h-6 w-6" /> Reopen Migrated Quotes
+        </h1>
+        <p className="text-muted-foreground max-w-3xl">
+          Quotes imported from UC Vision came in fully fulfilled, so they all show as Closed.
+          Search for the jobs that are still ongoing, tick them, and reopen them so they become
+          open Work Orders again. Each reopen is recorded in the quote's audit trail.
+        </p>
+      </div>
+
+      {/* Search (server-side) on the left; selection count + reopen action on the right. */}
+      <div className="flex items-center gap-3">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            className="pl-9"
+            placeholder="Search by project or customer..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <div className="ml-auto flex items-center gap-3">
+          <span className="text-sm text-muted-foreground">{selectedIds.size} selected</span>
+          <Button onClick={reopenSelected} disabled={busy || selectedIds.size === 0} className="gap-2">
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Unlock className="h-4 w-4" />}
+            {busy ? "Reopening..." : `Reopen ${selectedIds.size} selected`}
+          </Button>
+        </div>
+      </div>
+
+      {/* Results table: checkbox + guidance columns (projected status is the key hint). */}
+      <div className="border rounded-md overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50">
+            <tr className="text-left">
+              <th className="w-10 p-2">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 accent-primary"
+                  aria-label="Select all on this page"
+                  checked={allOnPageSelected}
+                  onChange={(e) => toggleAllOnPage(e.target.checked)}
+                />
+              </th>
+              <th className="p-2 font-medium">Quote</th>
+              <th className="p-2 font-medium">Project</th>
+              <th className="p-2 font-medium">Customer</th>
+              <th className="p-2 font-medium">Created</th>
+              <th className="p-2 font-medium text-right">Lines</th>
+              <th className="p-2 font-medium">On reopen</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr>
+                <td colSpan={7} className="p-8 text-center text-muted-foreground">
+                  Loading…
+                </td>
+              </tr>
+            ) : rows.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="p-8 text-center text-muted-foreground">
+                  {debouncedSearch
+                    ? "No migrated quotes match your search."
+                    : "No migrated quotes are eligible to reopen."}
+                </td>
+              </tr>
+            ) : (
+              rows.map((r) => (
+                <tr key={r.id} className="border-t hover:bg-muted/30">
+                  <td className="p-2">
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4 accent-primary"
+                      aria-label={`Select quote ${r.quote_number}`}
+                      checked={selectedIds.has(r.id)}
+                      onChange={() => toggle(r.id)}
+                    />
+                  </td>
+                  <td className="p-2 font-medium">{r.quote_number}</td>
+                  <td className="p-2">
+                    {r.uca_project_number}
+                    <span className="text-muted-foreground"> · {r.project_name}</span>
+                  </td>
+                  <td className="p-2">{r.customer_name ?? "—"}</td>
+                  <td className="p-2">{formatDate(r.created_at)}</td>
+                  <td className="p-2 text-right">{r.line_item_count}</td>
+                  <td className="p-2">{r.projected_status}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Page position + prev/next controls. */}
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-muted-foreground">
+          {pageStart}–{pageEnd} of {total}
+        </span>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={offset === 0 || loading}
+            onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+          >
+            <ChevronLeft className="h-4 w-4" /> Prev
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={offset + PAGE_SIZE >= total || loading}
+            onClick={() => setOffset(offset + PAGE_SIZE)}
+          >
+            Next <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -441,6 +441,35 @@ export interface Quote {
   line_items: QuoteLineItem[];
 }
 
+// ===== Reopen Migrated Quotes (Issue #164) =====
+/** One migrated quote eligible to reopen, with fields that guide the choice. */
+export interface ReopenableQuote {
+  id: number;
+  quote_number: string;
+  uca_project_number: string;
+  project_id: number;
+  project_name: string;
+  customer_name?: string | null;
+  created_at: string;
+  line_item_count: number;      // how many lines reopen will reset
+  has_client_po: boolean;       // true -> reopens to "Work Order", false -> "Draft"
+  projected_status: string;     // the status it shows after reopen
+}
+
+/** Per-quote outcome inside a bulk reopen response. */
+export interface BulkReopenResult {
+  quote_id: number;
+  reopened: boolean;            // true if this quote's fulfillment was reset
+  reason?: string | null;       // why it was skipped, when reopened is false
+}
+
+/** Aggregate result of a bulk reopen call, with a per-quote breakdown. */
+export interface BulkReopenResponse {
+  reopened_count: number;
+  skipped_count: number;
+  results: BulkReopenResult[];
+}
+
 export interface QuoteCreate {
   project_id: number;
   client_po_number?: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -735,7 +735,7 @@ export interface MigrationResult {
 }
 
 // ===== Quote Snapshots =====
-export type SnapshotActionType = 'create' | 'edit' | 'delete' | 'invoice' | 'date_edit' | 'revert';
+export type SnapshotActionType = 'create' | 'edit' | 'delete' | 'invoice' | 'date_edit' | 'revert' | 'reopen';
 
 export interface QuoteSnapshot {
   id: number;


### PR DESCRIPTION
Migrated UC Vision quotes were all imported with lines fully fulfilled, so they compute to "Closed" even when the job is still ongoing (#164). This lets staff reopen them — one at a time, per-project, or in bulk across projects.

What's in it:
- `POST /quotes/reopen-bulk` — reopen many at once, one transaction, capped at 500/call.
- `GET /quotes/reopenable` — paginated, searchable list of quotes eligible to reopen.
- Per-project panel (Project Details): a banner on the Quotes tab → checklist dialog.
- Global "Reopen Quotes" page (admin-gated, like Migration): searchable table, bulk reopen.
- Single-reopen refactored into shared helpers so single/bulk can't drift.

Live-data safety: reopen resets line fulfillment but is guarded (legacy-imported only, rejected if the quote has real Velocity invoices), snapshotted (auditable + revertible), and a no-op reopen writes no snapshot/version bump. Endpoints + schemas are additive; no change to existing behavior beyond the refactor.

Does NOT touch: pricing math, versioning internals, or non-migrated quotes. The global tool is admin-only; per-project and per-quote reopen stay available to all staff.

How to test (post-deploy): on a legacy Closed quote, the per-quote Reopen button flips it to Work Order/Draft with an audit entry; the per-project banner → dialog bulk-reopens a project's Closed quotes; the admin "Reopen Quotes" page searches, selects, and reopens across projects, reporting reopened/skipped counts.

Closes #164