### PR TITLE
feat: per-line labour hours column (#181)

### DIFF
--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -2176,6 +2176,7 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
               <TableRow>
                 <TableHead>Description</TableHead>
                 <TableHead className="text-right">Qty Ordered</TableHead>
+                {type === "labor" && <TableHead className="text-right">Hours</TableHead>}
                 <TableHead className="text-right">Qty Pending</TableHead>
                 {/* Qty to Fulfill column - only in invoicing mode */}
                 {editorMode === "invoicing" && (
@@ -2281,6 +2282,12 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
                       )}
                     </TableCell>
 
+                    {/* Hours Column — labour only (issue #181): line hours = catalog hours × qty */}
+                    {type === "labor" && (
+                      <TableCell className="text-right text-muted-foreground">
+                        {item.labor ? parseFloat((item.labor.hours * (editedItem?.quantity ?? item.quantity)).toFixed(2)) : "—"}
+                      </TableCell>
+                    )}
                     {/* Qty Pending Column - now read-only display */}
                     <TableCell className="text-right">
                       {item.qty_pending}
@@ -2620,6 +2627,12 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
                         <span className="text-green-700 dark:text-green-300 font-medium">{add.quantity}</span>
                       )}
                     </TableCell>
+                    {/* Hours — labour only (issue #181) */}
+                    {type === "labor" && (
+                      <TableCell className="text-right text-muted-foreground">
+                        {add.labor ? parseFloat((add.labor.hours * add.quantity).toFixed(2)) : "—"}
+                      </TableCell>
+                    )}
                     {/* Qty Pending */}
                     <TableCell className="text-right text-muted-foreground">-</TableCell>
                     {/* Qty to Fulfill - only in invoicing mode */}
@@ -2717,6 +2730,12 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
                   <TableCell className="font-semibold">Section Total</TableCell>
                   {/* Qty Ordered */}
                   <TableCell className="text-right font-semibold">{calculateSectionTotals(items, useEffectivePricing).qtyOrdered}</TableCell>
+                  {/* Hours total — labour only (issue #181) */}
+                  {type === "labor" && (
+                    <TableCell className="text-right font-semibold">
+                      {parseFloat(items.reduce((s, i) => s + (i.labor ? i.labor.hours * i.quantity : 0), 0).toFixed(2))}
+                    </TableCell>
+                  )}
                   {/* Qty Pending */}
                   <TableCell className="text-right font-semibold">{calculateSectionTotals(items, useEffectivePricing).qtyPending}</TableCell>
                   {/* Qty to Fulfill - only in invoicing mode */}
@@ -2781,6 +2800,8 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
                     </TableCell>
                     {/* Qty Ordered */}
                     <TableCell></TableCell>
+                    {/* Hours — labour only (issue #181) */}
+                    {type === "labor" && <TableCell></TableCell>}
                     {/* Qty Pending */}
                     <TableCell></TableCell>
                     {/* Qty to Fulfill */}


### PR DESCRIPTION
Closes #181 · stacked on #184 (base `feat/labour-product-code`)

Adds a per-line **Hours** column (catalog hours × qty) + a section total to the quote's Labour section. **Frontend only (`QuoteEditor.tsx`) — no schema, display-only.** Added to every row/footer variant (existing rows, staged adds, section-total footer, invoice-staging footer) so columns stay aligned; Parts/Misc unchanged; labour with no catalog link shows "—".

**Test:** open a quote with labour → the Labour section shows a Hours column + section total (Parts/Misc don't); in Edit mode it reflects staged quantity edits live.

Note: display-only. An *editable* "actual hours" field would be a separate, larger change (a new `QuoteLineItem` column).
