### PR TITLE
fix: dedup duplicate travel-distance tiers + guard against recurrence

### DIFF
--- a/backend/alembic/versions/20260729_027_dedup_travel_rates.py
+++ b/backend/alembic/versions/20260729_027_dedup_travel_rates.py
@@ -1,0 +1,68 @@
+"""Dedup active system_rates and guard against re-duplication
+
+The ``system_rates`` table accumulated duplicate ACTIVE rows per tier (the
+Travel Distance dropdown was showing each tier 4x). This migration:
+
+1. Soft-deactivates the redundant rows: for each (rate_type, description) it
+   keeps the lowest-id active row and sets is_active=false on the rest. This is
+   a non-destructive UPDATE (no row is deleted). Nothing has a foreign key to
+   system_rates, and quote line items reference the underlying miscellaneous
+   row rather than the rate, so existing quotes are unaffected.
+2. Adds a PARTIAL unique index so at most one ACTIVE row can exist per
+   (rate_type, description) going forward. It is partial (WHERE is_active) so
+   the soft-delete workflow can still keep historical inactive rows that share
+   a description.
+
+Idempotent: safe on a DB with no duplicates (the UPDATE touches 0 rows) and the
+index is created IF NOT EXISTS.
+
+Note: revision id kept short - alembic_version.version_num is VARCHAR(32).
+
+Revision ID: 027_dedup_travel_rates
+Revises: 026_labor_product_code
+Create Date: 2026-07-29
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '027_dedup_travel_rates'
+down_revision = '026_labor_product_code'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    # 1. Keep the lowest-id active row per (rate_type, description); soft-deactivate the rest.
+    conn.execute(sa.text(
+        """
+        UPDATE system_rates
+        SET is_active = false
+        WHERE is_active = true
+          AND id NOT IN (
+              SELECT MIN(id)
+              FROM system_rates
+              WHERE is_active = true
+              GROUP BY rate_type, description
+          )
+        """
+    ))
+    # 2. Enforce at most one ACTIVE row per (rate_type, description) going forward.
+    conn.execute(sa.text(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_system_rates_active_rate_desc
+        ON system_rates (rate_type, description)
+        WHERE is_active = true
+        """
+    ))
+
+
+def downgrade():
+    conn = op.get_bind()
+    # Only the index is reversible. The soft-deactivation is intentionally NOT
+    # undone: there is no record of which rows were the original active
+    # duplicates, and reactivating them would restore the bug.
+    conn.execute(sa.text(
+        "DROP INDEX IF EXISTS uq_system_rates_active_rate_desc"
+    ))

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Float, ForeignKey, Enum, Table, DateTime, Boolean, UniqueConstraint, Text
+from sqlalchemy import Column, Integer, String, Float, ForeignKey, Enum, Table, DateTime, Boolean, UniqueConstraint, Text, Index, text
 from sqlalchemy.orm import relationship
 from datetime import datetime
 import enum
@@ -459,6 +459,19 @@ class QuoteSnapshot(Base):
 
 class SystemRate(Base):
     __tablename__ = "system_rates"
+
+    # At most one ACTIVE rate per (rate_type, description). Partial index so the
+    # soft-delete workflow (is_active=false) can keep historical rows with the
+    # same description. Existing duplicates are deduped first by migration 027.
+    __table_args__ = (
+        Index(
+            "uq_system_rates_active_rate_desc",
+            "rate_type",
+            "description",
+            unique=True,
+            postgresql_where=text("is_active = true"),
+        ),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     rate_type = Column(String, nullable=False)  # "parking" or "travel_distance"

--- a/backend/routes/system_rates.py
+++ b/backend/routes/system_rates.py
@@ -88,6 +88,20 @@ def get_travel_distance_tiers(response: Response, db: Session = Depends(get_db))
 @router.post("/travel-distance", response_model=SystemRateSchema)
 def create_travel_distance_tier(data: SystemRateCreate, db: Session = Depends(get_db)):
     """Add a new travel distance tier."""
+    # Idempotency guard: at most one ACTIVE tier per description (also enforced
+    # at the DB level by a partial unique index on system_rates). Return a clean
+    # 409 rather than letting the insert raise a raw IntegrityError.
+    existing = db.query(SystemRate).filter(
+        SystemRate.rate_type == "travel_distance",
+        SystemRate.description == data.description,
+        SystemRate.is_active == True,
+    ).first()
+    if existing:
+        raise HTTPException(
+            status_code=409,
+            detail="An active travel distance tier with this description already exists.",
+        )
+
     rate = SystemRate(
         rate_type="travel_distance",
         description=data.description,
@@ -116,6 +130,19 @@ def update_travel_distance_tier(rate_id: int, data: SystemRateUpdate, db: Sessio
         raise HTTPException(status_code=404, detail="Travel distance tier not found")
 
     if data.description is not None:
+        # Guard: block a rename that collides with another ACTIVE tier's
+        # description (the partial unique index would otherwise raise a raw 500).
+        conflict = db.query(SystemRate).filter(
+            SystemRate.rate_type == "travel_distance",
+            SystemRate.description == data.description,
+            SystemRate.is_active == True,
+            SystemRate.id != rate_id,
+        ).first()
+        if conflict:
+            raise HTTPException(
+                status_code=409,
+                detail="An active travel distance tier with this description already exists.",
+            )
         rate.description = data.description
     if data.unit_price is not None:
         rate.unit_price = data.unit_price

--- a/backend/routes/system_rates.py
+++ b/backend/routes/system_rates.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
 from typing import List
 
 from database import get_db
@@ -111,10 +112,20 @@ def create_travel_distance_tier(data: SystemRateCreate, db: Session = Depends(ge
         is_active=True,
     )
     db.add(rate)
-    db.flush()
-
-    _sync_misc_shadow(db, rate)
-    db.commit()
+    try:
+        db.flush()
+        _sync_misc_shadow(db, rate)
+        db.commit()
+    except IntegrityError:
+        # SettingsPage saves all tiers concurrently (Promise.all), so two requests
+        # can both pass the pre-check above and still collide on the partial unique
+        # index. Let the DB be the source of truth and return a clean 409 instead
+        # of the raw 500 this PR set out to eliminate.
+        db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail="An active travel distance tier with this description already exists.",
+        )
     db.refresh(rate)
     return rate
 
@@ -151,8 +162,17 @@ def update_travel_distance_tier(rate_id: int, data: SystemRateUpdate, db: Sessio
     if data.sort_order is not None:
         rate.sort_order = data.sort_order
 
-    _sync_misc_shadow(db, rate)
-    db.commit()
+    try:
+        _sync_misc_shadow(db, rate)
+        db.commit()
+    except IntegrityError:
+        # A concurrent rename can pass the conflict pre-check and still collide on
+        # the partial unique index; return a clean 409 instead of a raw 500.
+        db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail="An active travel distance tier with this description already exists.",
+        )
     db.refresh(rate)
     return rate
 

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -3,8 +3,13 @@ Database seeding for system items and company settings.
 Run this at application startup to ensure system items exist.
 """
 from sqlalchemy.orm import Session
-from sqlalchemy import inspect as sa_inspect
+from sqlalchemy import inspect as sa_inspect, text
 from models import Miscellaneous, CompanySettings, SystemRate
+
+# Advisory-lock key that serializes seed_system_items() across gunicorn workers
+# (2 workers, no --preload → concurrent seeds on cold start). Arbitrary constant;
+# nothing else in the app uses advisory locks.
+_SEED_LOCK_KEY = 20260729
 
 SYSTEM_MISC_ITEMS = [
     # Parking
@@ -74,7 +79,24 @@ def seed_system_items(db: Session) -> None:
     """
     Seed system miscellaneous items and company settings if they don't exist.
     Called at application startup.
+
+    Serializes across gunicorn workers with a Postgres advisory lock: without
+    --preload each worker imports main and runs this concurrently on cold start;
+    on a fresh DB that race duplicated the system items/rates (issue #186). Only
+    one worker holds the lock and seeds; the others block, then re-read and find
+    everything already present. The lock lives on a dedicated connection so it
+    spans the commits below and is released before that connection is pooled.
     """
+    with db.get_bind().connect() as lock_conn:
+        lock_conn.execute(text("SELECT pg_advisory_lock(:k)"), {"k": _SEED_LOCK_KEY})
+        try:
+            _seed_system_items_locked(db)
+        finally:
+            lock_conn.execute(text("SELECT pg_advisory_unlock(:k)"), {"k": _SEED_LOCK_KEY})
+
+
+def _seed_system_items_locked(db: Session) -> None:
+    """Do the actual seeding; the caller holds the advisory lock."""
     # Fast path: if the count matches what we expect to seed, nothing to do.
     # Avoids N filter().first() queries on every cold start (× every worker).
     expected_count = len(SYSTEM_MISC_ITEMS)

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -128,10 +128,19 @@ def seed_system_items(db: Session) -> None:
                 Miscellaneous.is_system_item == True
             ).all()
 
+            seen_rate_keys = set()
             for misc in misc_items:
                 mapping = rate_map.get(misc.description)
                 if mapping:
                     rate_type, sort_order = mapping
+                    # Skip duplicate misc system-items (e.g. a duplicated catalog
+                    # block) so we never create more than one active rate per
+                    # tier — keeps seed compatible with the partial unique index
+                    # on system_rates(rate_type, description) WHERE is_active.
+                    rate_key = (rate_type, misc.description)
+                    if rate_key in seen_rate_keys:
+                        continue
+                    seen_rate_keys.add(rate_key)
                     db.add(SystemRate(
                         rate_type=rate_type,
                         description=misc.description,


### PR DESCRIPTION
Closes #186 · stacked on #185 (base `feat/per-line-labour-hours`)

⚠️ **No CI until the stack merges and this retargets; do NOT merge before #182→#185.**

The Travel Distance dropdown listed each tier ~4× because `system_rates` held 28 active rows instead of 7 (real duplicate rows). Migration `027` soft-deactivates the redundant active rows (keeps the lowest id per `rate_type`+`description`) and adds a **partial unique index** (one active row per tier); the model declares the same index (so `alembic check` passes), and the create/update API returns **409** on a duplicate while the seed loop de-dupes — so it can't recur. **Non-destructive** (`is_active=false`, reversible; downgrade only drops the index). Existing quotes untouched — they reference `miscellaneous`, which this PR does not modify.

**Test** (runs first in CI post-retarget + on the Railway preview — **not executed anywhere yet, never against prod**): after `alembic upgrade head`, the Travel dropdown and Settings → Travel Distance list **7** tiers once each; adding a duplicate-named tier returns 409. Migration-Integrity CI exercises up→down→up.

Note: the duplicate `miscellaneous` rows are left in place (some may be referenced by quote lines — needs a reference check first) — tracked follow-up.
