### PR TITLE
feat: per-quote line description override (#178)

### DIFF
--- a/backend/alembic/versions/20260728_025_add_line_description_override.py
+++ b/backend/alembic/versions/20260728_025_add_line_description_override.py
@@ -1,0 +1,47 @@
+"""Add per-quote description override to quote line items (issue #178)
+
+Adds a nullable ``description_override`` column to ``quote_line_items`` and
+``quote_line_item_snapshots``. This is a per-quote display override, distinct
+from the existing ``description`` field (which for migrated lines holds the
+original UC Vision line description). Additive and nullable: existing rows are
+untouched, so migrated quotes render exactly as before until a user edits a
+line's description.
+
+Note: revision id kept short - alembic_version.version_num is VARCHAR(32).
+
+Revision ID: 025_line_desc_override
+Revises: 024_invoice_versioning
+Create Date: 2026-07-28
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '025_line_desc_override'
+down_revision = '024_invoice_versioning'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute(sa.text(
+        "ALTER TABLE quote_line_items "
+        "ADD COLUMN IF NOT EXISTS description_override VARCHAR"
+    ))
+    conn.execute(sa.text(
+        "ALTER TABLE quote_line_item_snapshots "
+        "ADD COLUMN IF NOT EXISTS description_override VARCHAR"
+    ))
+
+
+def downgrade():
+    conn = op.get_bind()
+    conn.execute(sa.text(
+        "ALTER TABLE quote_line_item_snapshots "
+        "DROP COLUMN IF EXISTS description_override"
+    ))
+    conn.execute(sa.text(
+        "ALTER TABLE quote_line_items "
+        "DROP COLUMN IF EXISTS description_override"
+    ))

--- a/backend/models.py
+++ b/backend/models.py
@@ -200,6 +200,7 @@ class QuoteLineItem(Base):
     part_id = Column(Integer, ForeignKey('parts.id'), nullable=True)
     misc_id = Column(Integer, ForeignKey('miscellaneous.id'), nullable=True)
     description = Column(String)  # For misc items or override
+    description_override = Column(String, nullable=True)  # Per-quote display description override (issue #178)
     quantity = Column(Integer, default=1)  # Qty Ordered (must be whole number)
     unit_price = Column(Float)  # Override price if needed
     qty_pending = Column(Integer, default=0)  # Remaining to fulfill (must be whole number)
@@ -498,6 +499,7 @@ class QuoteLineItemSnapshot(Base):
     part_id = Column(Integer)
     misc_id = Column(Integer)
     description = Column(String)
+    description_override = Column(String, nullable=True)  # Per-quote display description override (issue #178)
     quantity = Column(Integer)  # qty_ordered (must be whole number)
     unit_price = Column(Float)
     qty_pending = Column(Integer)  # Must be whole number

--- a/backend/routes/quotes.py
+++ b/backend/routes/quotes.py
@@ -1402,7 +1402,9 @@ def create_invoice(
             invoice_id=invoice.id,
             quote_line_item_id=line_item.id,
             item_type=line_item.item_type,
-            description=line_item.description or item_desc,
+            # Freeze the customer-facing description: a per-quote override (issue #178)
+            # wins over the catalog/original label, so the invoice matches the quote.
+            description=line_item.description_override or line_item.description or item_desc,
             unit_price=line_item.unit_price,
             qty_ordered=line_item.quantity,
             qty_fulfilled_this_invoice=fulfill_qty,

--- a/backend/routes/quotes.py
+++ b/backend/routes/quotes.py
@@ -80,6 +80,7 @@ def create_snapshot(
             part_id=item.part_id,
             misc_id=item.misc_id,
             description=item.description,
+            description_override=item.description_override,
             quantity=item.quantity,
             unit_price=item.unit_price,
             qty_pending=item.qty_pending,
@@ -530,6 +531,7 @@ def clone_quote(quote_id: int, db: Session = Depends(get_db)):
             part_id=item.part_id,
             misc_id=item.misc_id,
             description=item.description,
+            description_override=item.description_override,
             quantity=item.quantity,
             unit_price=item.unit_price,
             qty_pending=item.quantity,  # Reset: pending = quantity
@@ -922,6 +924,10 @@ def update_quote_line(
         if db_line.unit_price != line_data.unit_price:
             changes.append(f"unit_price: ${db_line.unit_price or 0:.2f} → ${line_data.unit_price:.2f}")
         db_line.unit_price = line_data.unit_price
+    if line_data.description_override is not None:
+        if db_line.description_override != line_data.description_override:
+            changes.append("description override updated")
+        db_line.description_override = line_data.description_override
 
     # Create snapshot if there were actual changes
     if changes:
@@ -1001,6 +1007,7 @@ def delete_quote_line(quote_id: int, line_id: int, db: Session = Depends(get_db)
             part_id=item.part_id,
             misc_id=item.misc_id,
             description=item.description,
+            description_override=item.description_override,
             quantity=item.quantity,
             unit_price=item.unit_price,
             qty_pending=item.qty_pending,
@@ -1184,6 +1191,11 @@ def commit_edits(
             if change.description is not None and change.description != line_item.description:
                 item_changes.append("updated description")
                 line_item.description = change.description
+
+            # Update per-quote description override if provided (issue #178)
+            if change.description_override is not None and change.description_override != line_item.description_override:
+                item_changes.append("updated description override")
+                line_item.description_override = change.description_override
 
             # Update base_cost (unit cost) if provided
             if change.base_cost is not None and change.base_cost != line_item.base_cost:
@@ -1573,6 +1585,7 @@ def revert_to_snapshot(quote_id: int, version: int, db: Session = Depends(get_db
                 part_id=item_state.part_id,
                 misc_id=item_state.misc_id,
                 description=item_state.description,
+                description_override=item_state.description_override,
                 quantity=item_state.quantity,
                 unit_price=item_state.unit_price,
                 qty_pending=item_state.qty_pending,
@@ -1613,6 +1626,7 @@ def revert_to_snapshot(quote_id: int, version: int, db: Session = Depends(get_db
             part_id=item.part_id,
             misc_id=item.misc_id,
             description=item.description,
+            description_override=item.description_override,
             quantity=item.quantity,
             unit_price=item.unit_price,
             qty_pending=item.qty_pending,

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -432,6 +432,7 @@ class QuoteLineItemBase(BaseModel):
     part_id: Optional[int] = None
     misc_id: Optional[int] = None
     description: Optional[str] = None
+    description_override: Optional[str] = None  # Per-quote display description override (issue #178)
     quantity: int = 1  # Must be a positive whole number
     unit_price: Optional[float] = None
     is_pms: bool = False  # True for PMS items (Project Management Services)
@@ -458,6 +459,7 @@ class QuoteLineItemCreate(QuoteLineItemBase):
 class QuoteLineItemUpdate(BaseModel):
     quantity: Optional[int] = None  # Must be a positive whole number
     unit_price: Optional[float] = None
+    description_override: Optional[str] = None  # Per-quote display description override (issue #178)
 
     @validator('quantity', pre=True)
     def quantity_must_be_positive_integer(cls, v) -> Optional[int]:
@@ -972,6 +974,7 @@ class QuoteLineItemSnapshotBase(BaseModel):
     part_id: Optional[int] = None
     misc_id: Optional[int] = None
     description: Optional[str] = None
+    description_override: Optional[str] = None  # Per-quote display description override (issue #178)
     quantity: int  # Must be whole number
     unit_price: Optional[float] = None
     qty_pending: int  # Must be whole number
@@ -1051,6 +1054,7 @@ class StagedLineItemChange(BaseModel):
     part_id: Optional[int] = None
     misc_id: Optional[int] = None
     description: Optional[str] = None
+    description_override: Optional[str] = None  # Per-quote display description override (issue #178)
     quantity: Optional[int] = None  # Must be a positive whole number
     unit_price: Optional[float] = None
     is_pms: bool = False

--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -2240,7 +2240,7 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
                             Deleted
                           </Badge>
                         )}
-                        {item.item_type === "part" && item.part && (
+                        {item.item_type === "part" && item.part && !(item.description_override && item.description_override.trim()) && (
                           <span className="text-muted-foreground ml-2">- {item.part.description}</span>
                         )}
                       </div>

--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -696,6 +696,7 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
       (staged.quantity === undefined || staged.quantity === item.quantity) &&
       (staged.unit_price === undefined || staged.unit_price === item.unit_price) &&
       (staged.description === undefined || staged.description === item.description) &&
+      (staged.description_override === undefined || staged.description_override === (item.description_override ?? "")) &&
       (staged.markup_percent === undefined || staged.markup_percent === item.markup_percent) &&
       (staged.base_cost === undefined || staged.base_cost === item.base_cost)
 
@@ -787,6 +788,7 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
           quantity: edit.quantity,
           unit_price: edit.unit_price,
           description: edit.description,
+          description_override: edit.description_override,
           markup_percent: edit.markup_percent,
           base_cost: edit.base_cost,
         })
@@ -1043,6 +1045,11 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
   }
 
   const getLineItemDescription = (item: QuoteLineItem): string => {
+    // A per-quote description override (issue #178) wins over the catalog label
+    // when set. Migrated lines leave this empty, so they render exactly as before.
+    if (item.description_override && item.description_override.trim()) {
+      return item.description_override
+    }
     if (item.item_type === "labor") {
       if (item.labor) {
         return item.labor.description
@@ -2237,6 +2244,19 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
                           <span className="text-muted-foreground ml-2">- {item.part.description}</span>
                         )}
                       </div>
+                      {/* Per-quote description override (issue #178) — edit mode only.
+                          Changes only this quote line's printed description, never inventory. */}
+                      {editorMode === "edit" && !isDeleted && (
+                        <Input
+                          type="text"
+                          className="mt-1 h-7 text-sm"
+                          placeholder="Custom description for this quote (optional)"
+                          value={editedItem?.description_override ?? item.description_override ?? ""}
+                          onChange={(e) => stageEdit(item, { description_override: e.target.value })}
+                          disabled={hasBeenInvoiced}
+                          title="Overrides this line's printed description for this quote only — does not change the inventory item"
+                        />
+                      )}
                     </TableCell>
 
                     {/* Qty Ordered Column — inline-editable in edit mode (non-PMS) */}

--- a/frontend/src/components/pdf/QuotePDF.tsx
+++ b/frontend/src/components/pdf/QuotePDF.tsx
@@ -135,6 +135,9 @@ function LineItemTable({
 }
 
 function getItemDescription(item: QuoteLineItem): string {
+  // A per-quote description override (issue #178) wins over the catalog label
+  // when set. Migrated lines leave this empty, so they print exactly as before.
+  if (item.description_override && item.description_override.trim()) return item.description_override
   if (item.item_type === 'labor' && item.labor) return item.labor.description
   if (item.item_type === 'part' && item.part)
     return `${item.part.part_number} - ${item.part.description}`

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -380,6 +380,7 @@ export interface QuoteLineItem {
   part_id?: number;
   misc_id?: number;
   description?: string;
+  description_override?: string;  // Per-quote display description override (issue #178)
   quantity: number;  // Qty Ordered
   unit_price?: number;
   qty_pending: number;  // Remaining to fulfill
@@ -856,6 +857,7 @@ export interface StagedEdit {
   quantity?: number;
   unit_price?: number;
   description?: string;
+  description_override?: string;  // Per-quote display description override (issue #178)
   markup_percent?: number;
   base_cost?: number;  // Unit cost override
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -825,6 +825,7 @@ export interface StagedLineItemChange {
   part_id?: number;
   misc_id?: number;
   description?: string;
+  description_override?: string;  // Per-quote display description override (issue #178)
   quantity?: number;
   unit_price?: number;
   is_pms?: boolean;


### PR DESCRIPTION
Closes #178 · stacked on #182 (base `fix/parking-travel-labour-hours`)

Adds a per-quote **`description_override`** so a line's printed description can be tailored on a quote without changing the inventory item. New **nullable** column on `quote_line_items` + `quote_line_item_snapshots` (Alembic `025`, **additive, no backfill → safe on live data**; migrated quotes keep their Vision description and render exactly as before — override only on an explicit edit). Fully versioned: applied in `commit_edits`/`update_quote_line`, captured in all 3 snapshot-creation sites, restored on revert, carried on clone. Editor and PDF both prefer it when set.

**Test:** edit a line's description → commit → shows on screen **and** the PDF, inventory item unchanged; open a migrated quote → unchanged; revert a version → the override restores.

Out of scope: invoice surfaces resolve descriptions separately and may still show the catalog label.
