### PR TITLE
feat(migration): Vision raw-staging tooling (Stage A + verify)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ CLAUDE.md
 
 # Audit / review artifacts (screenshots, findings docs) — durable value lives in GitHub issues, not in the repo
 testing/ux-review/
+
+# Migration planning docs — local working artifacts, not shipped in PRs
+docs/MIGRATION_PARITY.md
+docs/MIGRATION_PROPOSAL.md

--- a/backend/scripts/vision_migration/README.md
+++ b/backend/scripts/vision_migration/README.md
@@ -1,0 +1,61 @@
+# Vision → Velocity migration tooling (local, Windows-only)
+
+Local one-time cutover tooling. **Not** part of the deployed backend — it reads
+the legacy UC Vision Access (`.mdb`) backend and loads it into Postgres.
+
+See `docs/MIGRATION_PROPOSAL.md` for the full plan. This directory is **PKG 1**:
+Stage A raw staging + a load-verification harness.
+
+## What it does
+- **`stage`** — copies every Vision *user* table verbatim into an isolated
+  `vision_legacy` schema in Postgres (drop-and-recreate; safe to re-run).
+- **`verify`** — compares each table's source row count (Access) against the
+  staged count (Postgres) and reports mismatches.
+
+It writes **only** to the `vision_legacy` schema; it never touches Velocity's
+application tables.
+
+## Safety
+- Target DB is read from `MIGRATION_DATABASE_URL` (or `--database-url`) — a
+  **separate** variable from the app's `DATABASE_URL`, so it can't inherit a
+  prod-pointing shell.
+- `stage` refuses to run without `--i-understand-scratch-db`, and **hard-blocks**
+  any host containing `railway.internal` (production) — extend the denylist via
+  `MIGRATION_BLOCKED_HOSTS`.
+- **Never point this at production.** Use a local or throwaway/preview Postgres.
+
+## Setup (Windows)
+```powershell
+# 1. A scratch Postgres. Simplest: a local DB (nothing leaves your machine).
+#    e.g. create an empty database "vision_scratch" on localhost.
+
+# 2. A venv for the tooling (keep it separate from the backend venv).
+cd backend/scripts
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -r vision_migration/requirements.txt
+```
+
+## Run
+```powershell
+$env:MIGRATION_DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/vision_scratch"
+$env:MIGRATION_MDB          = "C:\path\to\Dev_UCVision5_BE(2).mdb"
+$env:MIGRATION_WORKGROUP    = "C:\Users\<you>\AppData\Roaming\Microsoft\Access\System.mdw"
+
+python -m vision_migration stage --i-understand-scratch-db
+python -m vision_migration verify
+```
+
+`verify` exits non-zero if any table's counts don't match.
+
+## Notes / known-fiddly bits
+- The Access read uses ADODB via `pywin32` with the proven workgroup-unlock
+  connection string; it works while Access has the file open (`Share Deny None`),
+  but keep Access **read-only** during a run.
+- Date/time and binary/OLE values are coerced from COM types on load
+  (see `stage_raw._coerce`). If an OLE/blob value can't be converted it is stored
+  NULL **and counted** — `stage` prints a WARNING listing the affected columns,
+  and `verify` compares per-column non-null counts, so any such loss shows up as a
+  MISMATCH rather than passing silently. (Full photo handling is a later spike.)
+- `verify` checks row counts **and** per-column non-null counts; it exits
+  non-zero on any mismatch.

--- a/backend/scripts/vision_migration/__init__.py
+++ b/backend/scripts/vision_migration/__init__.py
@@ -1,0 +1,16 @@
+"""UC Vision -> UC Velocity migration tooling (local, Windows-only).
+
+This package is *local one-time cutover tooling*, NOT part of the deployed
+backend. It reads the legacy UC Vision Access (.mdb) backend and loads it into
+Postgres. It is intentionally standalone: it does NOT import the FastAPI app or
+its ORM, and its dependencies live in this package's own requirements.txt so
+they never reach the Linux-deployed `backend/requirements.txt`.
+
+PKG 1 scope (this commit):
+  - Stage A "raw staging": copy every Vision user table verbatim into an
+    isolated `vision_legacy` Postgres schema (M4).
+  - A load-verification harness: prove staged row counts match the source.
+
+Later packages add Stage B (the idempotent legacy-keyed sync into Velocity's
+real tables) on top of this foundation.
+"""

--- a/backend/scripts/vision_migration/__main__.py
+++ b/backend/scripts/vision_migration/__main__.py
@@ -1,0 +1,64 @@
+"""CLI entry point.
+
+Run from `backend/scripts`:
+    python -m vision_migration stage  --mdb "<path.mdb>" --workgroup "<path.mdw>" --i-understand-scratch-db
+    python -m vision_migration verify --mdb "<path.mdb>" --workgroup "<path.mdw>"
+
+The target Postgres comes from --database-url or MIGRATION_DATABASE_URL.
+See README.md for full setup.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from . import config
+from . import stage_raw
+from . import verify_staging
+
+
+def _common_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--mdb", default=os.getenv("MIGRATION_MDB"),
+                   help="Path to the Vision .mdb (or set MIGRATION_MDB).")
+    p.add_argument("--workgroup", default=os.getenv("MIGRATION_WORKGROUP"),
+                   help="Path to the workgroup .mdw (or set MIGRATION_WORKGROUP).")
+    p.add_argument("--database-url", default=None,
+                   help="Target Postgres URL (or set MIGRATION_DATABASE_URL).")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="vision_migration")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_stage = sub.add_parser("stage", help="Raw-stage all Vision tables into vision_legacy.")
+    _common_args(p_stage)
+    p_stage.add_argument("--i-understand-scratch-db", action="store_true",
+                         help="Confirm the target is a throwaway/preview DB, not production.")
+
+    p_verify = sub.add_parser("verify", help="Compare source vs staged row counts.")
+    _common_args(p_verify)
+
+    args = parser.parse_args(argv)
+
+    try:
+        target = config.resolve_target_url(args.database_url)
+        if args.command == "stage":
+            host = config.assert_scratch_target(target, args.i_understand_scratch_db)
+            print(f"Target host: {host} (staging into schema '{config.STAGING_SCHEMA}')")
+            stage_raw.stage_all(args.mdb, args.workgroup, target)
+            print("Staging complete.")
+            return 0
+        if args.command == "verify":
+            # verify only reads; still refuse blocked hosts, but no confirm needed.
+            config.assert_scratch_target(target, confirmed=True)
+            ok = verify_staging.verify(args.mdb, args.workgroup, target)
+            return 0 if ok else 1
+    except config.MigrationConfigError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/vision_migration/config.py
+++ b/backend/scripts/vision_migration/config.py
@@ -1,0 +1,222 @@
+"""Shared configuration, connections, safety guard, and type mapping.
+
+Everything that both `stage_raw` and `verify_staging` need lives here so the two
+commands connect to the same places in the same way.
+
+Safety model (read this):
+  - The target Postgres is read from `MIGRATION_DATABASE_URL` (or --database-url),
+    a DISTINCT variable from the app's `DATABASE_URL`. This is deliberate: it means
+    the tooling can never accidentally inherit a shell that points at production.
+  - `assert_scratch_target()` refuses to run unless the caller explicitly confirms
+    the target is a throwaway/scratch DB, and it hard-blocks any host that looks
+    like production.
+  - Even so, staging writes ONLY into the `vision_legacy` schema and never touches
+    Velocity's application tables.
+"""
+from __future__ import annotations
+
+import os
+from urllib.parse import urlparse
+
+# The isolated schema that holds the verbatim Vision copy. Never the app tables.
+STAGING_SCHEMA = "vision_legacy"
+
+# Hosts we refuse to write to, ever. Extend via MIGRATION_BLOCKED_HOSTS (comma-sep).
+# Covers Railway's private host (`railway.internal`, unreachable off-Railway) AND
+# the reachable public endpoints (`rlwy.net` proxy, `railway.app`) so a prod URL
+# sitting in the shell can't slip through. The check runs against the WHOLE
+# connection string (see assert_scratch_target), so keyword-form DSNs are caught.
+_DEFAULT_BLOCKED_HOST_MARKERS = ("railway.internal", "rlwy.net", "railway.app")
+
+# Postgres truncates identifiers to 63 bytes; Access allows up to 64 chars.
+MAX_PG_IDENTIFIER_BYTES = 63
+
+
+class MigrationConfigError(RuntimeError):
+    """Raised for any misconfiguration or safety-guard violation."""
+
+
+# --------------------------------------------------------------------------- #
+# Vision (Access) connection
+# --------------------------------------------------------------------------- #
+
+def vision_connection_string(mdb_path: str, workgroup_path: str) -> str:
+    """Build the ACE OLEDB connection string that unlocks Vision's user-level
+    security via the workgroup (.mdw) file. This is the exact form proven to read
+    the ULS-protected backend as the Admin user with `Share Deny None` (so it can
+    read while Access has the file open).
+    """
+    if not mdb_path or not os.path.exists(mdb_path):
+        raise MigrationConfigError(f"Vision .mdb not found: {mdb_path!r}")
+    if not workgroup_path or not os.path.exists(workgroup_path):
+        raise MigrationConfigError(f"Workgroup .mdw not found: {workgroup_path!r}")
+    return (
+        "Provider=Microsoft.ACE.OLEDB.12.0;"
+        f"Data Source={mdb_path};"
+        f"Jet OLEDB:System Database={workgroup_path};"
+        "Mode=Share Deny None;"
+    )
+
+
+def open_vision(mdb_path: str, workgroup_path: str):
+    """Open an ADODB connection to the Vision backend (returns the COM object).
+
+    Uses pywin32's late-bound COM. Imported lazily so `--help` and unit imports
+    work on machines without pywin32 (e.g. Linux CI).
+    """
+    try:
+        import win32com.client  # type: ignore
+    except ImportError as exc:  # pragma: no cover - environment specific
+        raise MigrationConfigError(
+            "pywin32 is required to read Access. Install this package's "
+            "requirements: pip install -r requirements.txt (Windows only)."
+        ) from exc
+    conn = win32com.client.Dispatch("ADODB.Connection")
+    conn.Open(vision_connection_string(mdb_path, workgroup_path))
+    return conn
+
+
+# --------------------------------------------------------------------------- #
+# Postgres (target) connection + guard
+# --------------------------------------------------------------------------- #
+
+def resolve_target_url(cli_url: str | None) -> str:
+    """The target Postgres URL: --database-url wins, else MIGRATION_DATABASE_URL.
+
+    Intentionally does NOT fall back to the app's DATABASE_URL.
+    """
+    url = cli_url or os.getenv("MIGRATION_DATABASE_URL")
+    if not url:
+        raise MigrationConfigError(
+            "No target database. Pass --database-url or set MIGRATION_DATABASE_URL "
+            "to a SCRATCH/preview Postgres (never production)."
+        )
+    return url
+
+
+def _blocked_markers() -> tuple[str, ...]:
+    extra = os.getenv("MIGRATION_BLOCKED_HOSTS", "")
+    extras = tuple(m.strip() for m in extra.split(",") if m.strip())
+    return _DEFAULT_BLOCKED_HOST_MARKERS + extras
+
+
+def _extract_host(url: str) -> str | None:
+    """Best-effort host from either a URL DSN or a libpq keyword/value DSN.
+
+    psycopg2 accepts BOTH `postgresql://user:pw@host/db` and the keyword form
+    `host=... dbname=... user=...`. urlparse only understands the first, so we
+    parse the keyword form ourselves -- otherwise a keyword-form prod DSN would
+    slip past a hostname-only guard.
+    """
+    parsed = urlparse(url)
+    if parsed.hostname:
+        return parsed.hostname
+    for token in url.replace("\t", " ").split():
+        if token.lower().startswith("host="):
+            return token[len("host="):].strip("'\"") or None
+    return None
+
+
+def assert_scratch_target(url: str, confirmed: bool) -> str:
+    """Refuse to proceed unless the target is an explicitly-confirmed non-prod DB.
+
+    Fails CLOSED: the blocked-marker check runs against the whole connection
+    string (so URL *and* keyword-form DSNs are covered), and an indeterminate
+    host is refused rather than assumed safe. Returns the host for logging.
+    """
+    raw = url.lower()
+    for marker in _blocked_markers():
+        if marker and marker.lower() in raw:
+            raise MigrationConfigError(
+                f"Refusing to run: connection string matches blocked marker "
+                f"{marker!r}. This looks like production."
+            )
+    host = (_extract_host(url) or "").lower()
+    if not host:
+        raise MigrationConfigError(
+            "Could not determine the target host from the connection string. "
+            "Refusing (fail-closed) -- use an explicit host, e.g. "
+            "postgresql://postgres:postgres@localhost:5432/vision_scratch."
+        )
+    if not confirmed:
+        raise MigrationConfigError(
+            f"Target host is {host!r}. Re-run with --i-understand-scratch-db to confirm "
+            "this is a throwaway/preview database, not production."
+        )
+    return host
+
+
+def check_identifier_length(name: str, kind: str = "identifier") -> None:
+    """Fail loud if a name exceeds Postgres' 63-byte identifier limit.
+
+    Access permits up to 64-char names; Postgres would silently truncate to 63,
+    which could collide two names or break the verify round-trip. Naming the
+    offender is far better than a silent truncation.
+    """
+    if len(name.encode("utf-8")) > MAX_PG_IDENTIFIER_BYTES:
+        raise MigrationConfigError(
+            f"{kind} {name!r} exceeds Postgres' {MAX_PG_IDENTIFIER_BYTES}-byte "
+            "identifier limit; staging would truncate/collide. Add a name mapping."
+        )
+
+
+def open_postgres(url: str):
+    """Open a psycopg2 connection. Imported lazily for the same reason as pywin32."""
+    try:
+        import psycopg2  # type: ignore
+    except ImportError as exc:  # pragma: no cover - environment specific
+        raise MigrationConfigError(
+            "psycopg2 is required. Install this package's requirements: "
+            "pip install -r requirements.txt"
+        ) from exc
+    return psycopg2.connect(url)
+
+
+# --------------------------------------------------------------------------- #
+# Access (ADO DataTypeEnum) -> Postgres type mapping
+# --------------------------------------------------------------------------- #
+# ADO DataTypeEnum values we expect from Vision. Full list is large; we map the
+# ones Vision actually uses and fall back to TEXT for anything unexpected.
+_ADO = {
+    2: "adSmallInt", 3: "adInteger", 4: "adSingle", 5: "adDouble",
+    6: "adCurrency", 7: "adDate", 11: "adBoolean", 14: "adDecimal",
+    16: "adTinyInt", 17: "adUnsignedTinyInt", 18: "adUnsignedSmallInt",
+    19: "adUnsignedInt", 20: "adBigInt", 72: "adGUID", 128: "adBinary",
+    129: "adChar", 130: "adWChar", 131: "adNumeric", 133: "adDBDate",
+    135: "adDBTimeStamp", 200: "adVarChar", 201: "adLongVarChar",
+    202: "adVarWChar", 203: "adLongVarWChar", 204: "adVarBinary",
+    205: "adLongVarBinary",
+}
+
+# Which ADO types land in a Postgres BYTEA column (need psycopg2.Binary wrapping).
+BINARY_ADO_TYPES = {128, 204, 205}
+# Which ADO types are date/time (need pywintypes->datetime coercion on load).
+DATETIME_ADO_TYPES = {7, 133, 135}
+
+
+def access_type_to_pg(ado_type: int) -> str:
+    """Map an ADO field type to a Postgres column type for the staging mirror.
+
+    Deliberately generous: staging is a faithful copy, not a normalized schema,
+    so we prefer wide, lossless types (TEXT, DOUBLE PRECISION, NUMERIC, BYTEA).
+    """
+    if ado_type in (2, 3, 16, 17, 18, 19):
+        return "INTEGER"
+    if ado_type == 20:
+        return "BIGINT"
+    if ado_type in (4, 5):
+        return "DOUBLE PRECISION"
+    if ado_type in (6, 14, 131):
+        return "NUMERIC"
+    if ado_type == 11:
+        return "BOOLEAN"
+    if ado_type in DATETIME_ADO_TYPES:
+        return "TIMESTAMP"
+    if ado_type in BINARY_ADO_TYPES:
+        return "BYTEA"
+    # adChar/adWChar/adVarChar/adLongVar*/adGUID and anything unmapped -> TEXT
+    return "TEXT"
+
+
+def ado_type_name(ado_type: int) -> str:
+    return _ADO.get(ado_type, f"ado({ado_type})")

--- a/backend/scripts/vision_migration/requirements.txt
+++ b/backend/scripts/vision_migration/requirements.txt
@@ -1,0 +1,5 @@
+# LOCAL-ONLY migration tooling dependencies (Windows).
+# Do NOT merge these into backend/requirements.txt: pywin32 is Windows-only and
+# this tooling never runs on the Linux-deployed backend.
+pywin32==306
+psycopg2-binary==2.9.9

--- a/backend/scripts/vision_migration/stage_raw.py
+++ b/backend/scripts/vision_migration/stage_raw.py
@@ -1,0 +1,232 @@
+"""Stage A - raw staging: copy every Vision user table verbatim into Postgres.
+
+For each Vision user table we:
+  1. open a `SELECT * FROM [table]` recordset (gives us field names + ADO types),
+  2. CREATE the matching table in the `vision_legacy` schema (drop-and-recreate,
+     so re-running is idempotent for this isolated schema only),
+  3. stream the rows across in batches via ADODB `GetRows` -> psycopg2
+     `execute_values`.
+
+Nothing here touches Velocity's application tables. The only DDL is against the
+`vision_legacy` schema.
+
+Fidelity: values that cannot be faithfully converted (e.g. an OLE blob pywin32
+won't turn into bytes) are NOT silently dropped -- they are counted per column
+and reported as a WARNING at the end, and `verify_staging` independently compares
+per-column non-null counts so any such loss shows up as a MISMATCH.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+from typing import Any
+
+from . import config
+
+# ADODB constants
+_AD_OPEN_FORWARD_ONLY = 0
+_AD_LOCK_READ_ONLY = 1
+_AD_CMD_TEXT = 1
+_ROW_BATCH = 2000  # rows fetched per GetRows call
+_INSERT_PAGE_SIZE = 200  # rows per INSERT statement (bounds SQL size for wide/text rows)
+
+
+class _CoercionError(Exception):
+    """A cell value could not be faithfully converted for Postgres."""
+
+
+def _list_user_tables(vision_conn) -> list[str]:
+    """Return Vision's *user* table names (excludes MSys* system + ACCESS tables).
+
+    Uses ADOX, whose Table.Type is 'TABLE' for user tables and 'SYSTEM TABLE' /
+    'ACCESS TABLE' for engine internals. We keep EVERYTHING with Type 'TABLE' --
+    including report-scratch/test/switchboard tables -- because the rule is
+    "keep all": staging loses nothing.
+    """
+    import win32com.client  # type: ignore
+
+    cat = win32com.client.Dispatch("ADOX.Catalog")
+    cat.ActiveConnection = vision_conn
+    names = [t.Name for t in cat.Tables if t.Type == "TABLE"]
+    # NB: we deliberately do NOT set cat.ActiveConnection = None -- pywin32's
+    # late-bound COM raises on assigning None. The catalog releases its hold when
+    # it goes out of scope here; the shared `vision_conn` stays open for reuse.
+    return sorted(names)
+
+
+def _field_defs(recordset) -> list[tuple[str, int]]:
+    """(name, ado_type) for each field of an open recordset, in ordinal order."""
+    return [(f.Name, int(f.Type)) for f in recordset.Fields]
+
+
+def _coerce(value: Any, ado_type: int):
+    """Convert one ADODB value into something psycopg2 can bind.
+
+    - NULLs pass through.
+    - Date/time comes back as a pywintypes time; rebuild a plain datetime.
+    - Binary/OLE is wrapped with psycopg2.Binary.
+    - Everything else (str / int / float / Decimal / bool) binds directly.
+
+    Raises `_CoercionError` if a date or binary value cannot be converted, so the
+    caller can count it and store NULL *visibly* rather than corrupting silently.
+    """
+    if value is None:
+        return None
+    if ado_type in config.DATETIME_ADO_TYPES:
+        try:
+            return _dt.datetime(
+                value.year, value.month, value.day,
+                value.hour, value.minute, value.second,
+            )
+        except Exception as exc:
+            raise _CoercionError(f"date coercion failed: {exc}") from exc
+    if ado_type in config.BINARY_ADO_TYPES:
+        import psycopg2  # type: ignore
+        try:
+            return psycopg2.Binary(bytes(value))
+        except Exception as exc:
+            raise _CoercionError(f"binary coercion failed: {exc}") from exc
+    return value
+
+
+def _create_staging_table(pg_cur, table: str, fields: list[tuple[str, int]]) -> None:
+    """DROP + CREATE the staging mirror. Identifiers are quoted safely via
+    psycopg2.sql (handles spaces / & / / / - and any embedded quote), and every
+    name is length-checked so a >63-byte name fails loud instead of truncating.
+    """
+    from psycopg2 import sql  # type: ignore
+
+    config.check_identifier_length(table, "table name")
+    col_defs = []
+    for name, ado_type in fields:
+        config.check_identifier_length(name, f"column name in {table!r}")
+        col_defs.append(
+            sql.SQL("{} {}").format(
+                sql.Identifier(name), sql.SQL(config.access_type_to_pg(ado_type))
+            )
+        )
+    ident = sql.Identifier(config.STAGING_SCHEMA, table)
+    pg_cur.execute(sql.SQL("DROP TABLE IF EXISTS {} CASCADE").format(ident))
+    pg_cur.execute(sql.SQL("CREATE TABLE {} ({})").format(ident, sql.SQL(", ").join(col_defs)))
+
+
+def _load_rows(pg_cur, table: str, fields: list[tuple[str, int]], recordset):
+    """Stream the recordset into the staging table.
+
+    Returns (rows_loaded, {column: coercion_failure_count}).
+    """
+    from psycopg2 import sql  # type: ignore
+    from psycopg2.extras import execute_values  # type: ignore
+
+    names = [name for name, _ in fields]
+    ado_types = [ado for _, ado in fields]
+    target = sql.Identifier(config.STAGING_SCHEMA, table)
+    col_idents = sql.SQL(", ").join(sql.Identifier(n) for n in names)
+
+    # Tables with binary/OLE columns insert via executemany so each blob is sent
+    # as a bound parameter, not inlined into one huge SQL string (which overruns
+    # libpq's buffer). Blob-free tables use the faster execute_values path.
+    has_binary = any(a in config.BINARY_ADO_TYPES for a in ado_types)
+    if has_binary:
+        placeholders = sql.SQL(", ").join([sql.Placeholder()] * len(names))
+        insert_sql = sql.SQL("INSERT INTO {} ({}) VALUES ({})").format(
+            target, col_idents, placeholders
+        ).as_string(pg_cur)
+    else:
+        insert_sql = sql.SQL("INSERT INTO {} ({}) VALUES %s").format(
+            target, col_idents
+        ).as_string(pg_cur)
+
+    loaded = 0
+    fail_counts: dict[str, int] = {}
+    if recordset.EOF:  # empty table
+        return 0, fail_counts
+
+    while True:
+        # GetRows returns a COLUMN-major 2D tuple: block[col][row].
+        block = recordset.GetRows(_ROW_BATCH)
+        if not block or len(block) == 0 or len(block[0]) == 0:
+            break
+        rows = []
+        for row in zip(*block):  # transpose to row-major
+            out = []
+            for c, cell in enumerate(row):
+                try:
+                    out.append(_coerce(cell, ado_types[c]))
+                except _CoercionError:
+                    out.append(None)
+                    fail_counts[names[c]] = fail_counts.get(names[c], 0) + 1
+            rows.append(tuple(out))
+        if has_binary:
+            pg_cur.executemany(insert_sql, rows)
+        else:
+            execute_values(pg_cur, insert_sql, rows, page_size=_INSERT_PAGE_SIZE)
+        loaded += len(rows)
+        if recordset.EOF:
+            break
+    return loaded, fail_counts
+
+
+def stage_all(mdb_path: str, workgroup_path: str, target_url: str) -> dict[str, int]:
+    """Stage every Vision user table into `vision_legacy`. Returns {table: rows}.
+
+    The whole load runs in ONE Postgres transaction so a failure leaves no
+    half-populated schema.
+    """
+    from psycopg2 import sql  # type: ignore
+
+    vision = config.open_vision(mdb_path, workgroup_path)
+    pg = config.open_postgres(target_url)
+    results: dict[str, int] = {}
+    issues: dict[str, dict[str, int]] = {}  # table -> {column: failure_count}
+    try:
+        tables = _list_user_tables(vision)
+        print(f"Found {len(tables)} Vision user tables to stage.")
+        with pg:  # commit on success, rollback on exception
+            with pg.cursor() as cur:
+                cur.execute(
+                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
+                        sql.Identifier(config.STAGING_SCHEMA)
+                    )
+                )
+                for i, table in enumerate(tables, start=1):
+                    rs = None
+                    try:
+                        rs = _open_table(vision, table)
+                        fields = _field_defs(rs)
+                        _create_staging_table(cur, table, fields)
+                        n, fails = _load_rows(cur, table, fields, rs)
+                    finally:
+                        if rs is not None and rs.State:
+                            rs.Close()
+                    results[table] = n
+                    if fails:
+                        issues[table] = fails
+                    print(f"  [{i:>2}/{len(tables)}] {table}: {n} rows")
+    finally:
+        pg.close()
+        vision.Close()
+    _report_issues(issues)
+    return results
+
+
+def _report_issues(issues: dict[str, dict[str, int]]) -> None:
+    if not issues:
+        return
+    print("\n*** WARNING: some cell values could not be copied faithfully "
+          "(stored NULL). This is NOT a clean verbatim copy: ***")
+    for table, cols in issues.items():
+        for col, n in cols.items():
+            print(f"    {table}.{col}: {n} value(s) failed coercion -> NULL")
+    print("    Investigate these columns; `verify` will also flag them.\n")
+
+
+def _open_table(vision_conn, table: str):
+    """Open a read-only forward-only recordset over one table."""
+    import win32com.client  # type: ignore
+
+    rs = win32com.client.Dispatch("ADODB.Recordset")
+    # Bracket-quote the source name: Vision has tables like `tblShip/Transport`
+    # and `Name AutoCorrect Save Failures` that need quoting.
+    rs.Open(f"SELECT * FROM [{table}]", vision_conn,
+            _AD_OPEN_FORWARD_ONLY, _AD_LOCK_READ_ONLY, _AD_CMD_TEXT)
+    return rs

--- a/backend/scripts/vision_migration/verify_staging.py
+++ b/backend/scripts/vision_migration/verify_staging.py
@@ -1,0 +1,129 @@
+"""Load-verification harness: prove the raw staging copied faithfully.
+
+For every staged table it compares, between Access and `vision_legacy`:
+  - the total row count, AND
+  - the per-column NON-NULL count.
+
+Row counts alone can't catch content loss (a value coerced to NULL, or a blob
+that failed to copy, doesn't change COUNT(*)). Comparing per-column non-null
+counts does: if staging dropped a cell to NULL, that column's non-null count
+falls below the source and the table is flagged MISMATCH.
+
+The full Vision<->Velocity parity diff (which needs the Stage-B sync) is added in
+a later package but builds on the same idea: compare the two sides that now live
+in one database.
+"""
+from __future__ import annotations
+
+from . import config
+
+_AD_OPEN_FORWARD_ONLY = 0
+_AD_LOCK_READ_ONLY = 1
+_AD_CMD_TEXT = 1
+
+
+def _staged_tables(pg_cur) -> list[str]:
+    pg_cur.execute(
+        "SELECT table_name FROM information_schema.tables "
+        "WHERE table_schema = %s ORDER BY table_name;",
+        (config.STAGING_SCHEMA,),
+    )
+    return [r[0] for r in pg_cur.fetchall()]
+
+
+def _staged_columns(pg_cur, table: str) -> list[str]:
+    pg_cur.execute(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_schema = %s AND table_name = %s ORDER BY ordinal_position;",
+        (config.STAGING_SCHEMA, table),
+    )
+    return [r[0] for r in pg_cur.fetchall()]
+
+
+def _staged_counts(pg_cur, table: str, columns: list[str]) -> tuple[int, dict[str, int]]:
+    """Total rows + non-null count per column, in one query."""
+    from psycopg2 import sql  # type: ignore
+
+    selects = [sql.SQL("COUNT(*)")]
+    selects += [sql.SQL("COUNT({})").format(sql.Identifier(c)) for c in columns]
+    query = sql.SQL("SELECT {} FROM {}").format(
+        sql.SQL(", ").join(selects),
+        sql.Identifier(config.STAGING_SCHEMA, table),
+    )
+    pg_cur.execute(query)
+    row = pg_cur.fetchone()
+    return int(row[0]), {c: int(row[i + 1]) for i, c in enumerate(columns)}
+
+
+def _vision_counts(vision_conn, table: str, columns: list[str]) -> tuple[int, dict[str, int], bool]:
+    """Total rows + non-null count per column from Access.
+
+    Returns (total, {col: non_null}, columns_checked). Falls back to total-only
+    (columns_checked=False) if Access rejects a per-column COUNT (e.g. on some OLE
+    column type) -- so we never crash the whole verify over one odd column.
+    """
+    import win32com.client  # type: ignore
+
+    def run(query: str, ncols: int):
+        rs = win32com.client.Dispatch("ADODB.Recordset")
+        rs.Open(query, vision_conn, _AD_OPEN_FORWARD_ONLY, _AD_LOCK_READ_ONLY, _AD_CMD_TEXT)
+        try:
+            return [rs.Fields.Item(i).Value for i in range(ncols)]
+        finally:
+            rs.Close()
+
+    if columns:
+        cols_sql = ", ".join(f"COUNT([{c}])" for c in columns)
+        try:
+            vals = run(f"SELECT COUNT(*), {cols_sql} FROM [{table}]", len(columns) + 1)
+            return int(vals[0]), {c: int(vals[i + 1]) for i, c in enumerate(columns)}, True
+        except Exception:
+            pass  # fall through to total-only
+    vals = run(f"SELECT COUNT(*) FROM [{table}]", 1)
+    return int(vals[0]), {}, False
+
+
+def verify(mdb_path: str, workgroup_path: str, target_url: str) -> bool:
+    """Compare source vs staged (rows + per-column non-null). Returns True if all match."""
+    vision = config.open_vision(mdb_path, workgroup_path)
+    pg = config.open_postgres(target_url)
+    ok = True
+    try:
+        with pg.cursor() as cur:
+            staged = _staged_tables(cur)
+            if not staged:
+                print(f"No tables found in schema '{config.STAGING_SCHEMA}'. "
+                      "Run `stage` first.")
+                return False
+            print(f"{'table':40} {'vision':>10} {'staged':>10}  status")
+            print("-" * 74)
+            for table in staged:
+                columns = _staged_columns(cur, table)
+                s_total, s_cols = _staged_counts(cur, table, columns)
+                v_total, v_cols, cols_checked = _vision_counts(vision, table, columns)
+
+                row_match = s_total == v_total
+                col_mismatches = (
+                    [c for c in columns if s_cols.get(c) != v_cols.get(c)]
+                    if cols_checked else []
+                )
+                match = row_match and not col_mismatches
+                ok = ok and match
+
+                status = "OK" if match else "MISMATCH"
+                detail = ""
+                if not row_match:
+                    detail = f"  rows {v_total}->{s_total}"
+                elif col_mismatches:
+                    shown = ", ".join(col_mismatches[:5])
+                    more = "..." if len(col_mismatches) > 5 else ""
+                    detail = f"  non-null cols differ: {shown}{more}"
+                if not cols_checked:
+                    detail += "  (col-level check skipped)"
+                print(f"{table:40} {v_total:>10} {s_total:>10}  {status}{detail}")
+    finally:
+        pg.close()
+        vision.Close()
+    print("-" * 74)
+    print("ALL TABLES MATCH" if ok else "MISMATCHES FOUND (see above)")
+    return ok


### PR DESCRIPTION
Local, Windows-only migration tooling (not deployed). Reads the legacy UC Vision Access (`.mdb`) backend and copies all 69 tables verbatim into an isolated `vision_legacy` Postgres schema, plus a `verify` command that checks the copy is faithful. Foundation for the Vision→Velocity migration.

**Safe:** writes only to `vision_legacy` (never app tables); reads `MIGRATION_DATABASE_URL` (a separate var from the app's); refuses without `--i-understand-scratch-db` and blocks prod hosts. No app/model/Alembic changes → no CI impact.

**Test** (local/scratch Postgres — never prod):
```
cd backend/scripts && py -3.12 -m venv .venv && .\.venv\Scripts\Activate.ps1
pip install -r vision_migration/requirements.txt
$env:MIGRATION_DATABASE_URL="postgresql://postgres@localhost:5433/postgres"
$env:MIGRATION_MDB="<path .mdb>"; $env:MIGRATION_WORKGROUP="<path System.mdw>"
python -m vision_migration stage --i-understand-scratch-db
python -m vision_migration verify   # expect: ALL TABLES MATCH
```

Validated on Postgres 15.8: all 69 tables staged; verify ALL MATCH (rows + per-column non-null); real `chrStatus` intact (3,586 open of 8,342); OLE images preserved.
