### PR TITLE
fix: make Select dropdowns scrollable for long option lists

### DIFF
--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -73,7 +73,10 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        // Cap dropdown height so long lists (e.g. many travel tiers) scroll instead of
+        // overflowing off-screen — the Radix available-height var alone doesn't cap inside
+        // a Dialog. 24rem, shrinking to 60vh on short screens; overflow-y-auto does the scroll.
+        "relative z-50 max-h-[min(24rem,60vh)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className


### PR DESCRIPTION
The Travel Distance dropdown (and any Select with many options) rendered taller than the screen and clipped the top items with no way to scroll — the Radix `--radix-select-content-available-height` variable it relied on doesn't cap the popover inside a Dialog.

**What changed:** cap `SelectContent` height at `min(24rem, 60vh)` in the shared `components/ui/select.tsx`; the existing `overflow-y-auto` then scrolls. One shared primitive, so it fixes every dropdown at once (Travel, Parking, …).

**Scope / safety:** frontend-only — no backend, migration, or data. Short dropdowns are unaffected (below the cap); long ones now scroll instead of overflowing.

**How to test:** open a quote → Miscellaneous → **Travel**; the tier dropdown scrolls through all options (best checked on the Railway preview).

Supersedes the dropdown concern in #186, which is closed as by-design (the multiple travel tiers are intentional, not duplicate data). Replaces #187, which deduped them + added a recurrence guard that's no longer wanted.
