### PR TITLE
feat(migration): Vision->Velocity parity tooling (transform + reconcile + survey)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ CLAUDE.md
 
 # Audit / review artifacts (screenshots, findings docs) — durable value lives in GitHub issues, not in the repo
 testing/ux-review/
+
+# Migration planning docs — local working artifacts, not shipped in PRs
+docs/MIGRATION_PARITY.md
+docs/MIGRATION_PROPOSAL.md

--- a/backend/scripts/vision_migration/README.md
+++ b/backend/scripts/vision_migration/README.md
@@ -1,0 +1,61 @@
+# Vision → Velocity migration tooling (local, Windows-only)
+
+Local one-time cutover tooling. **Not** part of the deployed backend — it reads
+the legacy UC Vision Access (`.mdb`) backend and loads it into Postgres.
+
+See `docs/MIGRATION_PROPOSAL.md` for the full plan. This directory is **PKG 1**:
+Stage A raw staging + a load-verification harness.
+
+## What it does
+- **`stage`** — copies every Vision *user* table verbatim into an isolated
+  `vision_legacy` schema in Postgres (drop-and-recreate; safe to re-run).
+- **`verify`** — compares each table's source row count (Access) against the
+  staged count (Postgres) and reports mismatches.
+
+It writes **only** to the `vision_legacy` schema; it never touches Velocity's
+application tables.
+
+## Safety
+- Target DB is read from `MIGRATION_DATABASE_URL` (or `--database-url`) — a
+  **separate** variable from the app's `DATABASE_URL`, so it can't inherit a
+  prod-pointing shell.
+- `stage` refuses to run without `--i-understand-scratch-db`, and **hard-blocks**
+  any host containing `railway.internal` (production) — extend the denylist via
+  `MIGRATION_BLOCKED_HOSTS`.
+- **Never point this at production.** Use a local or throwaway/preview Postgres.
+
+## Setup (Windows)
+```powershell
+# 1. A scratch Postgres. Simplest: a local DB (nothing leaves your machine).
+#    e.g. create an empty database "vision_scratch" on localhost.
+
+# 2. A venv for the tooling (keep it separate from the backend venv).
+cd backend/scripts
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -r vision_migration/requirements.txt
+```
+
+## Run
+```powershell
+$env:MIGRATION_DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/vision_scratch"
+$env:MIGRATION_MDB          = "C:\path\to\Dev_UCVision5_BE(2).mdb"
+$env:MIGRATION_WORKGROUP    = "C:\Users\<you>\AppData\Roaming\Microsoft\Access\System.mdw"
+
+python -m vision_migration stage --i-understand-scratch-db
+python -m vision_migration verify
+```
+
+`verify` exits non-zero if any table's counts don't match.
+
+## Notes / known-fiddly bits
+- The Access read uses ADODB via `pywin32` with the proven workgroup-unlock
+  connection string; it works while Access has the file open (`Share Deny None`),
+  but keep Access **read-only** during a run.
+- Date/time and binary/OLE values are coerced from COM types on load
+  (see `stage_raw._coerce`). If an OLE/blob value can't be converted it is stored
+  NULL **and counted** — `stage` prints a WARNING listing the affected columns,
+  and `verify` compares per-column non-null counts, so any such loss shows up as a
+  MISMATCH rather than passing silently. (Full photo handling is a later spike.)
+- `verify` checks row counts **and** per-column non-null counts; it exits
+  non-zero on any mismatch.

--- a/backend/scripts/vision_migration/__init__.py
+++ b/backend/scripts/vision_migration/__init__.py
@@ -1,0 +1,16 @@
+"""UC Vision -> UC Velocity migration tooling (local, Windows-only).
+
+This package is *local one-time cutover tooling*, NOT part of the deployed
+backend. It reads the legacy UC Vision Access (.mdb) backend and loads it into
+Postgres. It is intentionally standalone: it does NOT import the FastAPI app or
+its ORM, and its dependencies live in this package's own requirements.txt so
+they never reach the Linux-deployed `backend/requirements.txt`.
+
+PKG 1 scope (this commit):
+  - Stage A "raw staging": copy every Vision user table verbatim into an
+    isolated `vision_legacy` Postgres schema (M4).
+  - A load-verification harness: prove staged row counts match the source.
+
+Later packages add Stage B (the idempotent legacy-keyed sync into Velocity's
+real tables) on top of this foundation.
+"""

--- a/backend/scripts/vision_migration/__main__.py
+++ b/backend/scripts/vision_migration/__main__.py
@@ -17,6 +17,7 @@ import sys
 from . import config
 from . import reconcile
 from . import stage_raw
+from . import survey
 from . import verify_staging
 
 
@@ -48,6 +49,13 @@ def main(argv: list[str] | None = None) -> int:
     p_reconcile.add_argument("--database-url", default=None,
                              help="Target Postgres URL (or set MIGRATION_DATABASE_URL).")
 
+    p_survey = sub.add_parser(
+        "survey",
+        help="Read-only survey: staged tables, row counts, migrated vs. remaining.",
+    )
+    p_survey.add_argument("--database-url", default=None,
+                          help="Target Postgres URL (or set MIGRATION_DATABASE_URL).")
+
     args = parser.parse_args(argv)
 
     try:
@@ -67,6 +75,11 @@ def main(argv: list[str] | None = None) -> int:
             # reconcile only reads staged data; refuse blocked hosts, no confirm needed.
             config.assert_scratch_target(target, confirmed=True)
             reconcile.run_reconciliation(target)
+            return 0
+        if args.command == "survey":
+            # survey only reads staged data; refuse blocked hosts, no confirm needed.
+            config.assert_scratch_target(target, confirmed=True)
+            survey.run_survey(target)
             return 0
     except config.MigrationConfigError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/backend/scripts/vision_migration/__main__.py
+++ b/backend/scripts/vision_migration/__main__.py
@@ -1,8 +1,9 @@
 """CLI entry point.
 
 Run from `backend/scripts`:
-    python -m vision_migration stage  --mdb "<path.mdb>" --workgroup "<path.mdw>" --i-understand-scratch-db
-    python -m vision_migration verify --mdb "<path.mdb>" --workgroup "<path.mdw>"
+    python -m vision_migration stage     --mdb "<path.mdb>" --workgroup "<path.mdw>" --i-understand-scratch-db
+    python -m vision_migration verify    --mdb "<path.mdb>" --workgroup "<path.mdw>"
+    python -m vision_migration reconcile
 
 The target Postgres comes from --database-url or MIGRATION_DATABASE_URL.
 See README.md for full setup.
@@ -14,6 +15,7 @@ import os
 import sys
 
 from . import config
+from . import reconcile
 from . import stage_raw
 from . import verify_staging
 
@@ -39,6 +41,13 @@ def main(argv: list[str] | None = None) -> int:
     p_verify = sub.add_parser("verify", help="Compare source vs staged row counts.")
     _common_args(p_verify)
 
+    p_reconcile = sub.add_parser(
+        "reconcile",
+        help="Read-only parity report (Diff A): transform staged data and quantify gaps.",
+    )
+    p_reconcile.add_argument("--database-url", default=None,
+                             help="Target Postgres URL (or set MIGRATION_DATABASE_URL).")
+
     args = parser.parse_args(argv)
 
     try:
@@ -54,6 +63,11 @@ def main(argv: list[str] | None = None) -> int:
             config.assert_scratch_target(target, confirmed=True)
             ok = verify_staging.verify(args.mdb, args.workgroup, target)
             return 0 if ok else 1
+        if args.command == "reconcile":
+            # reconcile only reads staged data; refuse blocked hosts, no confirm needed.
+            config.assert_scratch_target(target, confirmed=True)
+            reconcile.run_reconciliation(target)
+            return 0
     except config.MigrationConfigError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2

--- a/backend/scripts/vision_migration/__main__.py
+++ b/backend/scripts/vision_migration/__main__.py
@@ -1,0 +1,64 @@
+"""CLI entry point.
+
+Run from `backend/scripts`:
+    python -m vision_migration stage  --mdb "<path.mdb>" --workgroup "<path.mdw>" --i-understand-scratch-db
+    python -m vision_migration verify --mdb "<path.mdb>" --workgroup "<path.mdw>"
+
+The target Postgres comes from --database-url or MIGRATION_DATABASE_URL.
+See README.md for full setup.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from . import config
+from . import stage_raw
+from . import verify_staging
+
+
+def _common_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--mdb", default=os.getenv("MIGRATION_MDB"),
+                   help="Path to the Vision .mdb (or set MIGRATION_MDB).")
+    p.add_argument("--workgroup", default=os.getenv("MIGRATION_WORKGROUP"),
+                   help="Path to the workgroup .mdw (or set MIGRATION_WORKGROUP).")
+    p.add_argument("--database-url", default=None,
+                   help="Target Postgres URL (or set MIGRATION_DATABASE_URL).")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="vision_migration")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_stage = sub.add_parser("stage", help="Raw-stage all Vision tables into vision_legacy.")
+    _common_args(p_stage)
+    p_stage.add_argument("--i-understand-scratch-db", action="store_true",
+                         help="Confirm the target is a throwaway/preview DB, not production.")
+
+    p_verify = sub.add_parser("verify", help="Compare source vs staged row counts.")
+    _common_args(p_verify)
+
+    args = parser.parse_args(argv)
+
+    try:
+        target = config.resolve_target_url(args.database_url)
+        if args.command == "stage":
+            host = config.assert_scratch_target(target, args.i_understand_scratch_db)
+            print(f"Target host: {host} (staging into schema '{config.STAGING_SCHEMA}')")
+            stage_raw.stage_all(args.mdb, args.workgroup, target)
+            print("Staging complete.")
+            return 0
+        if args.command == "verify":
+            # verify only reads; still refuse blocked hosts, but no confirm needed.
+            config.assert_scratch_target(target, confirmed=True)
+            ok = verify_staging.verify(args.mdb, args.workgroup, target)
+            return 0 if ok else 1
+    except config.MigrationConfigError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/vision_migration/config.py
+++ b/backend/scripts/vision_migration/config.py
@@ -1,0 +1,222 @@
+"""Shared configuration, connections, safety guard, and type mapping.
+
+Everything that both `stage_raw` and `verify_staging` need lives here so the two
+commands connect to the same places in the same way.
+
+Safety model (read this):
+  - The target Postgres is read from `MIGRATION_DATABASE_URL` (or --database-url),
+    a DISTINCT variable from the app's `DATABASE_URL`. This is deliberate: it means
+    the tooling can never accidentally inherit a shell that points at production.
+  - `assert_scratch_target()` refuses to run unless the caller explicitly confirms
+    the target is a throwaway/scratch DB, and it hard-blocks any host that looks
+    like production.
+  - Even so, staging writes ONLY into the `vision_legacy` schema and never touches
+    Velocity's application tables.
+"""
+from __future__ import annotations
+
+import os
+from urllib.parse import urlparse
+
+# The isolated schema that holds the verbatim Vision copy. Never the app tables.
+STAGING_SCHEMA = "vision_legacy"
+
+# Hosts we refuse to write to, ever. Extend via MIGRATION_BLOCKED_HOSTS (comma-sep).
+# Covers Railway's private host (`railway.internal`, unreachable off-Railway) AND
+# the reachable public endpoints (`rlwy.net` proxy, `railway.app`) so a prod URL
+# sitting in the shell can't slip through. The check runs against the WHOLE
+# connection string (see assert_scratch_target), so keyword-form DSNs are caught.
+_DEFAULT_BLOCKED_HOST_MARKERS = ("railway.internal", "rlwy.net", "railway.app")
+
+# Postgres truncates identifiers to 63 bytes; Access allows up to 64 chars.
+MAX_PG_IDENTIFIER_BYTES = 63
+
+
+class MigrationConfigError(RuntimeError):
+    """Raised for any misconfiguration or safety-guard violation."""
+
+
+# --------------------------------------------------------------------------- #
+# Vision (Access) connection
+# --------------------------------------------------------------------------- #
+
+def vision_connection_string(mdb_path: str, workgroup_path: str) -> str:
+    """Build the ACE OLEDB connection string that unlocks Vision's user-level
+    security via the workgroup (.mdw) file. This is the exact form proven to read
+    the ULS-protected backend as the Admin user with `Share Deny None` (so it can
+    read while Access has the file open).
+    """
+    if not mdb_path or not os.path.exists(mdb_path):
+        raise MigrationConfigError(f"Vision .mdb not found: {mdb_path!r}")
+    if not workgroup_path or not os.path.exists(workgroup_path):
+        raise MigrationConfigError(f"Workgroup .mdw not found: {workgroup_path!r}")
+    return (
+        "Provider=Microsoft.ACE.OLEDB.12.0;"
+        f"Data Source={mdb_path};"
+        f"Jet OLEDB:System Database={workgroup_path};"
+        "Mode=Share Deny None;"
+    )
+
+
+def open_vision(mdb_path: str, workgroup_path: str):
+    """Open an ADODB connection to the Vision backend (returns the COM object).
+
+    Uses pywin32's late-bound COM. Imported lazily so `--help` and unit imports
+    work on machines without pywin32 (e.g. Linux CI).
+    """
+    try:
+        import win32com.client  # type: ignore
+    except ImportError as exc:  # pragma: no cover - environment specific
+        raise MigrationConfigError(
+            "pywin32 is required to read Access. Install this package's "
+            "requirements: pip install -r requirements.txt (Windows only)."
+        ) from exc
+    conn = win32com.client.Dispatch("ADODB.Connection")
+    conn.Open(vision_connection_string(mdb_path, workgroup_path))
+    return conn
+
+
+# --------------------------------------------------------------------------- #
+# Postgres (target) connection + guard
+# --------------------------------------------------------------------------- #
+
+def resolve_target_url(cli_url: str | None) -> str:
+    """The target Postgres URL: --database-url wins, else MIGRATION_DATABASE_URL.
+
+    Intentionally does NOT fall back to the app's DATABASE_URL.
+    """
+    url = cli_url or os.getenv("MIGRATION_DATABASE_URL")
+    if not url:
+        raise MigrationConfigError(
+            "No target database. Pass --database-url or set MIGRATION_DATABASE_URL "
+            "to a SCRATCH/preview Postgres (never production)."
+        )
+    return url
+
+
+def _blocked_markers() -> tuple[str, ...]:
+    extra = os.getenv("MIGRATION_BLOCKED_HOSTS", "")
+    extras = tuple(m.strip() for m in extra.split(",") if m.strip())
+    return _DEFAULT_BLOCKED_HOST_MARKERS + extras
+
+
+def _extract_host(url: str) -> str | None:
+    """Best-effort host from either a URL DSN or a libpq keyword/value DSN.
+
+    psycopg2 accepts BOTH `postgresql://user:pw@host/db` and the keyword form
+    `host=... dbname=... user=...`. urlparse only understands the first, so we
+    parse the keyword form ourselves -- otherwise a keyword-form prod DSN would
+    slip past a hostname-only guard.
+    """
+    parsed = urlparse(url)
+    if parsed.hostname:
+        return parsed.hostname
+    for token in url.replace("\t", " ").split():
+        if token.lower().startswith("host="):
+            return token[len("host="):].strip("'\"") or None
+    return None
+
+
+def assert_scratch_target(url: str, confirmed: bool) -> str:
+    """Refuse to proceed unless the target is an explicitly-confirmed non-prod DB.
+
+    Fails CLOSED: the blocked-marker check runs against the whole connection
+    string (so URL *and* keyword-form DSNs are covered), and an indeterminate
+    host is refused rather than assumed safe. Returns the host for logging.
+    """
+    raw = url.lower()
+    for marker in _blocked_markers():
+        if marker and marker.lower() in raw:
+            raise MigrationConfigError(
+                f"Refusing to run: connection string matches blocked marker "
+                f"{marker!r}. This looks like production."
+            )
+    host = (_extract_host(url) or "").lower()
+    if not host:
+        raise MigrationConfigError(
+            "Could not determine the target host from the connection string. "
+            "Refusing (fail-closed) -- use an explicit host, e.g. "
+            "postgresql://postgres:postgres@localhost:5432/vision_scratch."
+        )
+    if not confirmed:
+        raise MigrationConfigError(
+            f"Target host is {host!r}. Re-run with --i-understand-scratch-db to confirm "
+            "this is a throwaway/preview database, not production."
+        )
+    return host
+
+
+def check_identifier_length(name: str, kind: str = "identifier") -> None:
+    """Fail loud if a name exceeds Postgres' 63-byte identifier limit.
+
+    Access permits up to 64-char names; Postgres would silently truncate to 63,
+    which could collide two names or break the verify round-trip. Naming the
+    offender is far better than a silent truncation.
+    """
+    if len(name.encode("utf-8")) > MAX_PG_IDENTIFIER_BYTES:
+        raise MigrationConfigError(
+            f"{kind} {name!r} exceeds Postgres' {MAX_PG_IDENTIFIER_BYTES}-byte "
+            "identifier limit; staging would truncate/collide. Add a name mapping."
+        )
+
+
+def open_postgres(url: str):
+    """Open a psycopg2 connection. Imported lazily for the same reason as pywin32."""
+    try:
+        import psycopg2  # type: ignore
+    except ImportError as exc:  # pragma: no cover - environment specific
+        raise MigrationConfigError(
+            "psycopg2 is required. Install this package's requirements: "
+            "pip install -r requirements.txt"
+        ) from exc
+    return psycopg2.connect(url)
+
+
+# --------------------------------------------------------------------------- #
+# Access (ADO DataTypeEnum) -> Postgres type mapping
+# --------------------------------------------------------------------------- #
+# ADO DataTypeEnum values we expect from Vision. Full list is large; we map the
+# ones Vision actually uses and fall back to TEXT for anything unexpected.
+_ADO = {
+    2: "adSmallInt", 3: "adInteger", 4: "adSingle", 5: "adDouble",
+    6: "adCurrency", 7: "adDate", 11: "adBoolean", 14: "adDecimal",
+    16: "adTinyInt", 17: "adUnsignedTinyInt", 18: "adUnsignedSmallInt",
+    19: "adUnsignedInt", 20: "adBigInt", 72: "adGUID", 128: "adBinary",
+    129: "adChar", 130: "adWChar", 131: "adNumeric", 133: "adDBDate",
+    135: "adDBTimeStamp", 200: "adVarChar", 201: "adLongVarChar",
+    202: "adVarWChar", 203: "adLongVarWChar", 204: "adVarBinary",
+    205: "adLongVarBinary",
+}
+
+# Which ADO types land in a Postgres BYTEA column (need psycopg2.Binary wrapping).
+BINARY_ADO_TYPES = {128, 204, 205}
+# Which ADO types are date/time (need pywintypes->datetime coercion on load).
+DATETIME_ADO_TYPES = {7, 133, 135}
+
+
+def access_type_to_pg(ado_type: int) -> str:
+    """Map an ADO field type to a Postgres column type for the staging mirror.
+
+    Deliberately generous: staging is a faithful copy, not a normalized schema,
+    so we prefer wide, lossless types (TEXT, DOUBLE PRECISION, NUMERIC, BYTEA).
+    """
+    if ado_type in (2, 3, 16, 17, 18, 19):
+        return "INTEGER"
+    if ado_type == 20:
+        return "BIGINT"
+    if ado_type in (4, 5):
+        return "DOUBLE PRECISION"
+    if ado_type in (6, 14, 131):
+        return "NUMERIC"
+    if ado_type == 11:
+        return "BOOLEAN"
+    if ado_type in DATETIME_ADO_TYPES:
+        return "TIMESTAMP"
+    if ado_type in BINARY_ADO_TYPES:
+        return "BYTEA"
+    # adChar/adWChar/adVarChar/adLongVar*/adGUID and anything unmapped -> TEXT
+    return "TEXT"
+
+
+def ado_type_name(ado_type: int) -> str:
+    return _ADO.get(ado_type, f"ado({ado_type})")

--- a/backend/scripts/vision_migration/reconcile.py
+++ b/backend/scripts/vision_migration/reconcile.py
@@ -1,0 +1,409 @@
+"""Vision -> Velocity reconciliation report (read-only, "Diff A").
+
+Runs the pure transform (``transform.py``) over the staged ``vision_legacy``
+schema and prints a parity report: how the quote domain maps, what would be
+dropped, and -- the headline -- how many workorders the *real* Vision ship
+fields say were still open, versus the current CSV importer which stamps every
+migrated quote "Closed" (gap G1 in ``docs/MIGRATION_PARITY.md``).
+
+Safety: this only ever READS, and only from the ``vision_legacy`` staging
+schema. It opens the connection read-only and refuses blocked (production-looking)
+hosts via ``config.assert_scratch_target`` -- the same guard the staging command
+uses. It never touches Velocity's application tables.
+
+Two comparisons are possible (see the migration proposal):
+  * Diff A -- Vision source vs. transform output. Implemented here; needs only
+    the local staged data.
+  * Diff B -- transform output vs. the data in Velocity today. Requires a
+    read-only Velocity export loaded into a ``velocity_current`` schema. This
+    report detects whether that schema is present and, until it is, cleanly
+    reports Diff B as skipped rather than guessing.
+
+Heavy drivers (psycopg2) are imported lazily inside functions so importing this
+module never fails on a machine without them.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from . import config
+from .transform import (
+    opt_int,
+    transform_workorder,
+    transform_workorder_line,
+    workorder_source_closed,
+)
+
+SCHEMA = config.STAGING_SCHEMA  # "vision_legacy"
+
+# Staged source tables (verbatim Access names).
+_WORKORDER_TABLE = "tblServiceRecords"
+_LINE_TABLES = {  # item_type -> staged workorder-line table
+    "labor": "tblWorkorderApplication",
+    "part": "tblWorkorderMaterial",
+    "misc": "tblWorkorderZones",
+}
+# item_type -> (catalog table, its primary-key column) the line reference must exist in.
+_CATALOG = {
+    "labor": ("tblApplication", "ProductID"),
+    "part": ("tblMaterial", "ProductID"),
+    "misc": ("tblZones", "ZoneRateID"),
+}
+# item_type -> the transform's output field holding the legacy reference id.
+_REF_FIELD = {"labor": "labor_legacy_id", "part": "part_legacy_id", "misc": "misc_legacy_id"}
+_PROJECT_TABLE = ("tblProjects", "ProjectID")
+_PROJECT_CLIENT_COL = "ClientID"             # tblProjects -> client FK (importer drops if unresolved)
+_CLIENT_TABLE = ("tblClients", "Client ID")  # importer's customer_map source (note the space)
+
+# The G1 fields we expect and want to confirm actually exist in the staged schema.
+_WORKORDER_STATUS_FIELDS = ["chrStatus", "blnForceClosed", "blnLocked", "blnAllShipped"]
+_LINE_SHIP_FIELDS = ["intTotalShippedQuantity", "intShipQuantity", "intQuantityBO"]
+
+_VELOCITY_CURRENT_SCHEMA = "velocity_current"  # Diff B target, when an export is loaded
+
+
+# --------------------------------------------------------------------------- #
+# Small DB helpers (all read-only)
+# --------------------------------------------------------------------------- #
+
+def _table_exists(cur: Any, schema: str, table: str) -> bool:
+    cur.execute(
+        "SELECT 1 FROM information_schema.tables "
+        "WHERE table_schema = %s AND table_name = %s LIMIT 1",
+        (schema, table),
+    )
+    return cur.fetchone() is not None
+
+
+def _schema_exists(cur: Any, schema: str) -> bool:
+    cur.execute(
+        "SELECT 1 FROM information_schema.schemata WHERE schema_name = %s LIMIT 1",
+        (schema,),
+    )
+    return cur.fetchone() is not None
+
+
+def _columns(cur: Any, schema: str, table: str) -> set[str]:
+    cur.execute(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_schema = %s AND table_name = %s",
+        (schema, table),
+    )
+    return {r["column_name"] for r in cur.fetchall()}
+
+
+def _fetch_dicts(cur: Any, schema: str, table: str) -> list[dict[str, Any]]:
+    from psycopg2 import sql
+    cur.execute(sql.SQL("SELECT * FROM {}.{}").format(
+        sql.Identifier(schema), sql.Identifier(table)))
+    return [dict(r) for r in cur.fetchall()]
+
+
+def _fetch_id_set(cur: Any, schema: str, table: str, col: str) -> set[int]:
+    from psycopg2 import sql
+    cur.execute(sql.SQL("SELECT {} AS v FROM {}.{}").format(
+        sql.Identifier(col), sql.Identifier(schema), sql.Identifier(table)))
+    out: set[int] = set()
+    for r in cur.fetchall():
+        v = opt_int(r["v"])
+        if v is not None:
+            out.add(v)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Report
+# --------------------------------------------------------------------------- #
+
+def _fetch_lm_part_ids(cur: Any) -> set[int]:
+    """ProductIDs of 'LM-' combo parts in tblMaterial -- the importer skips these
+    from the catalog, so workorder part lines referencing them import detached
+    (part_id=NULL). Precomputed so those lines aren't scored 'resolved'."""
+    part_cat, part_key = _CATALOG["part"]
+    if not _table_exists(cur, SCHEMA, part_cat):
+        return set()
+    cols = _columns(cur, SCHEMA, part_cat)
+    if part_key not in cols or "chrProductName" not in cols:
+        return set()
+    from psycopg2 import sql
+    cur.execute(sql.SQL('SELECT {} AS v FROM {}.{} WHERE "chrProductName" ILIKE %s')
+                .format(sql.Identifier(part_key), sql.Identifier(SCHEMA), sql.Identifier(part_cat)),
+                ("LM-%",))
+    out: set[int] = set()
+    for r in cur.fetchall():
+        v = opt_int(r["v"])
+        if v is not None:
+            out.add(v)
+    return out
+
+
+def _pct(n: int, total: int) -> str:
+    return f"{(100.0 * n / total):.1f}%" if total else "n/a"
+
+
+def run_reconciliation(url: str) -> dict[str, Any]:
+    """Print the Diff A report and return a machine-readable summary dict."""
+    import psycopg2.extras
+
+    conn = config.open_postgres(url)
+    summary: dict[str, Any] = {}
+    try:
+        # Belt-and-suspenders: a read-only session on top of the read-only queries.
+        conn.set_session(readonly=True, autocommit=True)
+        cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+
+        print("=" * 72)
+        print(f"Vision -> Velocity reconciliation (Diff A)  schema='{SCHEMA}'")
+        print("=" * 72)
+
+        if not _schema_exists(cur, SCHEMA):
+            print(f"\nERROR: staging schema '{SCHEMA}' not found. Run the 'stage' "
+                  "command first.")
+            summary["staged"] = False
+            return summary
+        summary["staged"] = True
+
+        _report_schema_presence(cur, summary)
+        _report_quote_domain(cur, summary)
+        _report_diff_b_slot(cur, summary)
+
+        print("\n" + "=" * 72)
+        print("Diff A complete. (Diff B -- vs. live Velocity -- needs a read-only "
+              f"export in schema '{_VELOCITY_CURRENT_SCHEMA}'.)")
+        print("=" * 72)
+        return summary
+    finally:
+        conn.close()
+
+
+def _report_schema_presence(cur: Any, summary: dict[str, Any]) -> None:
+    """Confirm the G1 fields the parity register names actually exist in staging."""
+    print("\n-- Schema presence (G1 fields) " + "-" * 40)
+    presence: dict[str, Any] = {}
+
+    if _table_exists(cur, SCHEMA, _WORKORDER_TABLE):
+        cols = _columns(cur, SCHEMA, _WORKORDER_TABLE)
+        found = [f for f in _WORKORDER_STATUS_FIELDS if f in cols]
+        missing = [f for f in _WORKORDER_STATUS_FIELDS if f not in cols]
+        print(f"  {_WORKORDER_TABLE}: status fields present {found or '(none)'}"
+              + (f"  MISSING {missing}" if missing else ""))
+        presence[_WORKORDER_TABLE] = {"present": found, "missing": missing}
+    else:
+        print(f"  {_WORKORDER_TABLE}: TABLE NOT STAGED")
+        presence[_WORKORDER_TABLE] = None
+
+    for item_type, table in _LINE_TABLES.items():
+        if _table_exists(cur, SCHEMA, table):
+            cols = _columns(cur, SCHEMA, table)
+            found = [f for f in _LINE_SHIP_FIELDS if f in cols]
+            missing = [f for f in _LINE_SHIP_FIELDS if f not in cols]
+            print(f"  {table} ({item_type}): ship fields present {found or '(none)'}"
+                  + (f"  MISSING {missing}" if missing else ""))
+            presence[table] = {"present": found, "missing": missing}
+        else:
+            print(f"  {table} ({item_type}): TABLE NOT STAGED")
+            presence[table] = None
+    summary["schema_presence"] = presence
+
+
+def _report_quote_domain(cur: Any, summary: dict[str, Any]) -> None:
+    print("\n-- Quote coverage " + "-" * 53)
+    if not _table_exists(cur, SCHEMA, _WORKORDER_TABLE):
+        print(f"  {_WORKORDER_TABLE} not staged -- skipping quote domain.")
+        return
+
+    # Reproduce the importer's TRANSITIVE survivor set: a quote imports only if
+    # its project survives, and a project survives only if its client resolves.
+    # routes/migration.py drops a project whose ClientID is not in customer_map
+    # (lines 575-577), then drops that project's workorders (631-633), then those
+    # workorders' lines. Modelling client -> project -> quote makes the parity
+    # counts match what actually migrates, not merely what exists in the source.
+    ctab, ccol = _CLIENT_TABLE
+    client_modeled = _table_exists(cur, SCHEMA, ctab) and ccol in _columns(cur, SCHEMA, ctab)
+    client_ids: set[int] = _fetch_id_set(cur, SCHEMA, ctab, ccol) if client_modeled else set()
+
+    proj_table, proj_col = _PROJECT_TABLE
+    project_modeled = _table_exists(cur, SCHEMA, proj_table) and proj_col in _columns(cur, SCHEMA, proj_table)
+    all_project_ids: set[int] = set()
+    surviving_project_ids: set[int] = set()
+    if project_modeled:
+        for prow in _fetch_dicts(cur, SCHEMA, proj_table):
+            pid = opt_int(prow.get(proj_col))
+            if pid is None:
+                continue
+            all_project_ids.add(pid)
+            cid = opt_int(prow.get(_PROJECT_CLIENT_COL))
+            # Survives if we can't model clients (fall back to "exists"), or if
+            # its client resolves -- mirroring the importer's project_map.
+            if not client_modeled or (cid is not None and cid in client_ids):
+                surviving_project_ids.add(pid)
+
+    workorders = _fetch_dicts(cur, SCHEMA, _WORKORDER_TABLE)
+    total = len(workorders)
+
+    # source-declared close-state, per SURVIVING workorder + distribution
+    source_state: dict[int, Optional[bool]] = {}
+    src_closed = src_open = src_unknown = 0
+    valid_wo_ids: set[int] = set()  # workorders that actually migrate
+    dropped_no_wo_id = dropped_unknown_project = dropped_client_orphaned = 0
+
+    for row in workorders:
+        q = transform_workorder(row)
+        wo = q["workorder_legacy_id"]
+        if not wo:
+            dropped_no_wo_id += 1
+            continue
+        proj = q["project_legacy_id"]
+        if project_modeled:
+            if proj is None or proj not in all_project_ids:
+                dropped_unknown_project += 1
+                continue
+            if proj not in surviving_project_ids:
+                dropped_client_orphaned += 1
+                continue
+        valid_wo_ids.add(wo)
+        sc = workorder_source_closed(row)
+        source_state[wo] = sc
+        if sc is True:
+            src_closed += 1
+        elif sc is False:
+            src_open += 1
+        else:
+            src_unknown += 1
+
+    print(f"  Workorders (tblServiceRecords):        {total:>8}")
+    print(f"    migrate (survive all drop rules):    {len(valid_wo_ids):>8}")
+    print(f"    drop -- empty WorkorderID:           {dropped_no_wo_id:>8}")
+    print(f"    drop -- unknown project:             {dropped_unknown_project:>8}"
+          + ("" if project_modeled else "   (tblProjects not staged -- not checked)"))
+    print(f"    drop -- project's client dropped:    {dropped_client_orphaned:>8}"
+          + ("" if client_modeled else "   (tblClients not staged -- not modeled)"))
+
+    # --- G1: derive real fulfillment from the line ship fields ---
+    lm_part_ids = _fetch_lm_part_ids(cur)  # part lines referencing these import detached
+
+    wo_pending: dict[int, bool] = {}   # wo -> any line still pending (surviving workorders only)
+    line_counts = {"labor": 0, "part": 0, "misc": 0}
+    ship_known = ship_unknown = 0
+    orphan_ref = {"labor": 0, "part": 0, "misc": 0}
+    null_ref = {"labor": 0, "part": 0, "misc": 0}
+    orphan_wo_lines = 0    # line rows whose parent workorder does not survive migration
+    lm_detached_lines = 0  # part lines referencing an LM- part -> import as null part_id
+
+    for item_type, table in _LINE_TABLES.items():
+        if not _table_exists(cur, SCHEMA, table):
+            print(f"  ({table} not staged -- {item_type} lines skipped)")
+            continue
+        cat_table, cat_col = _CATALOG[item_type]
+        cat_ids: set[int] = set()
+        if _table_exists(cur, SCHEMA, cat_table) and cat_col in _columns(cur, SCHEMA, cat_table):
+            cat_ids = _fetch_id_set(cur, SCHEMA, cat_table, cat_col)
+        ref_field = _REF_FIELD[item_type]
+
+        for row in _fetch_dicts(cur, SCHEMA, table):
+            line = transform_workorder_line(row, item_type)
+            line_counts[item_type] += 1
+            wo = line["workorder_legacy_id"]
+            if wo is not None and wo in valid_wo_ids:
+                if line["qty_pending"] > 0:
+                    wo_pending[wo] = True
+                else:
+                    wo_pending.setdefault(wo, False)
+            else:
+                # line points at a workorder not in tblServiceRecords (or no id);
+                # the CSV importer drops these (unknown intWorkorderID).
+                orphan_wo_lines += 1
+            if line["ship_data_present"]:
+                ship_known += 1
+            else:
+                ship_unknown += 1
+            ref = line.get(ref_field)
+            if ref is None:
+                null_ref[item_type] += 1
+            elif item_type == "part" and ref in lm_part_ids:
+                lm_detached_lines += 1
+            elif cat_ids and ref not in cat_ids:
+                orphan_ref[item_type] += 1
+
+    total_lines = sum(line_counts.values())
+    derived_open = sum(1 for v in wo_pending.values() if v)
+    derived_closed = sum(1 for v in wo_pending.values() if not v)
+    no_lines = len(valid_wo_ids - set(wo_pending.keys()))
+
+    migrated = len(valid_wo_ids)
+    print(f"\n-- G1: quote close-state (over the {migrated} migrating workorders) " + "-" * 8)
+    print("  Source's own label (chrStatus / blnForceClosed / blnAllShipped):")
+    print(f"    closed:  {src_closed:>8}  ({_pct(src_closed, migrated)})")
+    print(f"    open:    {src_open:>8}  ({_pct(src_open, migrated)})")
+    print(f"    unknown: {src_unknown:>8}  ({_pct(src_unknown, migrated)})")
+    print("  Derived from real per-line ship quantities:")
+    print(f"    open (>=1 pending line): {derived_open:>8}")
+    print(f"    closed (all shipped):    {derived_closed:>8}")
+    print(f"    no line items:           {no_lines:>8}")
+
+    # Agreement between the two independent open/closed signals.
+    both_open = sum(1 for wo, p in wo_pending.items() if p and source_state.get(wo) is False)
+    both_closed = sum(1 for wo, p in wo_pending.items() if not p and source_state.get(wo) is True)
+    src_closed_derived_open = sum(
+        1 for wo, p in wo_pending.items() if p and source_state.get(wo) is True)
+    src_open_derived_closed = sum(
+        1 for wo, p in wo_pending.items() if not p and source_state.get(wo) is False)
+    print("  Agreement (workorders with lines):")
+    print(f"    source-open  & derived-open:   {both_open:>8}")
+    print(f"    source-closed& derived-closed: {both_closed:>8}")
+    print(f"    source-closed& derived-open:   {src_closed_derived_open:>8}")
+    print(f"    source-open  & derived-closed: {src_open_derived_closed:>8}")
+
+    print("\n  >>> HEADLINE: a correct migration derives "
+          f"{derived_open} workorders as OPEN (source label: {src_open} open).")
+    print("      The current CSV importer stamps ALL of them 'Closed' (gap G1).")
+
+    print("\n-- Line items + fulfillment data quality " + "-" * 30)
+    print(f"  line items total:            {total_lines:>8}"
+          f"  (labor {line_counts['labor']}, part {line_counts['part']}, misc {line_counts['misc']})")
+    print(f"    with real ship data:       {ship_known:>8}  ({_pct(ship_known, total_lines)})")
+    print(f"    no ship data (-> pending): {ship_unknown:>8}  ({_pct(ship_unknown, total_lines)})")
+
+    print("\n-- Referential coverage (line ref -> catalog) " + "-" * 25)
+    print(f"  line rows on a dropped workorder:             {orphan_wo_lines:>6}  "
+          "(importer drops these entirely)")
+    print(f"  part lines referencing an LM- (dropped) part: {lm_detached_lines:>6}  "
+          "(import with null part_id)")
+    for item_type in ("labor", "part", "misc"):
+        cat_table = _CATALOG[item_type][0]
+        print(f"  {item_type:<5}: null ref {null_ref[item_type]:>6}   "
+              f"orphan (not in {cat_table}) {orphan_ref[item_type]:>6}")
+
+    # --- G7: LM- parts the importer drops from the catalog ---
+    part_cat = _CATALOG["part"][0]
+    print("\n-- G7: LM- parts " + "-" * 54)
+    print(f"  {part_cat} rows with 'LM-' part number: {len(lm_part_ids)} "
+          "(skipped by the importer's catalog build)")
+    print(f"  quote part lines pointing at them:      {lm_detached_lines} "
+          "(would import detached)")
+    summary["lm_parts"] = len(lm_part_ids)
+
+    summary["quotes"] = {
+        "total": total,
+        "migrate": len(valid_wo_ids),
+        "dropped_no_wo_id": dropped_no_wo_id,
+        "dropped_unknown_project": dropped_unknown_project,
+        "dropped_client_orphaned": dropped_client_orphaned,
+        "source_label": {"closed": src_closed, "open": src_open, "unknown": src_unknown},
+        "derived": {"open": derived_open, "closed": derived_closed, "no_lines": no_lines},
+        "lines": {"total": total_lines, "ship_known": ship_known, "ship_unknown": ship_unknown,
+                  "by_type": line_counts, "orphan_ref": orphan_ref, "null_ref": null_ref,
+                  "orphan_wo_lines": orphan_wo_lines, "lm_detached_lines": lm_detached_lines},
+    }
+
+
+def _report_diff_b_slot(cur: Any, summary: dict[str, Any]) -> None:
+    print("\n-- Diff B (vs. live Velocity) " + "-" * 41)
+    present = _schema_exists(cur, _VELOCITY_CURRENT_SCHEMA)
+    summary["diff_b_available"] = present
+    if present:
+        print(f"  schema '{_VELOCITY_CURRENT_SCHEMA}' present -- live diff can be built "
+              "(not implemented in this increment).")
+    else:
+        print(f"  schema '{_VELOCITY_CURRENT_SCHEMA}' absent -- SKIPPED. Load a read-only "
+              "Velocity export there to enable it.")

--- a/backend/scripts/vision_migration/reconcile.py
+++ b/backend/scripts/vision_migration/reconcile.py
@@ -29,6 +29,14 @@ from typing import Any, Optional
 from . import config
 from .transform import (
     opt_int,
+    transform_category,
+    transform_labor,
+    transform_misc,
+    transform_part,
+    transform_po,
+    transform_po_line,
+    transform_profile,
+    transform_project,
     transform_workorder,
     transform_workorder_line,
     workorder_source_closed,
@@ -54,6 +62,10 @@ _REF_FIELD = {"labor": "labor_legacy_id", "part": "part_legacy_id", "misc": "mis
 _PROJECT_TABLE = ("tblProjects", "ProjectID")
 _PROJECT_CLIENT_COL = "ClientID"             # tblProjects -> client FK (importer drops if unresolved)
 _CLIENT_TABLE = ("tblClients", "Client ID")  # importer's customer_map source (note the space)
+_VENDOR_TABLE = ("tblVendors", "VendorID")
+_CATEGORY_TABLE = ("tblPartsCategories", "CategoryID")
+_PO_TABLE = ("tblPurchaseOrders", "PurchaseOrderID")
+_PO_LINE_TABLE = "tblPurchaseOrdersMaterial"
 
 # The G1 fields we expect and want to confirm actually exist in the staged schema.
 _WORKORDER_STATUS_FIELDS = ["chrStatus", "blnForceClosed", "blnLocked", "blnAllShipped"]
@@ -137,6 +149,33 @@ def _fetch_lm_part_ids(cur: Any) -> set[int]:
     return out
 
 
+def _surviving_projects(cur: Any) -> tuple[set[int], set[int], bool, bool]:
+    """(all_project_ids, surviving_project_ids, project_modeled, client_modeled).
+
+    Mirrors the importer's client->project drop: a project survives only if its
+    ClientID resolves to a staged client (or, if clients aren't staged, falls
+    back to "the project exists"). Shared by the quote, project, and PO reports
+    so the survivor rule lives in exactly one place.
+    """
+    ctab, ccol = _CLIENT_TABLE
+    client_modeled = _table_exists(cur, SCHEMA, ctab) and ccol in _columns(cur, SCHEMA, ctab)
+    client_ids = _fetch_id_set(cur, SCHEMA, ctab, ccol) if client_modeled else set()
+    proj_table, proj_col = _PROJECT_TABLE
+    project_modeled = _table_exists(cur, SCHEMA, proj_table) and proj_col in _columns(cur, SCHEMA, proj_table)
+    all_ids: set[int] = set()
+    surviving: set[int] = set()
+    if project_modeled:
+        for prow in _fetch_dicts(cur, SCHEMA, proj_table):
+            pid = opt_int(prow.get(proj_col))
+            if pid is None:
+                continue
+            all_ids.add(pid)
+            cid = opt_int(prow.get(_PROJECT_CLIENT_COL))
+            if not client_modeled or (cid is not None and cid in client_ids):
+                surviving.add(pid)
+    return all_ids, surviving, project_modeled, client_modeled
+
+
 def _pct(n: int, total: int) -> str:
     return f"{(100.0 * n / total):.1f}%" if total else "n/a"
 
@@ -165,6 +204,10 @@ def run_reconciliation(url: str) -> dict[str, Any]:
 
         _report_schema_presence(cur, summary)
         _report_quote_domain(cur, summary)
+        _report_catalog(cur, summary)
+        _report_profiles(cur, summary)
+        _report_projects(cur, summary)
+        _report_po_domain(cur, summary)
         _report_diff_b_slot(cur, summary)
 
         print("\n" + "=" * 72)
@@ -212,31 +255,10 @@ def _report_quote_domain(cur: Any, summary: dict[str, Any]) -> None:
         print(f"  {_WORKORDER_TABLE} not staged -- skipping quote domain.")
         return
 
-    # Reproduce the importer's TRANSITIVE survivor set: a quote imports only if
-    # its project survives, and a project survives only if its client resolves.
-    # routes/migration.py drops a project whose ClientID is not in customer_map
-    # (lines 575-577), then drops that project's workorders (631-633), then those
-    # workorders' lines. Modelling client -> project -> quote makes the parity
-    # counts match what actually migrates, not merely what exists in the source.
-    ctab, ccol = _CLIENT_TABLE
-    client_modeled = _table_exists(cur, SCHEMA, ctab) and ccol in _columns(cur, SCHEMA, ctab)
-    client_ids: set[int] = _fetch_id_set(cur, SCHEMA, ctab, ccol) if client_modeled else set()
-
-    proj_table, proj_col = _PROJECT_TABLE
-    project_modeled = _table_exists(cur, SCHEMA, proj_table) and proj_col in _columns(cur, SCHEMA, proj_table)
-    all_project_ids: set[int] = set()
-    surviving_project_ids: set[int] = set()
-    if project_modeled:
-        for prow in _fetch_dicts(cur, SCHEMA, proj_table):
-            pid = opt_int(prow.get(proj_col))
-            if pid is None:
-                continue
-            all_project_ids.add(pid)
-            cid = opt_int(prow.get(_PROJECT_CLIENT_COL))
-            # Survives if we can't model clients (fall back to "exists"), or if
-            # its client resolves -- mirroring the importer's project_map.
-            if not client_modeled or (cid is not None and cid in client_ids):
-                surviving_project_ids.add(pid)
+    # Reproduce the importer's transitive survivor set (client -> project ->
+    # quote -> line): a quote imports only if its project survives, and a project
+    # survives only if its client resolves. See _surviving_projects.
+    all_project_ids, surviving_project_ids, project_modeled, client_modeled = _surviving_projects(cur)
 
     workorders = _fetch_dicts(cur, SCHEMA, _WORKORDER_TABLE)
     total = len(workorders)
@@ -394,6 +416,227 @@ def _report_quote_domain(cur: Any, summary: dict[str, Any]) -> None:
         "lines": {"total": total_lines, "ship_known": ship_known, "ship_unknown": ship_unknown,
                   "by_type": line_counts, "orphan_ref": orphan_ref, "null_ref": null_ref,
                   "orphan_wo_lines": orphan_wo_lines, "lm_detached_lines": lm_detached_lines},
+    }
+
+
+def _report_catalog(cur: Any, summary: dict[str, Any]) -> None:
+    print("\n-- Catalog (categories / parts / labour / misc) " + "-" * 23)
+    vtab, vcol = _VENDOR_TABLE
+    vendor_ids = (_fetch_id_set(cur, SCHEMA, vtab, vcol)
+                  if _table_exists(cur, SCHEMA, vtab) and vcol in _columns(cur, SCHEMA, vtab) else set())
+    # Categories resolve by TYPE, exactly like the importer: cat_map_part holds
+    # Material + 'Application & Material'; cat_map_labor holds Application + both.
+    # A part pointing at a labour-only category imports detached (category NULL),
+    # so a single flat set would under-count orphan categories.
+    ctab, ccol = _CATEGORY_TABLE
+    part_cat_ids: set[int] = set()
+    labor_cat_ids: set[int] = set()
+    cat_velocity_rows = 0
+    crows = _fetch_dicts(cur, SCHEMA, ctab) if _table_exists(cur, SCHEMA, ctab) else []
+    for cr in crows:
+        for c in transform_category(cr):
+            cat_velocity_rows += 1
+            cid = c["category_legacy_id"]
+            if cid is None:
+                continue
+            (part_cat_ids if c["type"] == "part" else labor_cat_ids).add(cid)
+    if crows:
+        print(f"  categories (tblPartsCategories): {len(crows)} source -> {cat_velocity_rows} "
+              "Velocity rows ('Application & Material' splits into two)")
+
+    part_tab = _CATALOG["part"][0]
+    if _table_exists(cur, SCHEMA, part_tab):
+        total = mapped = lm = empty = orphan_v = orphan_c = 0
+        for r in _fetch_dicts(cur, SCHEMA, part_tab):
+            p = transform_part(r)
+            total += 1
+            if not p["part_legacy_id"] or not p["part_number"]:
+                empty += 1  # importer skips empty ProductID / part number
+                continue
+            if p["skipped_lm"]:
+                lm += 1
+                continue
+            mapped += 1
+            if vendor_ids and p["vendor_legacy_id"] is not None and p["vendor_legacy_id"] not in vendor_ids:
+                orphan_v += 1
+            if part_cat_ids and p["category_legacy_id"] is not None and p["category_legacy_id"] not in part_cat_ids:
+                orphan_c += 1
+        print(f"  parts (tblMaterial): {total} source -> {mapped} imported, {lm} LM- skipped (G7), "
+              f"{empty} blank-key skipped; orphan vendor {orphan_v}, orphan category {orphan_c}")
+
+    lab_tab = _CATALOG["labor"][0]
+    if _table_exists(cur, SCHEMA, lab_tab):
+        total = mapped = empty = orphan_c = 0
+        for r in _fetch_dicts(cur, SCHEMA, lab_tab):
+            lab = transform_labor(r)
+            total += 1
+            if not lab["labor_legacy_id"] or not lab["description"]:
+                empty += 1  # importer skips empty ProductID / description
+                continue
+            mapped += 1
+            if labor_cat_ids and lab["category_legacy_id"] is not None and lab["category_legacy_id"] not in labor_cat_ids:
+                orphan_c += 1
+        print(f"  labour (tblApplication): {total} source -> {mapped} imported, "
+              f"{empty} blank-key skipped; orphan category {orphan_c}")
+
+    misc_tab = _CATALOG["misc"][0]
+    if _table_exists(cur, SCHEMA, misc_tab):
+        total = mapped = empty = 0
+        for r in _fetch_dicts(cur, SCHEMA, misc_tab):
+            m = transform_misc(r)
+            total += 1
+            if not m["misc_legacy_id"]:
+                empty += 1
+                continue
+            mapped += 1
+        print(f"  misc (tblZones): {total} source -> {mapped} imported, {empty} blank-key skipped")
+
+
+def _report_profiles(cur: Any, summary: dict[str, Any]) -> None:
+    print("\n-- Profiles (customers / vendors) " + "-" * 37)
+    for ptype, (tab, _key) in (("customer", _CLIENT_TABLE), ("vendor", _VENDOR_TABLE)):
+        if not _table_exists(cur, SCHEMA, tab):
+            print(f"  {ptype}s: {tab} not staged")
+            continue
+        id_field = "customer_legacy_id" if ptype == "customer" else "vendor_legacy_id"
+        total = profiles = contacts = blank = empty = 0
+        for r in _fetch_dicts(cur, SCHEMA, tab):
+            prof, cts = transform_profile(r, ptype)
+            total += 1
+            if not prof[id_field]:
+                empty += 1  # importer skips rows with an empty legacy id
+                continue
+            profiles += 1
+            contacts += len(cts)
+            if prof["name"].startswith("Unknown "):
+                blank += 1
+        print(f"  {ptype}s ({tab}): {total} source -> {profiles} imported, {contacts} contacts"
+              + (f", {blank} blank-name fallback" if blank else "")
+              + (f", {empty} empty-id skipped" if empty else ""))
+
+
+def _report_projects(cur: Any, summary: dict[str, Any]) -> None:
+    print("\n-- Projects " + "-" * 59)
+    proj_tab = _PROJECT_TABLE[0]
+    if not _table_exists(cur, SCHEMA, proj_tab):
+        print(f"  {proj_tab} not staged")
+        return
+    all_ids, surviving, _pm, _cm = _surviving_projects(cur)
+    rows = _fetch_dicts(cur, SCHEMA, proj_tab)
+    archived = active = dropped_client = 0
+    uca_seen: dict[str, int] = {}
+    for r in rows:
+        p = transform_project(r)
+        pid = p["project_legacy_id"]
+        if pid is not None and pid in surviving:
+            # Only surviving (migrating) projects count toward the split + UCA
+            # dedup -- the importer dedups seen_uca only after the client check.
+            if p["status"] == "archived":
+                archived += 1
+            else:
+                active += 1
+            uca = p["uca_project_number"]
+            if uca:
+                uca_seen[uca] = uca_seen.get(uca, 0) + 1
+        elif pid is not None and pid in all_ids:
+            dropped_client += 1  # project exists but its client didn't resolve
+    uca_dups = sum(c - 1 for c in uca_seen.values() if c > 1)
+    print(f"  projects (tblProjects): {len(rows)}  ->  migrate {len(surviving)}, "
+          f"drop (client unresolved) {dropped_client}")
+    print(f"    active {active}, archived {archived}; duplicate UCA numbers {uca_dups}")
+
+
+def _report_po_domain(cur: Any, summary: dict[str, Any]) -> None:
+    print("\n-- Purchase orders (G2: close-state) " + "-" * 33)
+    po_tab, _po_key = _PO_TABLE
+    if not _table_exists(cur, SCHEMA, po_tab):
+        print(f"  {po_tab} not staged")
+        return
+    _all, surviving, project_modeled, _cm = _surviving_projects(cur)
+    vtab, vcol = _VENDOR_TABLE
+    vendor_ids = (_fetch_id_set(cur, SCHEMA, vtab, vcol)
+                  if _table_exists(cur, SCHEMA, vtab) and vcol in _columns(cur, SCHEMA, vtab) else set())
+
+    valid_po_ids: set[int] = set()
+    src = {"received_all": 0, "open": 0, "unknown": 0}
+    total = dropped_no_id = dropped_project = vendor_placeholder = 0
+    for r in _fetch_dicts(cur, SCHEMA, po_tab):
+        po = transform_po(r)
+        total += 1
+        pid = po["po_legacy_id"]
+        if not pid:
+            dropped_no_id += 1
+            continue
+        proj = po["project_legacy_id"]
+        if project_modeled and (proj is None or proj not in surviving):
+            dropped_project += 1
+            continue
+        valid_po_ids.add(pid)
+        v = po["vendor_legacy_id"]
+        if vendor_ids and (v is None or v not in vendor_ids):
+            vendor_placeholder += 1  # importer substitutes a placeholder vendor, keeps the PO
+        ra = po["legacy_received_all"]
+        if ra is True:
+            src["received_all"] += 1
+        elif ra is False:
+            src["open"] += 1
+        else:
+            src["unknown"] += 1
+
+    part_cat = _CATALOG["part"]
+    part_ids = (_fetch_id_set(cur, SCHEMA, part_cat[0], part_cat[1])
+                if _table_exists(cur, SCHEMA, part_cat[0]) and part_cat[1] in _columns(cur, SCHEMA, part_cat[0]) else set())
+    lm_part_ids = _fetch_lm_part_ids(cur)  # LM- parts detach PO lines too (G7), like quote lines
+    po_pending: dict[int, bool] = {}
+    line_total = orphan_po_lines = orphan_part = lm_detached = 0
+    if _table_exists(cur, SCHEMA, _PO_LINE_TABLE):
+        for r in _fetch_dicts(cur, SCHEMA, _PO_LINE_TABLE):
+            ln = transform_po_line(r)
+            line_total += 1
+            po_id = ln["po_legacy_id"]
+            if po_id is not None and po_id in valid_po_ids:
+                if ln["qty_pending"] > 0:
+                    po_pending[po_id] = True
+                else:
+                    po_pending.setdefault(po_id, False)
+            else:
+                orphan_po_lines += 1
+            ref = ln["part_legacy_id"]
+            if ref is not None:
+                if ref in lm_part_ids:
+                    lm_detached += 1  # importer drops LM- from the catalog -> null part_id
+                elif part_ids and ref not in part_ids:
+                    orphan_part += 1
+
+    migrate = len(valid_po_ids)
+    derived_open = sum(1 for v in po_pending.values() if v)
+    derived_closed = sum(1 for v in po_pending.values() if not v)
+    no_lines = len(valid_po_ids - set(po_pending.keys()))
+
+    print(f"  POs (tblPurchaseOrders): {total}  ->  migrate {migrate}, drop no-id {dropped_no_id}, "
+          f"drop unknown/orphaned project {dropped_project}")
+    print(f"    vendor missing -> placeholder: {vendor_placeholder}")
+    print("  Source's own label (blnRecievedAll):")
+    print(f"    received-all (closed): {src['received_all']:>6}")
+    print(f"    not received (open):   {src['open']:>6}")
+    print(f"    unknown:               {src['unknown']:>6}")
+    print("  Derived from real PO-line receipts:")
+    print(f"    open (>=1 pending line): {derived_open:>6}")
+    print(f"    closed (all received):   {derived_closed:>6}")
+    print(f"    no line items:           {no_lines:>6}")
+    print(f"\n  >>> G2 HEADLINE: a correct migration derives {derived_open} POs as OPEN.")
+    print("      The current CSV importer stamps ALL of them 'closed'.")
+    print(f"  PO lines: {line_total} total, orphan (missing PO) {orphan_po_lines}, "
+          f"orphan part ref {orphan_part}, LM- detached {lm_detached}")
+
+    summary["purchase_orders"] = {
+        "total": total, "migrate": migrate,
+        "dropped_no_id": dropped_no_id, "dropped_project": dropped_project,
+        "vendor_placeholder": vendor_placeholder,
+        "source_received_all": src,
+        "derived": {"open": derived_open, "closed": derived_closed, "no_lines": no_lines},
+        "lines": {"total": line_total, "orphan_po_lines": orphan_po_lines,
+                  "orphan_part": orphan_part, "lm_detached": lm_detached},
     }
 
 

--- a/backend/scripts/vision_migration/requirements.txt
+++ b/backend/scripts/vision_migration/requirements.txt
@@ -1,0 +1,5 @@
+# LOCAL-ONLY migration tooling dependencies (Windows).
+# Do NOT merge these into backend/requirements.txt: pywin32 is Windows-only and
+# this tooling never runs on the Linux-deployed backend.
+pywin32==306
+psycopg2-binary==2.9.9

--- a/backend/scripts/vision_migration/stage_raw.py
+++ b/backend/scripts/vision_migration/stage_raw.py
@@ -1,0 +1,232 @@
+"""Stage A - raw staging: copy every Vision user table verbatim into Postgres.
+
+For each Vision user table we:
+  1. open a `SELECT * FROM [table]` recordset (gives us field names + ADO types),
+  2. CREATE the matching table in the `vision_legacy` schema (drop-and-recreate,
+     so re-running is idempotent for this isolated schema only),
+  3. stream the rows across in batches via ADODB `GetRows` -> psycopg2
+     `execute_values`.
+
+Nothing here touches Velocity's application tables. The only DDL is against the
+`vision_legacy` schema.
+
+Fidelity: values that cannot be faithfully converted (e.g. an OLE blob pywin32
+won't turn into bytes) are NOT silently dropped -- they are counted per column
+and reported as a WARNING at the end, and `verify_staging` independently compares
+per-column non-null counts so any such loss shows up as a MISMATCH.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+from typing import Any
+
+from . import config
+
+# ADODB constants
+_AD_OPEN_FORWARD_ONLY = 0
+_AD_LOCK_READ_ONLY = 1
+_AD_CMD_TEXT = 1
+_ROW_BATCH = 2000  # rows fetched per GetRows call
+_INSERT_PAGE_SIZE = 200  # rows per INSERT statement (bounds SQL size for wide/text rows)
+
+
+class _CoercionError(Exception):
+    """A cell value could not be faithfully converted for Postgres."""
+
+
+def _list_user_tables(vision_conn) -> list[str]:
+    """Return Vision's *user* table names (excludes MSys* system + ACCESS tables).
+
+    Uses ADOX, whose Table.Type is 'TABLE' for user tables and 'SYSTEM TABLE' /
+    'ACCESS TABLE' for engine internals. We keep EVERYTHING with Type 'TABLE' --
+    including report-scratch/test/switchboard tables -- because the rule is
+    "keep all": staging loses nothing.
+    """
+    import win32com.client  # type: ignore
+
+    cat = win32com.client.Dispatch("ADOX.Catalog")
+    cat.ActiveConnection = vision_conn
+    names = [t.Name for t in cat.Tables if t.Type == "TABLE"]
+    # NB: we deliberately do NOT set cat.ActiveConnection = None -- pywin32's
+    # late-bound COM raises on assigning None. The catalog releases its hold when
+    # it goes out of scope here; the shared `vision_conn` stays open for reuse.
+    return sorted(names)
+
+
+def _field_defs(recordset) -> list[tuple[str, int]]:
+    """(name, ado_type) for each field of an open recordset, in ordinal order."""
+    return [(f.Name, int(f.Type)) for f in recordset.Fields]
+
+
+def _coerce(value: Any, ado_type: int):
+    """Convert one ADODB value into something psycopg2 can bind.
+
+    - NULLs pass through.
+    - Date/time comes back as a pywintypes time; rebuild a plain datetime.
+    - Binary/OLE is wrapped with psycopg2.Binary.
+    - Everything else (str / int / float / Decimal / bool) binds directly.
+
+    Raises `_CoercionError` if a date or binary value cannot be converted, so the
+    caller can count it and store NULL *visibly* rather than corrupting silently.
+    """
+    if value is None:
+        return None
+    if ado_type in config.DATETIME_ADO_TYPES:
+        try:
+            return _dt.datetime(
+                value.year, value.month, value.day,
+                value.hour, value.minute, value.second,
+            )
+        except Exception as exc:
+            raise _CoercionError(f"date coercion failed: {exc}") from exc
+    if ado_type in config.BINARY_ADO_TYPES:
+        import psycopg2  # type: ignore
+        try:
+            return psycopg2.Binary(bytes(value))
+        except Exception as exc:
+            raise _CoercionError(f"binary coercion failed: {exc}") from exc
+    return value
+
+
+def _create_staging_table(pg_cur, table: str, fields: list[tuple[str, int]]) -> None:
+    """DROP + CREATE the staging mirror. Identifiers are quoted safely via
+    psycopg2.sql (handles spaces / & / / / - and any embedded quote), and every
+    name is length-checked so a >63-byte name fails loud instead of truncating.
+    """
+    from psycopg2 import sql  # type: ignore
+
+    config.check_identifier_length(table, "table name")
+    col_defs = []
+    for name, ado_type in fields:
+        config.check_identifier_length(name, f"column name in {table!r}")
+        col_defs.append(
+            sql.SQL("{} {}").format(
+                sql.Identifier(name), sql.SQL(config.access_type_to_pg(ado_type))
+            )
+        )
+    ident = sql.Identifier(config.STAGING_SCHEMA, table)
+    pg_cur.execute(sql.SQL("DROP TABLE IF EXISTS {} CASCADE").format(ident))
+    pg_cur.execute(sql.SQL("CREATE TABLE {} ({})").format(ident, sql.SQL(", ").join(col_defs)))
+
+
+def _load_rows(pg_cur, table: str, fields: list[tuple[str, int]], recordset):
+    """Stream the recordset into the staging table.
+
+    Returns (rows_loaded, {column: coercion_failure_count}).
+    """
+    from psycopg2 import sql  # type: ignore
+    from psycopg2.extras import execute_values  # type: ignore
+
+    names = [name for name, _ in fields]
+    ado_types = [ado for _, ado in fields]
+    target = sql.Identifier(config.STAGING_SCHEMA, table)
+    col_idents = sql.SQL(", ").join(sql.Identifier(n) for n in names)
+
+    # Tables with binary/OLE columns insert via executemany so each blob is sent
+    # as a bound parameter, not inlined into one huge SQL string (which overruns
+    # libpq's buffer). Blob-free tables use the faster execute_values path.
+    has_binary = any(a in config.BINARY_ADO_TYPES for a in ado_types)
+    if has_binary:
+        placeholders = sql.SQL(", ").join([sql.Placeholder()] * len(names))
+        insert_sql = sql.SQL("INSERT INTO {} ({}) VALUES ({})").format(
+            target, col_idents, placeholders
+        ).as_string(pg_cur)
+    else:
+        insert_sql = sql.SQL("INSERT INTO {} ({}) VALUES %s").format(
+            target, col_idents
+        ).as_string(pg_cur)
+
+    loaded = 0
+    fail_counts: dict[str, int] = {}
+    if recordset.EOF:  # empty table
+        return 0, fail_counts
+
+    while True:
+        # GetRows returns a COLUMN-major 2D tuple: block[col][row].
+        block = recordset.GetRows(_ROW_BATCH)
+        if not block or len(block) == 0 or len(block[0]) == 0:
+            break
+        rows = []
+        for row in zip(*block):  # transpose to row-major
+            out = []
+            for c, cell in enumerate(row):
+                try:
+                    out.append(_coerce(cell, ado_types[c]))
+                except _CoercionError:
+                    out.append(None)
+                    fail_counts[names[c]] = fail_counts.get(names[c], 0) + 1
+            rows.append(tuple(out))
+        if has_binary:
+            pg_cur.executemany(insert_sql, rows)
+        else:
+            execute_values(pg_cur, insert_sql, rows, page_size=_INSERT_PAGE_SIZE)
+        loaded += len(rows)
+        if recordset.EOF:
+            break
+    return loaded, fail_counts
+
+
+def stage_all(mdb_path: str, workgroup_path: str, target_url: str) -> dict[str, int]:
+    """Stage every Vision user table into `vision_legacy`. Returns {table: rows}.
+
+    The whole load runs in ONE Postgres transaction so a failure leaves no
+    half-populated schema.
+    """
+    from psycopg2 import sql  # type: ignore
+
+    vision = config.open_vision(mdb_path, workgroup_path)
+    pg = config.open_postgres(target_url)
+    results: dict[str, int] = {}
+    issues: dict[str, dict[str, int]] = {}  # table -> {column: failure_count}
+    try:
+        tables = _list_user_tables(vision)
+        print(f"Found {len(tables)} Vision user tables to stage.")
+        with pg:  # commit on success, rollback on exception
+            with pg.cursor() as cur:
+                cur.execute(
+                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
+                        sql.Identifier(config.STAGING_SCHEMA)
+                    )
+                )
+                for i, table in enumerate(tables, start=1):
+                    rs = None
+                    try:
+                        rs = _open_table(vision, table)
+                        fields = _field_defs(rs)
+                        _create_staging_table(cur, table, fields)
+                        n, fails = _load_rows(cur, table, fields, rs)
+                    finally:
+                        if rs is not None and rs.State:
+                            rs.Close()
+                    results[table] = n
+                    if fails:
+                        issues[table] = fails
+                    print(f"  [{i:>2}/{len(tables)}] {table}: {n} rows")
+    finally:
+        pg.close()
+        vision.Close()
+    _report_issues(issues)
+    return results
+
+
+def _report_issues(issues: dict[str, dict[str, int]]) -> None:
+    if not issues:
+        return
+    print("\n*** WARNING: some cell values could not be copied faithfully "
+          "(stored NULL). This is NOT a clean verbatim copy: ***")
+    for table, cols in issues.items():
+        for col, n in cols.items():
+            print(f"    {table}.{col}: {n} value(s) failed coercion -> NULL")
+    print("    Investigate these columns; `verify` will also flag them.\n")
+
+
+def _open_table(vision_conn, table: str):
+    """Open a read-only forward-only recordset over one table."""
+    import win32com.client  # type: ignore
+
+    rs = win32com.client.Dispatch("ADODB.Recordset")
+    # Bracket-quote the source name: Vision has tables like `tblShip/Transport`
+    # and `Name AutoCorrect Save Failures` that need quoting.
+    rs.Open(f"SELECT * FROM [{table}]", vision_conn,
+            _AD_OPEN_FORWARD_ONLY, _AD_LOCK_READ_ONLY, _AD_CMD_TEXT)
+    return rs

--- a/backend/scripts/vision_migration/survey.py
+++ b/backend/scripts/vision_migration/survey.py
@@ -1,0 +1,110 @@
+"""Vision staging survey (read-only): what's migrated vs. what's left.
+
+Lists every staged table in the ``vision_legacy`` schema with its row count,
+flags the 13 tables the current CSV importer (``routes/migration.py``) consumes,
+and ranks the rest by size so the remaining migration scope is visible at a
+glance. Read-only; touches only the staging schema. This is the "how much is
+left to migrate" companion to the reconcile (parity) report.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from . import config
+
+SCHEMA = config.STAGING_SCHEMA
+
+# The 13 source tables the current importer (routes/migration.py) consumes.
+_MIGRATED_SOURCE_TABLES = {
+    "tblPartsCategories", "tblClients", "tblVendors", "tblMaterial",
+    "tblApplication", "tblZones", "tblProjects", "tblServiceRecords",
+    "tblWorkorderApplication", "tblWorkorderMaterial", "tblWorkorderZones",
+    "tblPurchaseOrders", "tblPurchaseOrdersMaterial",
+}
+
+
+def _all_tables(cur: Any) -> list[str]:
+    cur.execute(
+        "SELECT table_name FROM information_schema.tables "
+        "WHERE table_schema = %s ORDER BY table_name",
+        (SCHEMA,),
+    )
+    return [r["table_name"] for r in cur.fetchall()]
+
+
+def _count(cur: Any, table: str) -> int:
+    from psycopg2 import sql
+    cur.execute(sql.SQL("SELECT count(*) AS c FROM {}.{}").format(
+        sql.Identifier(SCHEMA), sql.Identifier(table)))
+    return cur.fetchone()["c"]
+
+
+def run_survey(url: str) -> dict[str, Any]:
+    """Print the migrated-vs-remaining survey and return a summary dict."""
+    import psycopg2.extras
+
+    conn = config.open_postgres(url)
+    summary: dict[str, Any] = {}
+    try:
+        conn.set_session(readonly=True, autocommit=True)
+        cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+
+        cur.execute(
+            "SELECT 1 FROM information_schema.schemata WHERE schema_name = %s",
+            (SCHEMA,),
+        )
+        if cur.fetchone() is None:
+            print(f"ERROR: staging schema '{SCHEMA}' not found. Run 'stage' first.")
+            return {"staged": False}
+
+        tables = _all_tables(cur)
+        rows = [(t, _count(cur, t), t in _MIGRATED_SOURCE_TABLES) for t in tables]
+
+        migrated = sorted([(t, c) for (t, c, m) in rows if m], key=lambda x: -x[1])
+        remaining_nonempty = sorted([(t, c) for (t, c, m) in rows if not m and c > 0],
+                                    key=lambda x: -x[1])
+        remaining_empty = sorted([t for (t, c, m) in rows if not m and c == 0])
+
+        migrated_rows = sum(c for _, c in migrated)
+        remaining_rows = sum(c for _, c in remaining_nonempty)
+
+        print("=" * 72)
+        print(f"Vision staging survey  schema='{SCHEMA}'  ({len(tables)} tables)")
+        print("=" * 72)
+
+        print(f"\n-- Migrated by the current importer ({len(migrated)} tables, "
+              f"{migrated_rows:,} rows) " + "-" * 6)
+        for t, c in migrated:
+            print(f"  {c:>10,}  {t}")
+
+        print(f"\n-- NOT migrated, non-empty ({len(remaining_nonempty)} tables, "
+              f"{remaining_rows:,} rows) " + "-" * 6)
+        for t, c in remaining_nonempty:
+            print(f"  {c:>10,}  {t}")
+
+        print(f"\n-- NOT migrated, empty ({len(remaining_empty)} tables) " + "-" * 20)
+        # wrap the empty-table names a few per line to keep it compact
+        line: list[str] = []
+        for t in remaining_empty:
+            line.append(t)
+            if len(line) == 3:
+                print("  " + ", ".join(line))
+                line = []
+        if line:
+            print("  " + ", ".join(line))
+
+        print("\n" + "=" * 72)
+        print(f"{len(migrated)} migrated / {len(remaining_nonempty)} remaining with data / "
+              f"{len(remaining_empty)} empty.")
+        print("=" * 72)
+
+        summary = {
+            "staged": True,
+            "table_count": len(tables),
+            "migrated": migrated,
+            "remaining_nonempty": remaining_nonempty,
+            "remaining_empty": remaining_empty,
+        }
+        return summary
+    finally:
+        conn.close()

--- a/backend/scripts/vision_migration/transform.py
+++ b/backend/scripts/vision_migration/transform.py
@@ -1,0 +1,325 @@
+"""Vision -> Velocity transform (compute side, quote domain).
+
+Pure, DB-free functions that map rows from the staged ``vision_legacy`` schema
+(see ``stage_raw.py``) into Velocity-shaped dictionaries. This is the *read /
+compute* half of the migration: it never writes to any application table and
+never opens a database session, so it is trivially unit-testable and cannot
+touch production.
+
+It intentionally MIRRORS the field mapping in ``backend/routes/migration.py``
+(the original CSV importer) so parity is auditable, with the deliberate
+correction the parity register flagged as G1 (``docs/MIGRATION_PARITY.md``):
+
+    G1 -- Quote close-state was hardcoded. The importer set every quote to
+    ``status="Closed"`` and every line to ``qty_fulfilled=quantity`` /
+    ``qty_pending=0``, so the whole migrated back-catalogue reports Closed even
+    though the real Vision ship quantities show ~43% of workorders were still
+    open. Here we read the real per-line ship fields
+    (``intTotalShippedQuantity`` / ``intShipQuantity`` / ``intQuantityBO``) and
+    derive ``qty_fulfilled`` / ``qty_pending`` from them. We do NOT set the
+    quote status ourselves -- the app's ``compute_quote_status`` derives it from
+    those line quantities at write time. Getting the quantities right is what
+    makes the status right.
+
+Pricing is carried verbatim (``curUnitPrice`` / ``curNetPrice`` /
+``curPrice``), exactly as the importer does. Markup / base-cost math stays the
+application's job (``calculate_base_cost`` in ``routes/quotes.py``) at write
+time and is never re-implemented here -- the pricing math is off-limits.
+
+Values coming out of ``vision_legacy`` are already typed (``stage_raw`` coerces
+Access types to Postgres types, so currency -> ``Decimal``, dates ->
+``datetime``, Access booleans -> ``bool``), but every helper below also tolerates
+raw strings so the same functions can be unit-tested with plain dict fixtures
+and reused against a CSV source if needed.
+
+This module is stdlib-only on purpose: it imports nothing from this package or
+from the FastAPI backend, so it can be imported (and its tests collected) on
+Linux CI where ``pywin32`` / ``psycopg2`` are not installed.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Optional
+
+
+# --------------------------------------------------------------------------- #
+# Coercion helpers -- pure, and tolerant of typed-or-string inputs.
+# --------------------------------------------------------------------------- #
+
+def to_str(val: Any, default: str = "") -> str:
+    """Stripped string, or ``default`` for None/blank."""
+    if val is None:
+        return default
+    s = str(val).strip()
+    return s or default
+
+
+def to_int(val: Any, default: int = 0) -> int:
+    """Parse to int. Blank/None -> ``default``. Floats/Decimals are rounded.
+
+    ``bool`` is handled explicitly because it is a subclass of ``int`` and we
+    want ``True`` -> 1 rather than a surprise elsewhere.
+    """
+    if val is None:
+        return default
+    if isinstance(val, bool):
+        return int(val)
+    if isinstance(val, int):
+        return val
+    if isinstance(val, (float, Decimal)):
+        return int(round(float(val)))
+    s = str(val).strip()
+    if not s:
+        return default
+    try:
+        return int(round(float(s)))
+    except (ValueError, TypeError):
+        return default
+
+
+def opt_int(val: Any) -> Optional[int]:
+    """Like :func:`to_int` but returns None (not 0) when the value is
+    absent/blank/unparseable. Used where "no value recorded" must be
+    distinguished from a real zero (e.g. ship quantities, legacy foreign keys).
+    """
+    if val is None:
+        return None
+    if isinstance(val, bool):
+        return int(val)
+    if isinstance(val, int):
+        return val
+    if isinstance(val, (float, Decimal)):
+        return int(round(float(val)))
+    s = str(val).strip()
+    if not s:
+        return None
+    try:
+        return int(round(float(s)))
+    except (ValueError, TypeError):
+        return None
+
+
+def to_float(val: Any, default: float = 0.0) -> float:
+    """Parse to float, handling ``Decimal`` (staged NUMERIC), currency symbols,
+    and accounting-style negatives ``(722.68)`` -> ``-722.68`` -- mirroring the
+    importer's ``clean_currency``.
+    """
+    if val is None:
+        return default
+    if isinstance(val, bool):
+        return float(val)
+    if isinstance(val, (int, float, Decimal)):
+        return float(val)
+    s = str(val).strip()
+    if not s:
+        return default
+    s = s.replace("$", "").replace(",", "").strip()
+    if not s:
+        return default
+    if s.startswith("(") and s.endswith(")"):
+        s = "-" + s[1:-1]
+    try:
+        return float(s)
+    except (ValueError, TypeError):
+        return default
+
+
+def to_bool(val: Any) -> Optional[bool]:
+    """Parse an Access boolean to True/False, or None if indeterminate.
+
+    Access stores TRUE as -1; staging maps it to a Postgres BOOLEAN, but we also
+    accept the raw ``-1`` / ``"-1"`` / ``"true"`` forms for fixtures.
+    """
+    if val is None:
+        return None
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, (int, float, Decimal)):
+        return bool(val)
+    s = str(val).strip().lower()
+    if s in ("1", "-1", "true", "yes", "y", "t"):
+        return True
+    if s in ("0", "false", "no", "n", "f"):
+        return False
+    return None
+
+
+_DATE_FORMATS = (
+    "%m/%d/%Y %H:%M:%S",
+    "%m/%d/%Y",
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%d",
+)
+
+
+def to_datetime(val: Any) -> Optional[datetime]:
+    """Pass a ``datetime`` through; parse Access date strings; else None."""
+    if val is None:
+        return None
+    if isinstance(val, datetime):
+        return val
+    s = str(val).strip()
+    if not s:
+        return None
+    for fmt in _DATE_FORMATS:
+        try:
+            return datetime.strptime(s, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def wo_prefixed_description(legacy_wo_id: int, raw_desc: Any) -> str:
+    """Prepend the legacy UC Vision work-order number as ``[WO {id}]``.
+
+    Mirrors ``routes.migration.wo_prefixed_description`` (Issue #54): in Vision
+    the WorkorderID was the human-facing quote number, so it is preserved at the
+    start of the migrated work description. A blank description collapses to just
+    the tag.
+    """
+    prefix = f"[WO {legacy_wo_id}]"
+    desc = to_str(raw_desc)
+    return f"{prefix} {desc}" if desc else prefix
+
+
+# --------------------------------------------------------------------------- #
+# Quote domain transform
+# --------------------------------------------------------------------------- #
+
+# ``item_type`` -> where that line type reads its fields FROM in the staged
+# workorder tables. labour = tblWorkorderApplication, part =
+# tblWorkorderMaterial, misc = tblWorkorderZones. The three tables share the
+# same shape except for the reference key, description column, and price column
+# -- matching how routes/migration.py reads them.
+_LINE_SPECS: dict[str, dict[str, str]] = {
+    "labor": {
+        "ref_key": "intProductName",
+        "ref_field": "labor_legacy_id",
+        "desc_key": "chrProductDescription",
+        "price_key": "curUnitPrice",
+    },
+    "part": {
+        "ref_key": "intProductName",
+        "ref_field": "part_legacy_id",
+        "desc_key": "chrProductDescription",
+        "price_key": "curUnitPrice",
+    },
+    "misc": {
+        "ref_key": "chrZones",
+        "ref_field": "misc_legacy_id",
+        "desc_key": "chrDistance",
+        "price_key": "curPrice",
+    },
+}
+
+# The source's own close-state labels (chrStatus text). Normalized lower-case.
+_CLOSED_STATUS_TOKENS = frozenset({"closed", "complete", "completed", "invoiced", "done"})
+_OPEN_STATUS_TOKENS = frozenset({"open", "active", "wip", "in progress", "pending"})
+
+
+def derive_line_fulfillment(row: dict[str, Any], quantity: int) -> Optional[tuple[int, int]]:
+    """Derive ``(qty_fulfilled, qty_pending)`` from the real Vision ship fields.
+
+    This is the heart of the G1 fix. Priority of signals:
+      1. ``intTotalShippedQuantity`` -- the running total shipped for the line.
+      2. ``intShipQuantity`` -- a single-shipment quantity, if the total is absent.
+      3. ``intQuantityBO`` (back-order) -- infer shipped = quantity - backordered.
+
+    Returns None if the row carries NONE of those fields (so the caller can tell
+    "no ship data recorded" apart from "zero shipped"). The result is clamped to
+    ``[0, quantity]`` so bad legacy data can't produce negative or over-fulfilled
+    quantities.
+    """
+    shipped = opt_int(row.get("intTotalShippedQuantity"))
+    if shipped is None:
+        shipped = opt_int(row.get("intShipQuantity"))
+    if shipped is None:
+        backordered = opt_int(row.get("intQuantityBO"))
+        if backordered is not None:
+            shipped = quantity - backordered
+    if shipped is None:
+        return None
+    shipped = max(0, min(shipped, quantity))
+    return shipped, quantity - shipped
+
+
+def transform_workorder_line(row: dict[str, Any], item_type: str) -> dict[str, Any]:
+    """Map one staged workorder-line row to a Velocity quote line-item dict.
+
+    ``item_type`` is one of ``"labor"`` / ``"part"`` / ``"misc"``. The returned
+    dict carries the *legacy* reference id (resolved to a Velocity id only at
+    write time) and the real fulfillment split. When the row has no ship data at
+    all, we default to fully PENDING and flag ``ship_data_present=False`` -- the
+    conservative choice (don't claim work was done when Vision didn't record it),
+    surfaced so the reconciler can report how much of the catalogue is uncertain.
+    """
+    if item_type not in _LINE_SPECS:
+        raise ValueError(f"unknown item_type {item_type!r}")
+    spec = _LINE_SPECS[item_type]
+
+    quantity = max(1, to_int(row.get("intQuantity"), default=1))
+    fulfillment = derive_line_fulfillment(row, quantity)
+    if fulfillment is None:
+        qty_fulfilled, qty_pending, ship_present = 0, quantity, False
+    else:
+        qty_fulfilled, qty_pending = fulfillment
+        ship_present = True
+
+    return {
+        "workorder_legacy_id": opt_int(row.get("intWorkorderID")),
+        "item_type": item_type,
+        spec["ref_field"]: opt_int(row.get(spec["ref_key"])),
+        "description": to_str(row.get(spec["desc_key"])) or None,
+        "quantity": quantity,
+        "unit_price": to_float(row.get(spec["price_key"])),
+        "base_cost": to_float(row.get("curNetPrice")),
+        "qty_fulfilled": qty_fulfilled,
+        "qty_pending": qty_pending,
+        "ship_data_present": ship_present,
+    }
+
+
+def workorder_source_closed(row: dict[str, Any]) -> Optional[bool]:
+    """The workorder's OWN declared close-state, from ``chrStatus`` +
+    ``blnForceClosed`` / ``blnAllShipped``.
+
+    Returns True/False, or None when the source declares nothing usable. This is
+    the source's *self-reported* label -- distinct from the state derived from
+    line ship quantities. The reconciler reports both and their disagreement, a
+    useful data-quality signal; the write-side status ultimately comes from the
+    quantities via ``compute_quote_status``.
+    """
+    if to_bool(row.get("blnForceClosed")) is True:
+        return True
+    if to_bool(row.get("blnAllShipped")) is True:
+        return True
+    status = to_str(row.get("chrStatus")).lower()
+    if status in _CLOSED_STATUS_TOKENS:
+        return True
+    if status in _OPEN_STATUS_TOKENS:
+        return False
+    return None
+
+
+def transform_workorder(row: dict[str, Any]) -> dict[str, Any]:
+    """Map one staged ``tblServiceRecords`` row to a Velocity quote header dict.
+
+    Status is intentionally NOT set: ``compute_quote_status`` derives it from the
+    line fulfillment quantities at write time (the G1 fix). The source's own
+    close-state labels are carried through as ``legacy_*`` fields for reporting
+    and as a searchable legacy reference. ``project_legacy_id`` reads the Vision
+    column ``PojectID`` -- the misspelling is in the source and is preserved.
+    """
+    legacy_wo_id = to_int(row.get("WorkorderID"))
+    return {
+        "workorder_legacy_id": legacy_wo_id,
+        "project_legacy_id": opt_int(row.get("PojectID")),
+        "created_at": to_datetime(row.get("dtmDateStarted")),
+        "work_description": wo_prefixed_description(legacy_wo_id, row.get("memWorkDescription")),
+        "quote_description": to_str(row.get("memQuoteDescription")) or None,
+        "client_po_number": to_str(row.get("intPONumber")) or None,
+        "legacy_status": to_str(row.get("chrStatus")) or None,
+        "legacy_force_closed": to_bool(row.get("blnForceClosed")),
+        "legacy_all_shipped": to_bool(row.get("blnAllShipped")),
+    }

--- a/backend/scripts/vision_migration/transform.py
+++ b/backend/scripts/vision_migration/transform.py
@@ -323,3 +323,232 @@ def transform_workorder(row: dict[str, Any]) -> dict[str, Any]:
         "legacy_force_closed": to_bool(row.get("blnForceClosed")),
         "legacy_all_shipped": to_bool(row.get("blnAllShipped")),
     }
+
+
+# --------------------------------------------------------------------------- #
+# Catalog domain (categories / parts / labour / misc)
+# --------------------------------------------------------------------------- #
+
+def transform_category(row: dict[str, Any]) -> list[dict[str, Any]]:
+    """tblPartsCategories -> Category(s). ``chrCategoryType`` selects the
+    Velocity catalog type: Application -> labor, Material -> part, and
+    "Application & Material" -> BOTH (the importer creates two Category rows).
+    Returns a list (0, 1, or 2 dicts) so the both-case is faithful.
+    """
+    legacy_id = opt_int(row.get("CategoryID"))
+    name = to_str(row.get("chrCategoryName")) or None
+    ctype = to_str(row.get("chrCategoryType"))
+    if not legacy_id or not name:
+        return []
+    if ctype == "Application":
+        return [{"category_legacy_id": legacy_id, "name": name, "type": "labor"}]
+    if ctype == "Material":
+        return [{"category_legacy_id": legacy_id, "name": name, "type": "part"}]
+    if ctype == "Application & Material":
+        return [
+            {"category_legacy_id": legacy_id, "name": name, "type": "part"},
+            {"category_legacy_id": legacy_id, "name": name, "type": "labor"},
+        ]
+    return []  # unknown type -> importer skips
+
+
+def transform_part(row: dict[str, Any]) -> dict[str, Any]:
+    """tblMaterial -> Part. ``skipped_lm`` flags an ``LM-`` combo part, which the
+    importer drops from the catalog (G7) -- workorder lines referencing it then
+    import detached (null part_id). Pricing (cost/markup) carried verbatim.
+    """
+    part_number = to_str(row.get("chrProductName")) or None
+    is_lm = bool(part_number and part_number.upper().startswith("LM-"))
+    return {
+        "part_legacy_id": opt_int(row.get("ProductID")),
+        "part_number": part_number,
+        "description": to_str(row.get("chrProductDescription")) or part_number,
+        "cost": to_float(row.get("curNetPrice")),
+        "markup_percent": to_float(row.get("intMarkup")),
+        "vendor_legacy_id": opt_int(row.get("intVendor")),
+        "category_legacy_id": opt_int(row.get("intCategory")),
+        "skipped_lm": is_lm,
+    }
+
+
+def transform_labor(row: dict[str, Any]) -> dict[str, Any]:
+    """tblApplication -> Labor. Rate is derived as net_price / hours when hours
+    are present (else the net price is treated as the rate for a 1-hour unit),
+    mirroring the importer."""
+    hours_raw = to_float(row.get("intTime"))
+    net_price = to_float(row.get("curNetPrice"))
+    if hours_raw > 0:
+        rate, hours = net_price / hours_raw, hours_raw
+    else:
+        rate, hours = net_price, 1.0
+    return {
+        "labor_legacy_id": opt_int(row.get("ProductID")),
+        "description": to_str(row.get("chrProductDescription")) or None,
+        "hours": hours,
+        "rate": rate,
+        "markup_percent": to_float(row.get("intMarkup")),
+        "category_legacy_id": opt_int(row.get("intCategory")),
+    }
+
+
+def transform_misc(row: dict[str, Any]) -> dict[str, Any]:
+    """tblZones -> Miscellaneous. Description is assembled from zone + distance."""
+    legacy_id = opt_int(row.get("ZoneRateID"))
+    zone = to_str(row.get("chrZones"))
+    distance = to_str(row.get("chrDistance"))
+    if zone and distance:
+        desc = f"{zone} - {distance}"
+    elif distance:
+        desc = distance
+    elif zone:
+        desc = zone
+    else:
+        desc = f"Zone {legacy_id}"
+    return {
+        "misc_legacy_id": legacy_id,
+        "description": desc,
+        "unit_price": to_float(row.get("curNetPrice")),
+        "markup_percent": to_float(row.get("intMarkup")),
+        "is_system_item": False,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Profiles (customers / vendors) + contacts
+# --------------------------------------------------------------------------- #
+
+def _contact(name: str, title: Any, email: Any, phone: Any, cell: Any) -> dict[str, Any]:
+    return {
+        "name": name,
+        "job_title": to_str(title) or None,
+        "email": to_str(email) or None,
+        "phone": to_str(phone) or None,   # -> ContactPhone(work)
+        "cell": to_str(cell) or None,     # -> ContactPhone(mobile)
+    }
+
+
+def transform_profile(row: dict[str, Any], profile_type: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """tblClients ('customer') / tblVendors ('vendor') -> (profile_dict, contacts).
+
+    Mirrors the importer: PST from chrProvincialTax, address assembled from
+    address/city/province, blank company name -> "Unknown {Type} {id}". Customers
+    can carry a second contact; vendors carry one.
+    """
+    if profile_type == "customer":
+        legacy_id = opt_int(row.get("Client ID"))
+        id_field = "customer_legacy_id"
+        fallback = f"Unknown Customer {legacy_id}"
+    elif profile_type == "vendor":
+        legacy_id = opt_int(row.get("VendorID"))
+        id_field = "vendor_legacy_id"
+        fallback = f"Unknown Vendor {legacy_id}"
+    else:
+        raise ValueError(f"unknown profile_type {profile_type!r}")
+
+    name = to_str(row.get("chrCompanyName")) or fallback
+    address = ", ".join(p for p in (
+        to_str(row.get("chrAddress")), to_str(row.get("chrCity")), to_str(row.get("chrProvince")),
+    ) if p)
+    profile = {
+        id_field: legacy_id,
+        "type": profile_type,
+        "name": name,
+        "pst": to_str(row.get("chrProvincialTax")),
+        "address": address,
+        "postal_code": to_str(row.get("chrPostalCode")),
+    }
+
+    contacts: list[dict[str, Any]] = []
+    name1 = f"{to_str(row.get('chrFirstName'))} {to_str(row.get('chrLastName'))}".strip()
+    if name1:
+        if profile_type == "customer":
+            contacts.append(_contact(name1, row.get("chrTitle"), row.get("chrEmailAddress"),
+                                     row.get("chrPhoneNumber"), row.get("chrCell")))
+        else:
+            # Vendors get a REDUCED contact, mirroring the importer: name +
+            # quote-stripped email + work phone only (no job_title, no mobile).
+            contacts.append({
+                "name": name1,
+                "job_title": None,
+                "email": to_str(row.get("chrEmailAddress")).strip("'") or None,
+                "phone": to_str(row.get("chrPhoneNumber")) or None,
+                "cell": None,
+            })
+    if profile_type == "customer":
+        name2 = f"{to_str(row.get('chrFirstName2'))} {to_str(row.get('chrLastName2'))}".strip()
+        if name2:
+            contacts.append(_contact(name2, row.get("chrTitle2"), row.get("chrEmailAddress2"),
+                                     row.get("chrPhoneNumber2"), row.get("chrCell2")))
+    return profile, contacts
+
+
+# --------------------------------------------------------------------------- #
+# Projects
+# --------------------------------------------------------------------------- #
+
+def transform_project(row: dict[str, Any]) -> dict[str, Any]:
+    """tblProjects -> Project. UCA number is reformatted to A#### (padded) when
+    numeric; blnArchive -> status. Duplicate-UCA and client-resolution handling
+    is stateful, so it stays in the reconciler/sync, not this per-row function.
+
+    Status reads the real staged BOOLEAN via ``to_bool`` (staging maps Access
+    boolean -> Postgres BOOLEAN). The importer compared the CSV string
+    ``== "1"``, which is fragile for other boolean encodings; reading the actual
+    boolean is the correct source semantics -- a deliberate, documented divergence.
+    """
+    legacy_id = opt_int(row.get("ProjectID"))
+    uca_raw = to_str(row.get("UCAProjectNr")) or (str(legacy_id) if legacy_id else "")
+    try:
+        uca = f"A{int(uca_raw):04d}"
+    except ValueError:
+        uca = uca_raw  # already prefixed or non-numeric
+    return {
+        "project_legacy_id": legacy_id,
+        "name": to_str(row.get("ProjectName")) or (f"Project {legacy_id}" if legacy_id else None),
+        "client_legacy_id": opt_int(row.get("ClientID")),
+        "uca_project_number": uca or None,
+        "ucsh_project_number": to_str(row.get("UCSHProjectNr")) or None,
+        "created_on": to_datetime(row.get("dtmStartDate")),
+        "status": "archived" if to_bool(row.get("blnArchive")) else "active",
+        "project_lead": to_str(row.get("EmployeeID")) or None,  # a name string, not an FK
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Purchase orders (G2: derive close-state instead of hardcoding closed)
+# --------------------------------------------------------------------------- #
+
+def transform_po(row: dict[str, Any]) -> dict[str, Any]:
+    """tblPurchaseOrders -> PurchaseOrder header. Status is NOT hardcoded closed
+    (G2): the source's ``blnRecievedAll`` (sic -- Vision's misspelling) is carried
+    as ``legacy_received_all``, and the true open/closed state is derived from the
+    PO lines' received quantities by the reconciler/sync.
+    """
+    return {
+        "po_legacy_id": opt_int(row.get("PurchaseOrderID")),
+        "project_legacy_id": opt_int(row.get("intProjectID")),
+        "vendor_legacy_id": opt_int(row.get("intVendorID")),
+        "created_at": to_datetime(row.get("dtmOrderDate")),
+        "work_description": to_str(row.get("memNote")) or None,
+        "legacy_received_all": to_bool(row.get("blnRecievedAll")),
+    }
+
+
+def transform_po_line(row: dict[str, Any]) -> dict[str, Any]:
+    """tblPurchaseOrdersMaterial -> POLineItem. qty_received sums the three Vision
+    receipt columns; qty_pending is the shortfall (mirrors the importer, which
+    already reads these -- unlike the PO status)."""
+    quantity = max(1, to_int(row.get("intQtyOrdered"), default=1))
+    received = (to_int(row.get("intQtyReceived1"))
+                + to_int(row.get("intQtyReceived2"))
+                + to_int(row.get("intQtyReceived3")))
+    return {
+        "po_legacy_id": opt_int(row.get("intPurchaseOrderID")),
+        "item_type": "part",
+        "part_legacy_id": opt_int(row.get("intProductID")),
+        "description": to_str(row.get("chrProductDescription")) or None,
+        "quantity": quantity,
+        "unit_price": to_float(row.get("curUnitPrice")),
+        "qty_received": received,
+        "qty_pending": max(0, quantity - received),
+    }

--- a/backend/scripts/vision_migration/verify_staging.py
+++ b/backend/scripts/vision_migration/verify_staging.py
@@ -1,0 +1,129 @@
+"""Load-verification harness: prove the raw staging copied faithfully.
+
+For every staged table it compares, between Access and `vision_legacy`:
+  - the total row count, AND
+  - the per-column NON-NULL count.
+
+Row counts alone can't catch content loss (a value coerced to NULL, or a blob
+that failed to copy, doesn't change COUNT(*)). Comparing per-column non-null
+counts does: if staging dropped a cell to NULL, that column's non-null count
+falls below the source and the table is flagged MISMATCH.
+
+The full Vision<->Velocity parity diff (which needs the Stage-B sync) is added in
+a later package but builds on the same idea: compare the two sides that now live
+in one database.
+"""
+from __future__ import annotations
+
+from . import config
+
+_AD_OPEN_FORWARD_ONLY = 0
+_AD_LOCK_READ_ONLY = 1
+_AD_CMD_TEXT = 1
+
+
+def _staged_tables(pg_cur) -> list[str]:
+    pg_cur.execute(
+        "SELECT table_name FROM information_schema.tables "
+        "WHERE table_schema = %s ORDER BY table_name;",
+        (config.STAGING_SCHEMA,),
+    )
+    return [r[0] for r in pg_cur.fetchall()]
+
+
+def _staged_columns(pg_cur, table: str) -> list[str]:
+    pg_cur.execute(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_schema = %s AND table_name = %s ORDER BY ordinal_position;",
+        (config.STAGING_SCHEMA, table),
+    )
+    return [r[0] for r in pg_cur.fetchall()]
+
+
+def _staged_counts(pg_cur, table: str, columns: list[str]) -> tuple[int, dict[str, int]]:
+    """Total rows + non-null count per column, in one query."""
+    from psycopg2 import sql  # type: ignore
+
+    selects = [sql.SQL("COUNT(*)")]
+    selects += [sql.SQL("COUNT({})").format(sql.Identifier(c)) for c in columns]
+    query = sql.SQL("SELECT {} FROM {}").format(
+        sql.SQL(", ").join(selects),
+        sql.Identifier(config.STAGING_SCHEMA, table),
+    )
+    pg_cur.execute(query)
+    row = pg_cur.fetchone()
+    return int(row[0]), {c: int(row[i + 1]) for i, c in enumerate(columns)}
+
+
+def _vision_counts(vision_conn, table: str, columns: list[str]) -> tuple[int, dict[str, int], bool]:
+    """Total rows + non-null count per column from Access.
+
+    Returns (total, {col: non_null}, columns_checked). Falls back to total-only
+    (columns_checked=False) if Access rejects a per-column COUNT (e.g. on some OLE
+    column type) -- so we never crash the whole verify over one odd column.
+    """
+    import win32com.client  # type: ignore
+
+    def run(query: str, ncols: int):
+        rs = win32com.client.Dispatch("ADODB.Recordset")
+        rs.Open(query, vision_conn, _AD_OPEN_FORWARD_ONLY, _AD_LOCK_READ_ONLY, _AD_CMD_TEXT)
+        try:
+            return [rs.Fields.Item(i).Value for i in range(ncols)]
+        finally:
+            rs.Close()
+
+    if columns:
+        cols_sql = ", ".join(f"COUNT([{c}])" for c in columns)
+        try:
+            vals = run(f"SELECT COUNT(*), {cols_sql} FROM [{table}]", len(columns) + 1)
+            return int(vals[0]), {c: int(vals[i + 1]) for i, c in enumerate(columns)}, True
+        except Exception:
+            pass  # fall through to total-only
+    vals = run(f"SELECT COUNT(*) FROM [{table}]", 1)
+    return int(vals[0]), {}, False
+
+
+def verify(mdb_path: str, workgroup_path: str, target_url: str) -> bool:
+    """Compare source vs staged (rows + per-column non-null). Returns True if all match."""
+    vision = config.open_vision(mdb_path, workgroup_path)
+    pg = config.open_postgres(target_url)
+    ok = True
+    try:
+        with pg.cursor() as cur:
+            staged = _staged_tables(cur)
+            if not staged:
+                print(f"No tables found in schema '{config.STAGING_SCHEMA}'. "
+                      "Run `stage` first.")
+                return False
+            print(f"{'table':40} {'vision':>10} {'staged':>10}  status")
+            print("-" * 74)
+            for table in staged:
+                columns = _staged_columns(cur, table)
+                s_total, s_cols = _staged_counts(cur, table, columns)
+                v_total, v_cols, cols_checked = _vision_counts(vision, table, columns)
+
+                row_match = s_total == v_total
+                col_mismatches = (
+                    [c for c in columns if s_cols.get(c) != v_cols.get(c)]
+                    if cols_checked else []
+                )
+                match = row_match and not col_mismatches
+                ok = ok and match
+
+                status = "OK" if match else "MISMATCH"
+                detail = ""
+                if not row_match:
+                    detail = f"  rows {v_total}->{s_total}"
+                elif col_mismatches:
+                    shown = ", ".join(col_mismatches[:5])
+                    more = "..." if len(col_mismatches) > 5 else ""
+                    detail = f"  non-null cols differ: {shown}{more}"
+                if not cols_checked:
+                    detail += "  (col-level check skipped)"
+                print(f"{table:40} {v_total:>10} {s_total:>10}  {status}{detail}")
+    finally:
+        pg.close()
+        vision.Close()
+    print("-" * 74)
+    print("ALL TABLES MATCH" if ok else "MISMATCHES FOUND (see above)")
+    return ok

--- a/backend/tests/test_vision_transform.py
+++ b/backend/tests/test_vision_transform.py
@@ -1,0 +1,218 @@
+"""Unit tests for the Vision -> Velocity transform (compute side).
+
+These exercise the pure mapping functions in
+``scripts.vision_migration.transform`` with plain dict fixtures -- no database
+and no ``pywin32`` -- so they run locally and on Linux CI. Fixtures use the
+Python types the staged ``vision_legacy`` schema actually returns (``Decimal``
+for currency, ``datetime`` for dates, ``bool`` for Access booleans) as well as
+raw strings, to prove the coercion helpers tolerate both.
+
+The headline behaviour under test is the G1 correction: a partially-shipped
+workorder line must derive ``qty_pending > 0`` from the real ship fields, rather
+than being forced fully-fulfilled the way the original CSV importer did.
+"""
+from datetime import datetime
+from decimal import Decimal
+
+from scripts.vision_migration import transform as t
+
+
+# --------------------------------------------------------------------------- #
+# Coercion helpers
+# --------------------------------------------------------------------------- #
+
+def test_to_int_rounds_and_defaults():
+    assert t.to_int("5") == 5
+    assert t.to_int(Decimal("4.6")) == 5
+    assert t.to_int(3.2) == 3
+    assert t.to_int(None) == 0
+    assert t.to_int("", default=7) == 7
+    assert t.to_int("garbage", default=-1) == -1
+    assert t.to_int(True) == 1  # bool handled explicitly
+
+
+def test_opt_int_distinguishes_zero_from_missing():
+    # The key property: a real 0 stays 0, but absent/blank -> None.
+    assert t.opt_int(0) == 0
+    assert t.opt_int("0") == 0
+    assert t.opt_int(None) is None
+    assert t.opt_int("") is None
+    assert t.opt_int("   ") is None
+    assert t.opt_int("nope") is None
+
+
+def test_to_float_handles_decimal_currency_and_accounting_negatives():
+    assert t.to_float(Decimal("12.50")) == 12.5
+    assert t.to_float("$1,234.56") == 1234.56
+    assert t.to_float("(722.68)") == -722.68  # accounting-style negative
+    assert t.to_float(None) == 0.0
+    assert t.to_float("") == 0.0
+
+
+def test_to_bool_access_style():
+    assert t.to_bool(True) is True
+    assert t.to_bool(-1) is True   # Access TRUE is -1
+    assert t.to_bool("-1") is True
+    assert t.to_bool(0) is False
+    assert t.to_bool("false") is False
+    assert t.to_bool(None) is None
+    assert t.to_bool("maybe") is None
+
+
+def test_to_datetime_passthrough_and_parse():
+    dt = datetime(2004, 11, 12)
+    assert t.to_datetime(dt) is dt
+    assert t.to_datetime("11/12/2004 0:00:00") == datetime(2004, 11, 12)
+    assert t.to_datetime("2004-11-12") == datetime(2004, 11, 12)
+    assert t.to_datetime(None) is None
+    assert t.to_datetime("not a date") is None
+
+
+def test_wo_prefixed_description_matches_importer_behaviour():
+    # Mirrors backend/tests/test_migration_import.py to keep parity auditable.
+    assert t.wo_prefixed_description(29, "Install switches") == "[WO 29] Install switches"
+    assert t.wo_prefixed_description(29, "  \n Arrive \n ") == "[WO 29] Arrive"
+    assert t.wo_prefixed_description(29, "") == "[WO 29]"
+    assert t.wo_prefixed_description(7, None) == "[WO 7]"
+
+
+# --------------------------------------------------------------------------- #
+# derive_line_fulfillment (the G1 core)
+# --------------------------------------------------------------------------- #
+
+def test_fulfillment_from_total_shipped_partial():
+    assert t.derive_line_fulfillment({"intTotalShippedQuantity": 3}, 10) == (3, 7)
+
+
+def test_fulfillment_falls_back_to_ship_quantity():
+    assert t.derive_line_fulfillment({"intShipQuantity": 4}, 10) == (4, 6)
+
+
+def test_fulfillment_infers_from_backorder():
+    # No shipped fields, but back-order says 2 of 10 remain -> 8 shipped.
+    assert t.derive_line_fulfillment({"intQuantityBO": 2}, 10) == (8, 2)
+
+
+def test_fulfillment_none_when_no_ship_data():
+    assert t.derive_line_fulfillment({}, 10) is None
+
+
+def test_fulfillment_clamps_out_of_range():
+    # Over-shipped legacy data clamps to quantity; garbage negatives clamp to 0.
+    assert t.derive_line_fulfillment({"intTotalShippedQuantity": 99}, 10) == (10, 0)
+    assert t.derive_line_fulfillment({"intQuantityBO": 99}, 10) == (0, 10)
+
+
+def test_fulfillment_prefers_total_over_ship_and_bo():
+    row = {"intTotalShippedQuantity": 5, "intShipQuantity": 1, "intQuantityBO": 9}
+    assert t.derive_line_fulfillment(row, 10) == (5, 5)
+
+
+# --------------------------------------------------------------------------- #
+# transform_workorder_line
+# --------------------------------------------------------------------------- #
+
+def test_labor_line_partial_ship_is_the_g1_fix():
+    """A partially-shipped labour line yields pending qty -- the whole point.
+
+    The original importer would have written qty_fulfilled=10, qty_pending=0.
+    """
+    row = {
+        "intWorkorderID": 42,
+        "intProductName": 7,
+        "chrProductDescription": "Install hinges",
+        "intQuantity": 10,
+        "curUnitPrice": Decimal("25.00"),
+        "curNetPrice": Decimal("18.00"),
+        "intTotalShippedQuantity": 3,
+    }
+    line = t.transform_workorder_line(row, "labor")
+    assert line["item_type"] == "labor"
+    assert line["workorder_legacy_id"] == 42
+    assert line["labor_legacy_id"] == 7
+    assert line["description"] == "Install hinges"
+    assert line["quantity"] == 10
+    assert line["unit_price"] == 25.0
+    assert line["base_cost"] == 18.0
+    assert line["qty_fulfilled"] == 3
+    assert line["qty_pending"] == 7
+    assert line["ship_data_present"] is True
+
+
+def test_line_no_ship_data_defaults_fully_pending():
+    row = {"intWorkorderID": 1, "intProductName": 2, "intQuantity": 4, "curUnitPrice": "10", "curNetPrice": "8"}
+    line = t.transform_workorder_line(row, "part")
+    assert line["item_type"] == "part"
+    assert line["part_legacy_id"] == 2
+    assert line["qty_fulfilled"] == 0
+    assert line["qty_pending"] == 4
+    assert line["ship_data_present"] is False
+
+
+def test_line_fully_shipped_is_fully_fulfilled():
+    row = {"intWorkorderID": 1, "intQuantity": 4, "intTotalShippedQuantity": 4}
+    line = t.transform_workorder_line(row, "labor")
+    assert line["qty_fulfilled"] == 4
+    assert line["qty_pending"] == 0
+
+
+def test_misc_line_uses_zone_and_distance_and_price_columns():
+    row = {
+        "intWorkorderID": 5,
+        "chrZones": 12,          # misc reference key is chrZones
+        "chrDistance": "0-50km", # misc description column
+        "intQuantity": 1,
+        "curPrice": Decimal("40.00"),  # misc price column is curPrice, not curUnitPrice
+        "curNetPrice": Decimal("30.00"),
+        "intTotalShippedQuantity": 1,
+    }
+    line = t.transform_workorder_line(row, "misc")
+    assert line["misc_legacy_id"] == 12
+    assert line["description"] == "0-50km"
+    assert line["unit_price"] == 40.0
+    assert line["base_cost"] == 30.0
+
+
+def test_quantity_floors_at_one():
+    row = {"intWorkorderID": 1, "intQuantity": 0, "intTotalShippedQuantity": 0}
+    line = t.transform_workorder_line(row, "labor")
+    assert line["quantity"] == 1
+
+
+def test_unknown_item_type_raises():
+    try:
+        t.transform_workorder_line({}, "widget")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError for unknown item_type")
+
+
+# --------------------------------------------------------------------------- #
+# transform_workorder (quote header)
+# --------------------------------------------------------------------------- #
+
+def test_workorder_header_does_not_hardcode_status():
+    row = {
+        "WorkorderID": 29,
+        "PojectID": 100,  # sic: Vision's misspelling, preserved
+        "dtmDateStarted": datetime(2004, 11, 12),
+        "memWorkDescription": "Install 2 hidden switches",
+        "chrStatus": "Open",
+    }
+    quote = t.transform_workorder(row)
+    assert "status" not in quote  # G1: status is NEVER hardcoded here
+    assert quote["workorder_legacy_id"] == 29
+    assert quote["project_legacy_id"] == 100
+    assert quote["created_at"] == datetime(2004, 11, 12)
+    assert quote["work_description"] == "[WO 29] Install 2 hidden switches"
+    assert quote["legacy_status"] == "Open"
+
+
+def test_workorder_source_closed_reads_flags_and_status():
+    assert t.workorder_source_closed({"blnForceClosed": True}) is True
+    assert t.workorder_source_closed({"blnAllShipped": -1}) is True   # Access TRUE
+    assert t.workorder_source_closed({"chrStatus": "Closed"}) is True
+    assert t.workorder_source_closed({"chrStatus": "Open"}) is False
+    assert t.workorder_source_closed({"chrStatus": "???"}) is None
+    assert t.workorder_source_closed({}) is None

--- a/backend/tests/test_vision_transform.py
+++ b/backend/tests/test_vision_transform.py
@@ -216,3 +216,130 @@ def test_workorder_source_closed_reads_flags_and_status():
     assert t.workorder_source_closed({"chrStatus": "Open"}) is False
     assert t.workorder_source_closed({"chrStatus": "???"}) is None
     assert t.workorder_source_closed({}) is None
+
+
+# --------------------------------------------------------------------------- #
+# Catalog domain
+# --------------------------------------------------------------------------- #
+
+def test_category_type_split():
+    assert t.transform_category({"CategoryID": 1, "chrCategoryName": "Locks", "chrCategoryType": "Application"}) == \
+        [{"category_legacy_id": 1, "name": "Locks", "type": "labor"}]
+    assert t.transform_category({"CategoryID": 2, "chrCategoryName": "Doors", "chrCategoryType": "Material"}) == \
+        [{"category_legacy_id": 2, "name": "Doors", "type": "part"}]
+    both = t.transform_category({"CategoryID": 3, "chrCategoryName": "X", "chrCategoryType": "Application & Material"})
+    assert [c["type"] for c in both] == ["part", "labor"]
+    assert t.transform_category({"CategoryID": 4, "chrCategoryName": "Y", "chrCategoryType": "???"}) == []
+    assert t.transform_category({"CategoryID": None, "chrCategoryName": "Z", "chrCategoryType": "Material"}) == []
+
+
+def test_part_flags_lm_and_carries_pricing_verbatim():
+    normal = t.transform_part({"ProductID": 10, "chrProductName": "HN-100",
+                               "chrProductDescription": "Hinge", "curNetPrice": Decimal("12.50"),
+                               "intMarkup": 40, "intVendor": 3, "intCategory": 2})
+    assert normal["part_legacy_id"] == 10
+    assert normal["cost"] == 12.5
+    assert normal["markup_percent"] == 40.0
+    assert normal["skipped_lm"] is False
+    lm = t.transform_part({"ProductID": 11, "chrProductName": "LM-COMBO", "curNetPrice": "5"})
+    assert lm["skipped_lm"] is True  # importer drops these from the catalog (G7)
+
+
+def test_labor_rate_derivation():
+    with_hours = t.transform_labor({"ProductID": 1, "chrProductDescription": "Install",
+                                    "intTime": 2, "curNetPrice": Decimal("100.00"), "intMarkup": 0})
+    assert with_hours["hours"] == 2.0
+    assert with_hours["rate"] == 50.0  # net / hours
+    zero_hours = t.transform_labor({"ProductID": 2, "chrProductDescription": "Flat",
+                                    "intTime": 0, "curNetPrice": Decimal("75.00")})
+    assert zero_hours["hours"] == 1.0
+    assert zero_hours["rate"] == 75.0  # net treated as the rate
+
+
+def test_misc_description_assembly():
+    assert t.transform_misc({"ZoneRateID": 1, "chrZones": "A", "chrDistance": "0-50km",
+                             "curNetPrice": Decimal("40")})["description"] == "A - 0-50km"
+    assert t.transform_misc({"ZoneRateID": 2, "chrDistance": "50-100km"})["description"] == "50-100km"
+    assert t.transform_misc({"ZoneRateID": 3})["description"] == "Zone 3"
+
+
+# --------------------------------------------------------------------------- #
+# Profiles
+# --------------------------------------------------------------------------- #
+
+def test_customer_profile_with_two_contacts_and_address():
+    profile, contacts = t.transform_profile({
+        "Client ID": 5, "chrCompanyName": "Acme", "chrProvincialTax": "12345",
+        "chrAddress": "1 Main", "chrCity": "Town", "chrProvince": "ON", "chrPostalCode": "A1A1A1",
+        "chrFirstName": "Jane", "chrLastName": "Doe", "chrTitle": "Buyer",
+        "chrEmailAddress": "j@x.com", "chrPhoneNumber": "555-1", "chrCell": "555-2",
+        "chrFirstName2": "Sam", "chrLastName2": "Roe",
+    }, "customer")
+    assert profile["customer_legacy_id"] == 5
+    assert profile["type"] == "customer"
+    assert profile["pst"] == "12345"
+    assert profile["address"] == "1 Main, Town, ON"
+    assert len(contacts) == 2
+    assert contacts[0]["name"] == "Jane Doe"
+    assert contacts[0]["phone"] == "555-1" and contacts[0]["cell"] == "555-2"
+    assert contacts[1]["name"] == "Sam Roe"
+
+
+def test_vendor_profile_blank_name_fallback_single_contact():
+    profile, contacts = t.transform_profile({
+        "VendorID": 9, "chrCompanyName": "", "chrFirstName": "Pat", "chrLastName": "Lee",
+    }, "vendor")
+    assert profile["vendor_legacy_id"] == 9
+    assert profile["name"] == "Unknown Vendor 9"
+    assert profile["type"] == "vendor"
+    assert len(contacts) == 1 and contacts[0]["name"] == "Pat Lee"
+
+
+def test_profile_unknown_type_raises():
+    try:
+        t.transform_profile({}, "staff")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError for unknown profile_type")
+
+
+# --------------------------------------------------------------------------- #
+# Projects
+# --------------------------------------------------------------------------- #
+
+def test_project_uca_padding_and_archive_status():
+    p = t.transform_project({"ProjectID": 7, "ProjectName": "Job", "ClientID": 5,
+                             "UCAProjectNr": "42", "blnArchive": True})
+    assert p["uca_project_number"] == "A0042"
+    assert p["client_legacy_id"] == 5
+    assert p["status"] == "archived"
+    # non-numeric UCA passes through; not archived
+    p2 = t.transform_project({"ProjectID": 8, "UCAProjectNr": "A9999", "blnArchive": 0})
+    assert p2["uca_project_number"] == "A9999"
+    assert p2["status"] == "active"
+
+
+# --------------------------------------------------------------------------- #
+# Purchase orders (G2)
+# --------------------------------------------------------------------------- #
+
+def test_po_header_does_not_hardcode_status():
+    po = t.transform_po({"PurchaseOrderID": 3, "intProjectID": 7, "intVendorID": 9,
+                         "memNote": "rush", "blnRecievedAll": False})
+    assert "status" not in po  # G2: never hardcoded closed
+    assert po["po_legacy_id"] == 3
+    assert po["legacy_received_all"] is False
+
+
+def test_po_line_sums_receipts_and_computes_pending():
+    line = t.transform_po_line({"intPurchaseOrderID": 3, "intProductID": 10,
+                                "intQtyOrdered": 10, "curUnitPrice": Decimal("4.00"),
+                                "intQtyReceived1": 2, "intQtyReceived2": 3, "intQtyReceived3": 0})
+    assert line["quantity"] == 10
+    assert line["qty_received"] == 5
+    assert line["qty_pending"] == 5
+    # fully received -> no pending
+    full = t.transform_po_line({"intPurchaseOrderID": 3, "intQtyOrdered": 4,
+                                "intQtyReceived1": 4})
+    assert full["qty_received"] == 4 and full["qty_pending"] == 0


### PR DESCRIPTION
Stacked on #189 (base `feat/vision-raw-staging`) — depends on PKG 1's staging package. ⚠️ **No CI until #189 merges and this retargets to master** (ci.yml only triggers on PRs to master); verified locally.

The Vision→Velocity **parity tooling** (compute side): turn staged Vision data into Velocity-shaped records and quantify every migration gap across all 13 migrated tables. Read-only, writes nothing, adds no migration.

**Commands** (`python -m vision_migration …`; reads `MIGRATION_DATABASE_URL`, refuses prod-looking hosts):
- **`reconcile`** — the parity report (Diff A): per-domain coverage vs the importer's transitive survivor set (client→project→quote/PO), plus the two headline gaps —
  - **G1** (quotes): importer marks all 8,338 migrating quotes Closed; **~4,201 (50%) were actually open** (derived from the real per-line ship fields).
  - **G2** (POs): importer marks all 175 `closed`; **~68 were still open** (derived from real receipts).
  - Also surfaces LM- detached lines (3,409 quote lines), orphan refs (214 parts→vendor, 132 PO lines→part, 26/30 quote misc/part), and catalog/profile/project coverage. Clean slot for **Diff B** (vs live Velocity — needs a read-only export).
- **`survey`** — staged tables with row counts: migrated (13) vs remaining (54 non-empty / 2 empty), so the remaining scope is visible.

**How it maps:** `transform.py` mirrors `routes/migration.py` field-for-field with the deliberate **G1/G2/G7** corrections; status is left to `compute_quote_status`/receipts at write time, never hardcoded. **Pricing carried verbatim (math untouched).**

**Safety / scope:** local CLI, off the deployed backend; read-only session, only ever reads the `vision_legacy` schema; no app routes/models/pricing changed. `transform.py` is stdlib-only, so its **30 unit tests run in CI**.

**Test:** `cd backend && pytest tests/test_vision_transform.py` (30 pass); `python -m vision_migration reconcile --database-url <scratch>` prints the full report; `python -m vision_migration survey --database-url <scratch>` prints the table survey.
