### PR TITLE
feat: add product code to labour (#179)

### DIFF
--- a/backend/alembic/versions/20260728_026_add_labor_product_code.py
+++ b/backend/alembic/versions/20260728_026_add_labor_product_code.py
@@ -1,0 +1,34 @@
+"""Add product_code to labor (issue #179)
+
+Adds a nullable ``product_code`` column to the ``labor`` table, mirroring
+``parts.part_number``. Additive and nullable: existing labour rows are
+unaffected (they simply have no code until one is entered).
+
+Note: revision id kept short - alembic_version.version_num is VARCHAR(32).
+
+Revision ID: 026_labor_product_code
+Revises: 025_line_desc_override
+Create Date: 2026-07-28
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '026_labor_product_code'
+down_revision = '025_line_desc_override'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute(sa.text(
+        "ALTER TABLE labor ADD COLUMN IF NOT EXISTS product_code VARCHAR"
+    ))
+
+
+def downgrade():
+    conn = op.get_bind()
+    conn.execute(sa.text(
+        "ALTER TABLE labor DROP COLUMN IF EXISTS product_code"
+    ))

--- a/backend/models.py
+++ b/backend/models.py
@@ -110,6 +110,7 @@ class Labor(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     description = Column(String, nullable=False)
+    product_code = Column(String, nullable=True)  # Product code, mirrors Part.part_number (issue #179)
     hours = Column(Float, nullable=False, default=1)
     rate = Column(Float, nullable=False)
     markup_percent = Column(Float, default=50.0)

--- a/backend/routes/labor.py
+++ b/backend/routes/labor.py
@@ -33,6 +33,7 @@ def create_labor(labor_data: LaborCreate, db: Session = Depends(get_db)):
 
     db_labor = Labor(
         description=labor_data.description,
+        product_code=labor_data.product_code,
         hours=labor_data.hours,
         rate=labor_data.rate,
         markup_percent=formatted_markup,
@@ -56,6 +57,8 @@ def update_labor(labor_id: int, labor_data: LaborUpdate, db: Session = Depends(g
     # Update fields if provided
     if labor_data.description is not None:
         db_labor.description = labor_data.description
+    if labor_data.product_code is not None:
+        db_labor.product_code = labor_data.product_code
     if labor_data.hours is not None:
         db_labor.hours = labor_data.hours
     if labor_data.rate is not None:

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -230,6 +230,7 @@ class Part(PartBase):
 # ===== Labor Schemas =====
 class LaborBase(BaseModel):
     description: str
+    product_code: Optional[str] = None  # Product code, mirrors Part.part_number (issue #179)
     hours: float = 1
     rate: float
     markup_percent: float = 50.0
@@ -252,6 +253,7 @@ class LaborCreate(LaborBase):
 
 class LaborUpdate(BaseModel):
     description: Optional[str] = None
+    product_code: Optional[str] = None  # Product code, mirrors Part.part_number (issue #179)
     hours: Optional[float] = None
     rate: Optional[float] = None
     markup_percent: Optional[float] = None

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -397,7 +397,8 @@ function App() {
           const term = inventorySearchTerm.toLowerCase()
           if (!term) return true
           return (
-            labor.description.toLowerCase().includes(term)
+            labor.description.toLowerCase().includes(term) ||
+            (labor.product_code?.toLowerCase().includes(term) ?? false)
           )
         })
 
@@ -537,10 +538,11 @@ function App() {
                       items={filteredLaborItems}
                       rowHeight={52}
                       height="calc(100vh - 360px)"
-                      gridCols="grid-cols-[3fr_1fr_1fr_1fr_1fr_minmax(110px,auto)]"
+                      gridCols="grid-cols-[2.5fr_1fr_1fr_1fr_1fr_1fr_minmax(110px,auto)]"
                       header={
                         <>
                           <div className={headerCellClass}>Labour Description</div>
+                          <div className={headerCellClass}>Product Code</div>
                           <div className={`${headerCellClass} text-right`}>Hours</div>
                           <div className={`${headerCellClass} text-right`}>Rate</div>
                           <div className={`${headerCellClass} text-right`}>Markup</div>
@@ -555,6 +557,7 @@ function App() {
                       renderRow={(labor) => (
                         <>
                           <div className={`${cellClass} font-medium truncate`}>{labor.description}</div>
+                          <div className={`${cellClass} text-muted-foreground truncate`}>{labor.product_code || "—"}</div>
                           <div className={`${cellClass} text-muted-foreground justify-end`}>{labor.hours}</div>
                           <div className={`${cellClass} text-muted-foreground justify-end`}>{formatCurrency(labor.rate)}/hr</div>
                           <div className={`${cellClass} text-muted-foreground justify-end`}>{labor.markup_percent}%</div>

--- a/frontend/src/components/forms/LaborForm.tsx
+++ b/frontend/src/components/forms/LaborForm.tsx
@@ -19,6 +19,7 @@ export function LaborForm({ labor, onSuccess, onCancel }: LaborFormProps) {
 
   // Form state - use strings for number fields to allow empty while editing
   const [description, setDescription] = useState("")
+  const [productCode, setProductCode] = useState("")
   const [hours, setHours] = useState("")
   const [rate, setRate] = useState("")
   // New labour defaults to 50% markup; edit mode loads the item's real value below.
@@ -28,6 +29,7 @@ export function LaborForm({ labor, onSuccess, onCancel }: LaborFormProps) {
   useEffect(() => {
     if (labor) {
       setDescription(labor.description)
+      setProductCode(labor.product_code || "")
       setHours(labor.hours.toString())
       setRate(labor.rate.toString())
       setMarkupPercent(labor.markup_percent.toString())
@@ -61,6 +63,7 @@ export function LaborForm({ labor, onSuccess, onCancel }: LaborFormProps) {
 
     const laborData: LaborCreate = {
       description,
+      product_code: productCode.trim() || undefined,
       hours: hoursValue,
       rate: parseFloat(rate) || 0,
       markup_percent: parseFloat(markupPercent) || 0,
@@ -97,6 +100,16 @@ export function LaborForm({ labor, onSuccess, onCancel }: LaborFormProps) {
           onChange={(e) => setDescription(e.target.value)}
           placeholder="e.g., Install HVAC System"
           required
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="product_code">Product Code</Label>
+        <Input
+          id="product_code"
+          value={productCode}
+          onChange={(e) => setProductCode(e.target.value)}
+          placeholder="e.g., LAB-001 (optional)"
         />
       </div>
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -146,6 +146,7 @@ export interface CostCodeUpdate {
 export interface Labor {
   id: number;
   description: string;
+  product_code?: string;  // Product code, mirrors Part.part_number (issue #179)
   hours: number;
   rate: number;
   markup_percent: number;
@@ -154,6 +155,7 @@ export interface Labor {
 
 export interface LaborCreate {
   description: string;
+  product_code?: string;  // Product code, mirrors Part.part_number (issue #179)
   hours: number;
   rate: number;
   markup_percent: number;


### PR DESCRIPTION
Closes #179 · stacked on #183 (base `feat/quote-line-description-edit`)

Gives labour a **`product_code`** (mirrors `Part.part_number`): new **nullable** column (Alembic `026`, **additive → safe on live data**; existing labour shows "—" until set), a form field, a list column, searchable by code, and persisted by the create/update endpoints. Not unique for now.

**Test:** add/edit a labour item with a code → it appears in the labour list and search filters to it; existing labour shows "—".

Notes: importing Vision's `chrProductName` into this field is deferred (needs a real Vision export to confirm the column). Alembic `026` chains `025`→`024`; confirm no other migration PR landed first before merge (avoid multiple heads).
