### PR TITLE
chore(lint): clear frontend eslint debt + enforce lint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
         run: npx tsc -b
 
       - name: Lint
-        continue-on-error: true
         run: npm run lint
 
       - name: Build

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -20,4 +20,13 @@ export default defineConfig([
       globals: globals.browser,
     },
   },
+  {
+    // shadcn UI primitives and the theme provider intentionally co-export
+    // helpers/hooks alongside their component (cva variants, useTheme); Fast
+    // Refresh isn't a concern for these library-style files.
+    files: ['src/components/ui/**/*.{ts,tsx}', 'src/components/theme-provider.tsx'],
+    rules: {
+      'react-refresh/only-export-components': 'off',
+    },
+  },
 ])

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -22,7 +22,8 @@ export default defineConfig([
   },
   {
     // Turns off react-refresh/only-export-components for the shadcn UI
-    // primitives and the theme-provider.
+    // primitives + theme-provider -- they intentionally co-export variants/hooks
+    // beside their component, so this Fast-Refresh guard doesn't apply.
     files: ['src/components/ui/**/*.{ts,tsx}', 'src/components/theme-provider.tsx'],
     rules: {
       'react-refresh/only-export-components': 'off',

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -21,9 +21,8 @@ export default defineConfig([
     },
   },
   {
-    // shadcn UI primitives and the theme provider intentionally co-export
-    // helpers/hooks alongside their component (cva variants, useTheme); Fast
-    // Refresh isn't a concern for these library-style files.
+    // Turns off react-refresh/only-export-components for the shadcn UI
+    // primitives and the theme-provider.
     files: ['src/components/ui/**/*.{ts,tsx}', 'src/components/theme-provider.tsx'],
     rules: {
       'react-refresh/only-export-components': 'off',

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -88,7 +88,7 @@ async function request<T>(
     if (typeof error.detail === 'string') {
       message = error.detail;
     } else if (Array.isArray(error.detail)) {
-      message = error.detail.map((e: any) => e.msg).join('; ');
+      message = error.detail.map((e: { msg?: string }) => e.msg).join('; ');
     }
     throw new Error(message);
   }
@@ -408,7 +408,7 @@ export const api = {
         if (typeof error.detail === 'string') {
           message = error.detail;
         } else if (Array.isArray(error.detail)) {
-          message = error.detail.map((e: any) => e.msg).join('; ');
+          message = error.detail.map((e: { msg?: string }) => e.msg).join('; ');
         }
         throw new Error(message);
       }
@@ -432,7 +432,7 @@ export const api = {
         if (typeof error.detail === 'string') {
           message = error.detail;
         } else if (Array.isArray(error.detail)) {
-          message = error.detail.map((e: any) => e.msg).join('; ');
+          message = error.detail.map((e: { msg?: string }) => e.msg).join('; ');
         }
         throw new Error(message);
       }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -88,7 +88,7 @@ async function request<T>(
     if (typeof error.detail === 'string') {
       message = error.detail;
     } else if (Array.isArray(error.detail)) {
-      // Join each validation error's msg into one string.
+      // Join each validation error's msg into one string (FastAPI `detail` is an array of { msg }).
       message = error.detail.map((e: { msg?: string }) => e.msg).join('; ');
     }
     throw new Error(message);
@@ -409,7 +409,7 @@ export const api = {
         if (typeof error.detail === 'string') {
           message = error.detail;
         } else if (Array.isArray(error.detail)) {
-          // Join each validation error's msg into one string.
+          // Join each validation error's msg into one string (FastAPI `detail` is an array of { msg }).
       message = error.detail.map((e: { msg?: string }) => e.msg).join('; ');
         }
         throw new Error(message);
@@ -434,7 +434,7 @@ export const api = {
         if (typeof error.detail === 'string') {
           message = error.detail;
         } else if (Array.isArray(error.detail)) {
-          // Join each validation error's msg into one string.
+          // Join each validation error's msg into one string (FastAPI `detail` is an array of { msg }).
       message = error.detail.map((e: { msg?: string }) => e.msg).join('; ');
         }
         throw new Error(message);

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -88,6 +88,7 @@ async function request<T>(
     if (typeof error.detail === 'string') {
       message = error.detail;
     } else if (Array.isArray(error.detail)) {
+      // Join each validation error's msg into one string.
       message = error.detail.map((e: { msg?: string }) => e.msg).join('; ');
     }
     throw new Error(message);
@@ -408,7 +409,8 @@ export const api = {
         if (typeof error.detail === 'string') {
           message = error.detail;
         } else if (Array.isArray(error.detail)) {
-          message = error.detail.map((e: { msg?: string }) => e.msg).join('; ');
+          // Join each validation error's msg into one string.
+      message = error.detail.map((e: { msg?: string }) => e.msg).join('; ');
         }
         throw new Error(message);
       }
@@ -432,7 +434,8 @@ export const api = {
         if (typeof error.detail === 'string') {
           message = error.detail;
         } else if (Array.isArray(error.detail)) {
-          message = error.detail.map((e: { msg?: string }) => e.msg).join('; ');
+          // Join each validation error's msg into one string.
+      message = error.detail.map((e: { msg?: string }) => e.msg).join('; ');
         }
         throw new Error(message);
       }

--- a/frontend/src/components/editors/EditCreatedAtDialog.tsx
+++ b/frontend/src/components/editors/EditCreatedAtDialog.tsx
@@ -49,8 +49,6 @@ export function EditCreatedAtDialog({
 
   // Reset the input to the current value each time the dialog opens.
   useEffect(() => {
-    // Deliberate open-triggered sync of the local input to the current value;
-    // this is intentional one-shot state reset, not a render loop.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     if (open) setLocalValue(toDateTimeLocalValue(currentCreatedAt))
   }, [open, currentCreatedAt])

--- a/frontend/src/components/editors/EditCreatedAtDialog.tsx
+++ b/frontend/src/components/editors/EditCreatedAtDialog.tsx
@@ -49,6 +49,7 @@ export function EditCreatedAtDialog({
 
   // Reset the input to the current value each time the dialog opens.
   useEffect(() => {
+    // Intentional one-shot reset when the dialog opens (not a render loop), so the rule is safe to disable here.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     if (open) setLocalValue(toDateTimeLocalValue(currentCreatedAt))
   }, [open, currentCreatedAt])

--- a/frontend/src/components/editors/EditCreatedAtDialog.tsx
+++ b/frontend/src/components/editors/EditCreatedAtDialog.tsx
@@ -49,6 +49,9 @@ export function EditCreatedAtDialog({
 
   // Reset the input to the current value each time the dialog opens.
   useEffect(() => {
+    // Deliberate open-triggered sync of the local input to the current value;
+    // this is intentional one-shot state reset, not a render loop.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (open) setLocalValue(toDateTimeLocalValue(currentCreatedAt))
   }, [open, currentCreatedAt])
 

--- a/frontend/src/components/editors/InvoiceEditor.tsx
+++ b/frontend/src/components/editors/InvoiceEditor.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/components/ui/select"
 import { Button } from "@/components/ui/button"
 import { api } from "@/api/client"
-import type { Invoice, Project, CompanySettings } from "@/types"
+import type { Invoice, Project } from "@/types"
 import { Receipt, Package, Wrench, FileText, AlertTriangle, Printer, Loader2, Pencil } from "lucide-react"
 import { formatDateTime } from "@/lib/format"
 import { EditCreatedAtDialog } from "./EditCreatedAtDialog"

--- a/frontend/src/components/editors/POAuditTrail.tsx
+++ b/frontend/src/components/editors/POAuditTrail.tsx
@@ -240,7 +240,7 @@ export function POAuditTrail({ purchaseOrderId, currentVersion, onRevert }: POAu
                               v{snapshot.version}
                             </span>
                             <Badge
-                              variant={getActionBadgeVariant(snapshot.action_type) as any}
+                              variant={getActionBadgeVariant(snapshot.action_type) as "default" | "secondary" | "destructive" | "outline"}
                               className={getActionBadgeClass(snapshot.action_type)}
                             >
                               {snapshot.action_type}

--- a/frontend/src/components/editors/POAuditTrail.tsx
+++ b/frontend/src/components/editors/POAuditTrail.tsx
@@ -111,7 +111,7 @@ export function POAuditTrail({ purchaseOrderId, currentVersion, onRevert }: POAu
     }
   }
 
-  // Maps an action type to its Badge `variant`.
+  // Maps an action type to its Badge `variant`; the call site casts to that union (avoids `any`).
   const getActionBadgeVariant = (actionType: string) => {
     switch (actionType) {
       case "create":

--- a/frontend/src/components/editors/POAuditTrail.tsx
+++ b/frontend/src/components/editors/POAuditTrail.tsx
@@ -111,8 +111,7 @@ export function POAuditTrail({ purchaseOrderId, currentVersion, onRevert }: POAu
     }
   }
 
-  // Returns one of the four Badge `variant` values, so the call site casts to
-  // that union (not `any`).
+  // Maps an action type to its Badge `variant`.
   const getActionBadgeVariant = (actionType: string) => {
     switch (actionType) {
       case "create":

--- a/frontend/src/components/editors/POAuditTrail.tsx
+++ b/frontend/src/components/editors/POAuditTrail.tsx
@@ -111,6 +111,8 @@ export function POAuditTrail({ purchaseOrderId, currentVersion, onRevert }: POAu
     }
   }
 
+  // Returns one of the four Badge `variant` values, so the call site casts to
+  // that union (not `any`).
   const getActionBadgeVariant = (actionType: string) => {
     switch (actionType) {
       case "create":

--- a/frontend/src/components/editors/POEditor.tsx
+++ b/frontend/src/components/editors/POEditor.tsx
@@ -51,7 +51,7 @@ import { Calendar as CalendarWidget } from "@/components/ui/calendar"
 import type { SearchableSelectOption } from "@/components/ui/searchable-select"
 import { api } from "@/api/client"
 import type {
-  PurchaseOrder, POLineItem, POLineItemCreate, POLineItemType, POStatus, Part, CostCode,
+  PurchaseOrder, POLineItem, POLineItemType, POStatus, Part, CostCode,
   POEditorMode, StagedPOEdit, StagedPOAdd,
   StagedPOLineItemChange, POCommitEditsRequest, POReceiving, POReceivingCreate, POReceivingLineItemCreate,
   CompanySettings, Project
@@ -171,7 +171,6 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
   const hasStagedChanges = stagedEdits.size > 0 || stagedAdds.length > 0 || stagedDeletes.size > 0
   const stagedChangesCount = stagedEdits.size + stagedAdds.length + stagedDeletes.size
   const hasAnyUnsavedChanges = editorMode === "edit" && hasStagedChanges
-  const canEdit = editorMode === "edit" && po?.status === "Draft"
   const hasPendingItems = po?.line_items.some(item => item.qty_pending > 0) ?? false
   const canReceive = (po?.status === "Sent" || po?.status === "Received") && hasPendingItems
   const stagedReceivingsCount = Array.from(stagedReceivings.values()).filter(r => r.qty_received > 0).length
@@ -950,15 +949,6 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
         return <Package className="h-4 w-4" />
       case "misc":
         return <FileText className="h-4 w-4" />
-    }
-  }
-
-  const getTypeBadgeVariant = (type: POLineItemType) => {
-    switch (type) {
-      case "part":
-        return "secondary"
-      case "misc":
-        return "outline"
     }
   }
 

--- a/frontend/src/components/editors/QuoteEditor.tsx
+++ b/frontend/src/components/editors/QuoteEditor.tsx
@@ -52,7 +52,7 @@ import { api } from "@/api/client"
 import type {
   Quote, QuoteLineItem, QuoteLineItemCreate,
   LineItemType, Part, Labor, Miscellaneous, CostCode,
-  StagedFulfillment, InvoiceCreate, QuoteEditorMode, StagedEdit, StagedAdd,
+  InvoiceCreate, QuoteEditorMode, StagedEdit, StagedAdd,
   StagedLineItemChange, CommitEditsRequest
 } from "@/types"
 import { Plus, Minus, Trash2, Wrench, Package, FileText, Pencil, ClipboardCheck, Receipt, Percent, Info, Copy, Car, MapPin, X, Lock, GitCommit, Eye, AlertTriangle, Check, CheckCircle2, Printer, Loader2, Hash, ChevronUp, ChevronDown, ArrowLeft } from "lucide-react"
@@ -69,11 +69,8 @@ import { toast } from "@/hooks/use-toast"
 import {
   getLineItemBaseCost,
   getLineItemUnitPrice as _getLineItemUnitPrice,
-  getLineItemSubtotal as _getLineItemSubtotal,
-  getLineItemTotal as _getLineItemTotal,
   calculateNonPmsTotal as _calculateNonPmsTotal,
   getEffectiveUnitPrice as _getEffectiveUnitPrice,
-  getEffectiveLineItemTotal as _getEffectiveLineItemTotal,
   getFulfilledLineItemValue as _getFulfilledLineItemValue,
   calculateSectionTotals as _calculateSectionTotals,
   calculateQuoteTotal,
@@ -576,17 +573,6 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
     }
   }
 
-  const handleDeleteLine = async (lineId: number) => {
-    if (!confirm("Delete this line item?")) return
-    try {
-      await api.quotes.deleteLine(quoteId, lineId)
-      fetchQuote()
-      onUpdate?.()
-    } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to delete line item")
-    }
-  }
-
   // ===== Edit Mode Handlers (Issue #8: Commit-based workflow) =====
 
   const enterEditMode = () => {
@@ -726,10 +712,6 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
     setStagedAdds(prev => [...prev, { ...newItem, tempId }])
   }
 
-  const unstageAdd = (tempId: number) => {
-    setStagedAdds(prev => prev.filter(item => item.tempId !== tempId))
-  }
-
   const updateStagedAdd = (
     tempId: number,
     changes: Partial<Pick<StagedAdd, "quantity" | "base_cost" | "markup_percent" | "description">>
@@ -852,20 +834,6 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
       setIsCommitting(false)
     }
   }
-
-  // Helper to get display value considering staged edits
-  const getDisplayQuantity = (item: QuoteLineItem): number => {
-    const staged = stagedEdits.get(item.id)
-    return staged?.quantity ?? item.quantity
-  }
-
-  const getDisplayUnitPrice = (item: QuoteLineItem): number | undefined => {
-    const staged = stagedEdits.get(item.id)
-    return staged?.unit_price ?? item.unit_price
-  }
-
-  // Check if controls should be enabled based on mode
-  const canEdit = editorMode === "edit" && !hasBeenInvoiced
 
   // These per-field "Save" buttons only close the inline editor; the value is held
   // in local state and persisted together on Commit (see handleCommitChanges).
@@ -1091,16 +1059,8 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
     return item.description || ""
   }
 
-  const getDescriptionLabel = (item: QuoteLineItem): string => {
-    if (item.item_type === "labor") return "Labour Description"
-    if (item.item_type === "part") return "Part Number"
-    return "Misc Description"
-  }
-
   // Pricing functions — delegate to shared @/lib/pricing module
   const getLineItemUnitPrice = (item: QuoteLineItem): number => _getLineItemUnitPrice(item)
-  const getLineItemSubtotal = (item: QuoteLineItem): number => _getLineItemSubtotal(item)
-  const getLineItemTotal = (item: QuoteLineItem): number => _getLineItemTotal(item)
 
   const calculateNonPmsTotal = (): number => {
     if (!quote) return 0
@@ -1109,9 +1069,6 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
 
   const getEffectiveUnitPrice = (item: QuoteLineItem): number =>
     _getEffectiveUnitPrice(item, calculateNonPmsTotal())
-
-  const getEffectiveLineItemTotal = (item: QuoteLineItem): number =>
-    _getEffectiveLineItemTotal(item, calculateNonPmsTotal())
 
   const calculateTotal = (): number => {
     if (!quote) return 0
@@ -1837,9 +1794,6 @@ export function QuoteEditor({ quoteId, onUpdate, onSelectQuote }: QuoteEditorPro
     newStepperValues.delete(item.id)
     setStepperValues(newStepperValues)
   }
-
-  // Get total staged items count
-  const stagedCount = stagedFulfillments.size
 
   // Create invoice from staged fulfillments
   const handleCreateInvoice = async () => {

--- a/frontend/src/components/forms/ProfileForm.tsx
+++ b/frontend/src/components/forms/ProfileForm.tsx
@@ -12,7 +12,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import { api } from "@/api/client"
-import type { Profile, ProfileCreate, ProfileType, ContactCreate, PhoneType, ContactPhoneCreate } from "@/types"
+import type { Profile, ProfileCreate, ProfileType, ContactCreate, PhoneType } from "@/types"
 import { Plus, Trash2, Phone, User } from "lucide-react"
 
 // Helper to generate temporary IDs for new items

--- a/frontend/src/components/ui/searchable-multi-select.tsx
+++ b/frontend/src/components/ui/searchable-multi-select.tsx
@@ -199,7 +199,7 @@ export function SearchableMultiSelect<T>({
             <DialogHeader>
               <DialogTitle>{createDialogTitle}</DialogTitle>
             </DialogHeader>
-            {/* Inject onSuccess/onCancel into the create form; typed as Record<string, unknown> rather than `any`. */}
+            {/* Clone the create form with onSuccess/onCancel injected. */}
             {React.cloneElement(createForm as React.ReactElement<Record<string, unknown>>, {
               onSuccess: handleCreateFormSuccess,
               onCancel: () => setCreateDialogOpen(false),

--- a/frontend/src/components/ui/searchable-multi-select.tsx
+++ b/frontend/src/components/ui/searchable-multi-select.tsx
@@ -199,6 +199,7 @@ export function SearchableMultiSelect<T>({
             <DialogHeader>
               <DialogTitle>{createDialogTitle}</DialogTitle>
             </DialogHeader>
+            {/* Inject onSuccess/onCancel into the create form; typed as Record<string, unknown> rather than `any`. */}
             {React.cloneElement(createForm as React.ReactElement<Record<string, unknown>>, {
               onSuccess: handleCreateFormSuccess,
               onCancel: () => setCreateDialogOpen(false),

--- a/frontend/src/components/ui/searchable-multi-select.tsx
+++ b/frontend/src/components/ui/searchable-multi-select.tsx
@@ -199,7 +199,7 @@ export function SearchableMultiSelect<T>({
             <DialogHeader>
               <DialogTitle>{createDialogTitle}</DialogTitle>
             </DialogHeader>
-            {React.cloneElement(createForm as React.ReactElement<any>, {
+            {React.cloneElement(createForm as React.ReactElement<Record<string, unknown>>, {
               onSuccess: handleCreateFormSuccess,
               onCancel: () => setCreateDialogOpen(false),
             })}

--- a/frontend/src/components/ui/searchable-multi-select.tsx
+++ b/frontend/src/components/ui/searchable-multi-select.tsx
@@ -199,7 +199,7 @@ export function SearchableMultiSelect<T>({
             <DialogHeader>
               <DialogTitle>{createDialogTitle}</DialogTitle>
             </DialogHeader>
-            {/* Clone the create form with onSuccess/onCancel injected. */}
+            {/* Clone the create form with onSuccess/onCancel injected; typed Record<string, unknown> so the props inject without `any`. */}
             {React.cloneElement(createForm as React.ReactElement<Record<string, unknown>>, {
               onSuccess: handleCreateFormSuccess,
               onCancel: () => setCreateDialogOpen(false),

--- a/frontend/src/components/ui/searchable-select.tsx
+++ b/frontend/src/components/ui/searchable-select.tsx
@@ -173,7 +173,7 @@ export function SearchableSelect<T>({
             <DialogHeader>
               <DialogTitle>{createDialogTitle}</DialogTitle>
             </DialogHeader>
-            {/* Clone the create form with onSuccess/onCancel injected. */}
+            {/* Clone the create form with onSuccess/onCancel injected; typed Record<string, unknown> so the props inject without `any`. */}
             {React.cloneElement(createForm as React.ReactElement<Record<string, unknown>>, {
               onSuccess: handleCreateFormSuccess,
               onCancel: () => setCreateDialogOpen(false),

--- a/frontend/src/components/ui/searchable-select.tsx
+++ b/frontend/src/components/ui/searchable-select.tsx
@@ -173,7 +173,7 @@ export function SearchableSelect<T>({
             <DialogHeader>
               <DialogTitle>{createDialogTitle}</DialogTitle>
             </DialogHeader>
-            {React.cloneElement(createForm as React.ReactElement<any>, {
+            {React.cloneElement(createForm as React.ReactElement<Record<string, unknown>>, {
               onSuccess: handleCreateFormSuccess,
               onCancel: () => setCreateDialogOpen(false),
             })}

--- a/frontend/src/components/ui/searchable-select.tsx
+++ b/frontend/src/components/ui/searchable-select.tsx
@@ -173,7 +173,7 @@ export function SearchableSelect<T>({
             <DialogHeader>
               <DialogTitle>{createDialogTitle}</DialogTitle>
             </DialogHeader>
-            {/* Inject onSuccess/onCancel into the create form; typed as Record<string, unknown> rather than `any`. */}
+            {/* Clone the create form with onSuccess/onCancel injected. */}
             {React.cloneElement(createForm as React.ReactElement<Record<string, unknown>>, {
               onSuccess: handleCreateFormSuccess,
               onCancel: () => setCreateDialogOpen(false),

--- a/frontend/src/components/ui/searchable-select.tsx
+++ b/frontend/src/components/ui/searchable-select.tsx
@@ -173,6 +173,7 @@ export function SearchableSelect<T>({
             <DialogHeader>
               <DialogTitle>{createDialogTitle}</DialogTitle>
             </DialogHeader>
+            {/* Inject onSuccess/onCancel into the create form; typed as Record<string, unknown> rather than `any`. */}
             {React.cloneElement(createForm as React.ReactElement<Record<string, unknown>>, {
               onSuccess: handleCreateFormSuccess,
               onCancel: () => setCreateDialogOpen(false),

--- a/frontend/src/hooks/use-toast.ts
+++ b/frontend/src/hooks/use-toast.ts
@@ -12,7 +12,7 @@ type ToasterToast = {
   duration?: number
 }
 
-// The set of toast action-type string literals.
+// The toast action-type string literals; a type (not a runtime const) since it's only used as a type.
 type ActionType = {
   ADD_TOAST: "ADD_TOAST"
   UPDATE_TOAST: "UPDATE_TOAST"

--- a/frontend/src/hooks/use-toast.ts
+++ b/frontend/src/hooks/use-toast.ts
@@ -12,12 +12,12 @@ type ToasterToast = {
   duration?: number
 }
 
-const actionTypes = {
-  ADD_TOAST: "ADD_TOAST",
-  UPDATE_TOAST: "UPDATE_TOAST",
-  DISMISS_TOAST: "DISMISS_TOAST",
-  REMOVE_TOAST: "REMOVE_TOAST",
-} as const
+type ActionType = {
+  ADD_TOAST: "ADD_TOAST"
+  UPDATE_TOAST: "UPDATE_TOAST"
+  DISMISS_TOAST: "DISMISS_TOAST"
+  REMOVE_TOAST: "REMOVE_TOAST"
+}
 
 let count = 0
 
@@ -25,8 +25,6 @@ function genId() {
   count = (count + 1) % Number.MAX_SAFE_INTEGER
   return count.toString()
 }
-
-type ActionType = typeof actionTypes
 
 type Action =
   | {

--- a/frontend/src/hooks/use-toast.ts
+++ b/frontend/src/hooks/use-toast.ts
@@ -12,6 +12,7 @@ type ToasterToast = {
   duration?: number
 }
 
+// The set of toast action-type string literals.
 type ActionType = {
   ADD_TOAST: "ADD_TOAST"
   UPDATE_TOAST: "UPDATE_TOAST"


### PR DESCRIPTION
Standalone off `master` — clears the pre-existing frontend lint debt and turns on enforcement. Independent of the in-flight feature PRs (they added **zero** new lint). **Merge this last and rebase** so the small lint PR absorbs the shared-file conflicts (`QuoteEditor.tsx`/`POEditor.tsx`/`client.ts`) instead of forcing those PRs to rebase.

**What & why:** `master` carried **28 eslint errors + 10 warnings** that annotate every PR, and the CI Lint step has `continue-on-error: true`, so a green check never meant lint passed. This clears the 28 errors and flips lint to blocking.

**Errors cleared (all behaviour-preserving):**
- **17 `no-unused-vars`** — dead imports/vars/functions removed (incl. unused pricing-wrapper helpers in `QuoteEditor` + their now-orphaned imports; **`pricing.ts` untouched**).
- **6 `no-explicit-any`** — narrowed to real types (`{ msg?: string }`, `Record<string, unknown>`, the Badge variant union).
- **4 `react-refresh/only-export-components`** — config-exempted for `src/components/ui/**` + `theme-provider.tsx` (the shadcn co-export pattern; Fast Refresh isn't a concern for those library files).
- **1 `react-hooks/set-state-in-effect`** — kept behind a documented `eslint-disable` (intentional open-triggered reset in `EditCreatedAtDialog`).

**⚠️ Decision for you (Jay):** this removes `continue-on-error` from the Lint step, so **lint now blocks on errors** going forward. If you'd rather keep lint advisory, drop that one line in `.github/workflows/ci.yml` — everything else stands. The 10 `exhaustive-deps`-style **warnings are deliberately left non-blocking** (behaviour-risky to "fix" blindly).

**Scope/safety:** frontend + CI only; no backend, no API, no pricing math. Dead-code removal + type narrowing.

**Verified locally:** `npx tsc -b` clean · `eslint .` → **0 errors / 10 warnings** · `npm run build` OK · `npm test` 15 pass.
