### PR TITLE
feat(migration): Vision-import verification report + key columns

### DIFF
--- a/backend/alembic/versions/20260806_028_add_legacy_keys.py
+++ b/backend/alembic/versions/20260806_028_add_legacy_keys.py
@@ -1,0 +1,59 @@
+"""Add Vision-migration keys (legacy_source/legacy_id) + a partial-unique guard.
+
+Every table whose rows can be imported from the legacy UC Vision database gets a
+nullable ``legacy_source`` (which Vision table the row came from) and ``legacy_id``
+(that row's Vision primary key), plus a PARTIAL unique index on the pair WHERE
+``legacy_id IS NOT NULL``. This lets the Vision importer re-run safely: it matches
+on the key to UPDATE an already-imported row instead of inserting a duplicate,
+while rows a user created directly in Velocity (both keys NULL) stay unconstrained.
+Everything is additive + nullable, so the downgrade is a clean drop and the live
+app is unaffected until the importer populates the keys.
+
+NOTE (rebase before merge): ``down_revision`` points at this branch's current
+Alembic head. Other in-flight migration branches also fork from that same head, so
+before this merges, repoint ``down_revision`` to the then-current head to keep a
+single migration head (no fork).
+
+Revision ID: 028_legacy_keys
+Revises: 024_invoice_versioning
+Create Date: 2026-08-06
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '028_legacy_keys'
+down_revision = '024_invoice_versioning'
+branch_labels = None
+depends_on = None
+
+# The 10 Vision-origin tables that carry the legacy key. Order is irrelevant --
+# the columns are independent and reference nothing.
+_TABLES = [
+    "categories", "profiles", "parts", "labor", "miscellaneous", "projects",
+    "quotes", "quote_line_items", "purchase_orders", "po_line_items",
+]
+
+
+def upgrade():
+    for table in _TABLES:
+        # Additive nullable key columns: which Vision table + which Vision row.
+        op.add_column(table, sa.Column("legacy_source", sa.String(), nullable=True))
+        op.add_column(table, sa.Column("legacy_id", sa.Integer(), nullable=True))
+        # Partial unique guard: one Velocity row per Vision row, migrated rows only
+        # (NULL-key user rows are excluded by the WHERE, so they stay unconstrained).
+        op.create_index(
+            f"uq_{table}_legacy",
+            table,
+            ["legacy_source", "legacy_id"],
+            unique=True,
+            postgresql_where=sa.text("legacy_id IS NOT NULL"),
+        )
+
+
+def downgrade():
+    for table in _TABLES:
+        # Drop the guard first, then the two columns (reverse of upgrade per table).
+        op.drop_index(f"uq_{table}_legacy", table_name=table)
+        op.drop_column(table, "legacy_id")
+        op.drop_column(table, "legacy_source")

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Float, ForeignKey, Enum, Table, DateTime, Boolean, UniqueConstraint, Text
+from sqlalchemy import Column, Integer, String, Float, ForeignKey, Enum, Table, DateTime, Boolean, UniqueConstraint, Text, Index, text
 from sqlalchemy.orm import relationship
 from datetime import datetime
 import enum
@@ -32,12 +32,66 @@ class POStatus(str, enum.Enum):
     closed = "Closed"
 
 
+# --------------------------------------------------------------------------- #
+# Vision-migration keys
+# --------------------------------------------------------------------------- #
+# Tables whose rows can be imported from the legacy UC Vision database carry a
+# stable "which Vision table + which Vision row" key. The importer matches on it
+# so re-running the import finds the existing row and UPDATEs it instead of
+# inserting a duplicate. Both columns are nullable -- rows a user creates directly
+# in Velocity have neither and are never touched by the importer. Factored into
+# helpers because every such table carries the identical pair + guard.
+
+def _legacy_source_col():
+    """Column holding which Vision table a row came from (e.g. 'tblServiceRecords').
+
+    Returns:
+        A fresh nullable String Column (a NEW instance per call -- a Column can't
+        be shared across tables). NULL means "created in Velocity, not migrated".
+    """
+    return Column(String, nullable=True)
+
+
+def _legacy_id_col():
+    """Column holding the Vision row's own primary key.
+
+    Returns:
+        A fresh nullable Integer Column. NULL means the row is user-created.
+    """
+    return Column(Integer, nullable=True)
+
+
+def _legacy_unique_index(table_name: str) -> Index:
+    """Partial unique index: one Velocity row per Vision row.
+
+    Enforces uniqueness of ``(legacy_source, legacy_id)`` ONLY where
+    ``legacy_id IS NOT NULL`` -- so a re-run can't duplicate a migrated row, while
+    user-created rows (both keys NULL) stay unconstrained. Partial keeps the index
+    small: it covers only migrated rows, not every user row.
+
+    Args:
+        table_name: The owning table's name; used only to name the index.
+
+    Returns:
+        A partial-unique ``Index`` for the table's ``__table_args__``.
+    """
+    return Index(
+        f"uq_{table_name}_legacy",
+        "legacy_source", "legacy_id",
+        unique=True,
+        postgresql_where=text("legacy_id IS NOT NULL"),
+    )
+
+
 class Category(Base):
     __tablename__ = "categories"
 
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, nullable=False)
     type = Column(String, nullable=False)  # "part" or "labor"
+    legacy_source = _legacy_source_col()  # Vision import: which source table
+    legacy_id = _legacy_id_col()          # Vision import: source row's id
+    __table_args__ = (_legacy_unique_index("categories"),)
 
     parts = relationship("Part", back_populates="category")
     labor_items = relationship("Labor", back_populates="category")
@@ -53,6 +107,9 @@ class Profile(Base):
     address = Column(String, nullable=False)
     postal_code = Column(String, nullable=False)
     default_discount_percent = Column(Float, nullable=True)  # Default vendor discount %
+    legacy_source = _legacy_source_col()  # Vision import: which source table
+    legacy_id = _legacy_id_col()          # Vision import: source row's id
+    __table_args__ = (_legacy_unique_index("profiles"),)
 
     # Relationships
     contacts = relationship("Contact", back_populates="profile", cascade="all, delete-orphan")
@@ -98,6 +155,9 @@ class Part(Base):
     vendor_id = Column(Integer, ForeignKey('profiles.id'), nullable=True, index=True)
     list_price = Column(Float, nullable=True)
     discount_percent = Column(Float, nullable=True)  # Per-part discount override (nullable)
+    legacy_source = _legacy_source_col()  # Vision import: which source table
+    legacy_id = _legacy_id_col()          # Vision import: source row's id
+    __table_args__ = (_legacy_unique_index("parts"),)
 
     # Relationships
     category = relationship("Category", back_populates="parts")
@@ -114,6 +174,9 @@ class Labor(Base):
     rate = Column(Float, nullable=False)
     markup_percent = Column(Float, default=50.0)
     category_id = Column(Integer, ForeignKey('categories.id'))
+    legacy_source = _legacy_source_col()  # Vision import: which source table
+    legacy_id = _legacy_id_col()          # Vision import: source row's id
+    __table_args__ = (_legacy_unique_index("labor"),)
 
     # Relationships
     category = relationship("Category", back_populates="labor_items")
@@ -129,6 +192,9 @@ class Miscellaneous(Base):
     markup_percent = Column(Float, default=50.0)
     category_id = Column(Integer, ForeignKey('categories.id'))
     is_system_item = Column(Boolean, default=False)
+    legacy_source = _legacy_source_col()  # Vision import: which source table
+    legacy_id = _legacy_id_col()          # Vision import: source row's id
+    __table_args__ = (_legacy_unique_index("miscellaneous"),)
 
     # Relationships
     category = relationship("Category")
@@ -153,6 +219,9 @@ class Project(Base):
     ucsh_project_number = Column(String, nullable=True)
     uca_project_number = Column(String, unique=True, nullable=False)
     project_lead = Column(String, nullable=True)  # Static contact name
+    legacy_source = _legacy_source_col()  # Vision import: which source table
+    legacy_id = _legacy_id_col()          # Vision import: source row's id
+    __table_args__ = (_legacy_unique_index("projects"),)
 
     # Relationships
     customer = relationship("Profile", back_populates="projects")
@@ -164,6 +233,7 @@ class Quote(Base):
     __tablename__ = "quotes"
     __table_args__ = (
         UniqueConstraint('project_id', 'quote_sequence', name='uq_quote_project_sequence'),
+        _legacy_unique_index("quotes"),  # at most one quote per source Vision workorder
     )
 
     id = Column(Integer, primary_key=True, index=True)
@@ -181,6 +251,8 @@ class Quote(Base):
     misc_markup_percent = Column(Float, nullable=True)  # Section-level markup for misc
     cost_code_id = Column(Integer, ForeignKey('cost_codes.id'), nullable=True)
     legacy_imported = Column(Boolean, nullable=False, server_default='false')
+    legacy_source = _legacy_source_col()  # Vision import: which source table
+    legacy_id = _legacy_id_col()          # Vision import: source row's id
 
     # Relationships
     project = relationship("Project", back_populates="quotes")
@@ -209,6 +281,9 @@ class QuoteLineItem(Base):
     original_markup_percent = Column(Float, nullable=True)  # Individual markup before global override
     base_cost = Column(Float, nullable=True)  # Base cost used for recalculation
     markup_percent = Column(Float, nullable=True)  # Per-line-item markup (when global OFF)
+    legacy_source = _legacy_source_col()  # Vision import: which source table
+    legacy_id = _legacy_id_col()          # Vision import: source row's id
+    __table_args__ = (_legacy_unique_index("quote_line_items"),)
 
     # Relationships
     quote = relationship("Quote", back_populates="line_items")
@@ -221,6 +296,7 @@ class PurchaseOrder(Base):
     __tablename__ = "purchase_orders"
     __table_args__ = (
         UniqueConstraint('project_id', 'po_sequence', name='uq_po_project_sequence'),
+        _legacy_unique_index("purchase_orders"),  # at most one PO per source Vision PO
     )
 
     id = Column(Integer, primary_key=True, index=True)
@@ -235,6 +311,8 @@ class PurchaseOrder(Base):
     status = Column(Enum(POStatus), default=POStatus.draft)
     cost_code_id = Column(Integer, ForeignKey('cost_codes.id'), nullable=True)
     legacy_imported = Column(Boolean, nullable=False, server_default='false')
+    legacy_source = _legacy_source_col()  # Vision import: which source table
+    legacy_id = _legacy_id_col()          # Vision import: source row's id
 
     # Relationships
     project = relationship("Project", back_populates="purchase_orders")
@@ -258,6 +336,9 @@ class POLineItem(Base):
     qty_pending = Column(Integer, default=0)
     qty_received = Column(Integer, default=0)
     actual_unit_price = Column(Float, nullable=True)
+    legacy_source = _legacy_source_col()  # Vision import: which source table
+    legacy_id = _legacy_id_col()          # Vision import: source row's id
+    __table_args__ = (_legacy_unique_index("po_line_items"),)
 
     # Relationships
     purchase_order = relationship("PurchaseOrder", back_populates="line_items")

--- a/backend/scripts/vision_migration/__main__.py
+++ b/backend/scripts/vision_migration/__main__.py
@@ -15,6 +15,7 @@ import os
 import sys
 
 from . import config
+from . import load_velocity
 from . import reconcile
 from . import stage_raw
 from . import survey
@@ -56,6 +57,18 @@ def main(argv: list[str] | None = None) -> int:
     p_survey.add_argument("--database-url", default=None,
                           help="Target Postgres URL (or set MIGRATION_DATABASE_URL).")
 
+    p_load = sub.add_parser(
+        "load-velocity",
+        help="Copy live Velocity (read-only) into velocity_current, for Diff B.",
+    )
+    p_load.add_argument("--database-url", default=None,
+                        help="Target staging Postgres URL (or MIGRATION_DATABASE_URL).")
+    p_load.add_argument("--velocity-source-url", default=None,
+                        help="Live Velocity Postgres URL, read-only (or "
+                             "MIGRATION_VELOCITY_SOURCE_URL); e.g. the Railway public URL.")
+    p_load.add_argument("--i-understand-scratch-db", action="store_true",
+                        help="Confirm the TARGET is a throwaway/preview DB, not production.")
+
     args = parser.parse_args(argv)
 
     try:
@@ -80,6 +93,17 @@ def main(argv: list[str] | None = None) -> int:
             # survey only reads staged data; refuse blocked hosts, no confirm needed.
             config.assert_scratch_target(target, confirmed=True)
             survey.run_survey(target)
+            return 0
+        if args.command == "load-velocity":
+            # Writes into velocity_current on the TARGET -> guard the target like
+            # 'stage'. The SOURCE (live Velocity) is read-only and NOT guarded.
+            host = config.assert_scratch_target(target, args.i_understand_scratch_db)
+            source = config.resolve_velocity_source_url(args.velocity_source_url)
+            print(f"Target host: {host} (loading into schema "
+                  f"'{config.VELOCITY_CURRENT_SCHEMA}')")
+            print("Source: live Velocity (opened read-only).")
+            load_velocity.load_velocity(source, target)
+            print("Velocity load complete. Run 'reconcile' to see Diff B.")
             return 0
     except config.MigrationConfigError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/backend/scripts/vision_migration/__main__.py
+++ b/backend/scripts/vision_migration/__main__.py
@@ -69,6 +69,14 @@ def main(argv: list[str] | None = None) -> int:
     p_load.add_argument("--i-understand-scratch-db", action="store_true",
                         help="Confirm the TARGET is a throwaway/preview DB, not production.")
 
+    p_dryrun = sub.add_parser(
+        "dryrun",
+        help="Read-only: what the quote import would do (adopt/insert/update/skip) "
+             "vs velocity_current.",
+    )
+    p_dryrun.add_argument("--database-url", default=None,
+                          help="Staging Postgres URL (or set MIGRATION_DATABASE_URL).")
+
     args = parser.parse_args(argv)
 
     try:
@@ -104,6 +112,13 @@ def main(argv: list[str] | None = None) -> int:
             print("Source: live Velocity (opened read-only).")
             load_velocity.load_velocity(source, target)
             print("Velocity load complete. Run 'reconcile' to see Diff B.")
+            return 0
+        if args.command == "dryrun":
+            # Read-only: plans the quote import against velocity_current and writes
+            # nothing. Refuse blocked (prod-looking) hosts; no confirm needed.
+            config.assert_scratch_target(target, confirmed=True)
+            from .sync import dry_run
+            dry_run.run_quote_dry_run(target)
             return 0
     except config.MigrationConfigError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/backend/scripts/vision_migration/config.py
+++ b/backend/scripts/vision_migration/config.py
@@ -21,6 +21,11 @@ from urllib.parse import urlparse
 # The isolated schema that holds the verbatim Vision copy. Never the app tables.
 STAGING_SCHEMA = "vision_legacy"
 
+# The isolated schema that holds a read-only copy of live Velocity, for Diff B.
+# Like STAGING_SCHEMA it is never the app's own tables -- it lives on the same
+# throwaway staging DB and is written only by the `load-velocity` command.
+VELOCITY_CURRENT_SCHEMA = "velocity_current"
+
 # Hosts we refuse to write to, ever. Extend via MIGRATION_BLOCKED_HOSTS (comma-sep).
 # Covers Railway's private host (`railway.internal`, unreachable off-Railway) AND
 # the reachable public endpoints (`rlwy.net` proxy, `railway.app`) so a prod URL
@@ -90,6 +95,34 @@ def resolve_target_url(cli_url: str | None) -> str:
         raise MigrationConfigError(
             "No target database. Pass --database-url or set MIGRATION_DATABASE_URL "
             "to a SCRATCH/preview Postgres (never production)."
+        )
+    return url
+
+
+def resolve_velocity_source_url(cli_url: str | None) -> str:
+    """Resolve the READ-ONLY live-Velocity source url for Diff B.
+
+    Kept deliberately as a THIRD variable, distinct from both the app's
+    DATABASE_URL and the staging *target* url, so the loader can never confuse
+    "where I read live data" with "where I write the copy". It is never run
+    through the prod-host guard -- that guard protects write *targets*; reading
+    live Velocity is fine and the loader only issues SELECTs.
+
+    Args:
+        cli_url: The value of ``--velocity-source-url`` (or ``None`` if omitted).
+
+    Returns:
+        The source url: the CLI value if given, else ``MIGRATION_VELOCITY_SOURCE_URL``.
+
+    Raises:
+        MigrationConfigError: If neither the CLI arg nor the env var is set.
+    """
+    url = cli_url or os.getenv("MIGRATION_VELOCITY_SOURCE_URL")   # CLI wins, else env var
+    if not url:                                                    # nothing to read from -> fail loud
+        raise MigrationConfigError(
+            "No Velocity source. Pass --velocity-source-url or set "
+            "MIGRATION_VELOCITY_SOURCE_URL to the live Velocity Postgres "
+            "(read-only; e.g. the Railway public URL)."
         )
     return url
 

--- a/backend/scripts/vision_migration/load_velocity.py
+++ b/backend/scripts/vision_migration/load_velocity.py
@@ -1,0 +1,196 @@
+"""Diff B loader: copy live Velocity tables (READ-ONLY) into a local
+``velocity_current`` schema, so ``reconcile`` can compare the migration's
+transform output against what Velocity actually holds today.
+
+Safety model (read this):
+  * The SOURCE (live Velocity -- e.g. the Railway *public* URL) is opened
+    ``readonly`` at the session level and only ever SELECTed. We never write to
+    it. It is NOT run through the prod-host guard, because that guard protects
+    write *targets*; reading live Velocity is fine and pre-authorized.
+  * The TARGET is the local staging Postgres. We write ONLY into the isolated
+    ``velocity_current`` schema (drop+recreate per table), never Velocity's or
+    Vision's real tables. The caller runs the same ``assert_scratch_target``
+    guard on the target first, so this can't accidentally write back to Railway.
+
+Heavy drivers (psycopg2) are imported lazily inside functions so importing this
+module never fails on a machine without them (e.g. Linux CI).
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from . import config
+
+# Isolated destination schema on the staging DB -- never the app's own tables.
+SCHEMA = config.VELOCITY_CURRENT_SCHEMA  # "velocity_current"
+
+# The Velocity app tables we copy for Diff B: enough to compare the quote + PO
+# domains (the G1/G2 close-state headline) plus catalog/profile counts. An
+# EXPLICIT short list on purpose -- we never mirror the whole app schema.
+VELOCITY_TABLES = [
+    "categories", "profiles", "parts", "labor", "miscellaneous", "projects",
+    "quotes", "quote_line_items", "purchase_orders", "po_line_items",
+]
+
+# Rows are streamed in chunks this size so one big table (quote_line_items is
+# ~127k rows) never has to be inserted in a single oversized statement.
+_COPY_BATCH = 5000
+
+
+def _ddl_type(data_type: str) -> str:
+    """Map a source Postgres column type to the wide type we store it as.
+
+    Args:
+        data_type: The source column's ``information_schema.data_type`` (e.g.
+            ``"integer"``, ``"numeric"``, or ``"USER-DEFINED"`` for an enum).
+
+    Returns:
+        A Postgres DDL type for the ``velocity_current`` copy. Enums, arrays,
+        uuid and json all collapse to ``TEXT`` -- Diff B compares values as
+        strings, so preserving the *value* matters, not the exact source type.
+    """
+    dt = data_type.lower()                   # normalise case before matching
+    if dt in ("integer", "smallint"):        # small whole numbers -> INTEGER
+        return "INTEGER"
+    if dt == "bigint":                       # 64-bit ids -> BIGINT
+        return "BIGINT"
+    if dt in ("numeric", "decimal"):         # money/quantities -> exact NUMERIC (no rounding)
+        return "NUMERIC"
+    if dt in ("double precision", "real"):   # floats -> DOUBLE PRECISION
+        return "DOUBLE PRECISION"
+    if dt == "boolean":                      # flags -> BOOLEAN
+        return "BOOLEAN"
+    if dt.startswith("timestamp"):           # timestamp / timestamptz -> TIMESTAMP
+        return "TIMESTAMP"
+    if dt == "date":                         # date-only -> DATE
+        return "DATE"
+    return "TEXT"                            # enum/uuid/json/everything else -> TEXT
+
+
+def _source_columns(cur: Any, table: str) -> list[tuple[str, str]]:
+    """List a source table's columns and the staging type each maps to.
+
+    Args:
+        cur: A cursor on the SOURCE (live Velocity) connection.
+        table: The ``public`` table name to describe.
+
+    Returns:
+        ``(column_name, staging_ddl_type)`` pairs in the table's real column
+        order -- ready to build the copy's ``CREATE TABLE``.
+    """
+    # Read column names + types from the catalog, in physical column order.
+    cur.execute(
+        "SELECT column_name, data_type FROM information_schema.columns "
+        "WHERE table_schema = 'public' AND table_name = %s "
+        "ORDER BY ordinal_position",
+        (table,),
+    )
+    # Translate each source type to our wide staging type as we collect them.
+    return [(r[0], _ddl_type(r[1])) for r in cur.fetchall()]
+
+
+def _coerce(v: Any) -> Any:
+    """Make one cell value safe to insert into its ``TEXT`` staging column.
+
+    Args:
+        v: A value fetched from a source row.
+
+    Returns:
+        JSON text if ``v`` is a ``dict``/``list`` (a json/array column, which we
+        store as ``TEXT``); otherwise ``v`` unchanged.
+    """
+    if isinstance(v, (dict, list)):          # json/array columns arrive as dict/list
+        return json.dumps(v, default=str)    # serialise so it fits the TEXT column
+    return v                                 # scalars pass straight through
+
+
+def _copy_table(src_cur: Any, tgt_cur: Any, table: str) -> int:
+    """Drop, recreate, and refill one ``velocity_current`` table from the source.
+
+    Args:
+        src_cur: Cursor on the SOURCE (live Velocity, read-only).
+        tgt_cur: Cursor on the TARGET (local staging DB) we write into.
+        table: Table name to copy (same name in both schemas).
+
+    Returns:
+        Rows copied (0 if the table doesn't exist on the source).
+    """
+    # psycopg2 helpers imported lazily so the module imports without the driver.
+    from psycopg2 import sql
+    from psycopg2.extras import execute_values
+
+    cols = _source_columns(src_cur, table)   # (name, ddl_type) for every column
+    if not cols:                             # table absent on source -> nothing to copy
+        print(f"  {table}: not found on source -- skipped")
+        return 0
+
+    tgt = sql.Identifier(SCHEMA, table)      # safely-quoted velocity_current.<table>
+    # Build the "col TYPE, col TYPE, ..." body of the CREATE TABLE.
+    col_defs = sql.SQL(", ").join(
+        sql.SQL("{} {}").format(sql.Identifier(n), sql.SQL(t)) for n, t in cols
+    )
+    tgt_cur.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(tgt))    # fresh each run (idempotent)
+    tgt_cur.execute(sql.SQL("CREATE TABLE {} ({})").format(tgt, col_defs))
+
+    # One shared column list drives BOTH the SELECT and the INSERT, so value
+    # order always lines up with column order.
+    col_idents = sql.SQL(", ").join(sql.Identifier(n) for n, _ in cols)
+    # Pre-render the INSERT once; execute_values fills the single %s with rows.
+    insert_stmt = sql.SQL("INSERT INTO {} ({}) VALUES %s").format(
+        tgt, col_idents).as_string(tgt_cur)
+
+    # Read the source rows with an explicit column order (not SELECT *).
+    src_cur.execute(sql.SQL("SELECT {} FROM {}").format(
+        col_idents, sql.Identifier("public", table)))
+    loaded = 0                               # running count of rows copied
+    while True:
+        rows = src_cur.fetchmany(_COPY_BATCH)   # next chunk (bounded work per insert)
+        if not rows:                            # no more rows -> done
+            break
+        # Coerce each cell (json/array -> text), then bulk-insert the chunk.
+        values = [tuple(_coerce(v) for v in row) for row in rows]
+        execute_values(tgt_cur, insert_stmt, values)
+        loaded += len(rows)
+    return loaded
+
+
+def load_velocity(source_url: str, target_url: str) -> dict[str, int]:
+    """Copy the Diff B tables from live Velocity into ``velocity_current``.
+
+    Reads live Velocity read-only and writes only the isolated
+    ``velocity_current`` schema on the staging target -- never the app's tables.
+
+    Args:
+        source_url: Live Velocity Postgres URL (read-only source).
+        target_url: Local staging Postgres URL (write target; the caller has
+            already run the prod-host guard on it).
+
+    Returns:
+        ``{table_name: rows_copied}`` for every table in ``VELOCITY_TABLES``.
+    """
+    from psycopg2 import sql                 # lazy import (see module docstring)
+
+    src = config.open_postgres(source_url)   # live Velocity (source)
+    tgt = config.open_postgres(target_url)   # staging DB (target)
+    counts: dict[str, int] = {}              # per-table rows copied, for the return value
+    try:
+        # Belt-and-suspenders: read-only session on top of SELECT-only queries,
+        # so the source can never be modified even by mistake.
+        src.set_session(readonly=True, autocommit=True)
+        src_cur = src.cursor()
+        tgt_cur = tgt.cursor()
+        # Ensure the isolated destination schema exists before writing tables.
+        tgt_cur.execute(sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
+            sql.Identifier(SCHEMA)))
+        tgt.commit()
+        for i, table in enumerate(VELOCITY_TABLES, start=1):
+            n = _copy_table(src_cur, tgt_cur, table)   # copy this one table
+            tgt.commit()                     # commit per table -> a late failure keeps earlier copies
+            counts[table] = n
+            print(f"  [{i:>2}/{len(VELOCITY_TABLES)}] {table}: {n} rows")
+        return counts
+    finally:
+        # Always close both connections, even if a copy raised mid-way.
+        src.close()
+        tgt.close()

--- a/backend/scripts/vision_migration/reconcile.py
+++ b/backend/scripts/vision_migration/reconcile.py
@@ -24,11 +24,13 @@ module never fails on a machine without them.
 """
 from __future__ import annotations
 
+import re
 from typing import Any, Optional
 
 from . import config
 from .transform import (
     opt_int,
+    to_str,
     transform_category,
     transform_labor,
     transform_misc,
@@ -71,7 +73,11 @@ _PO_LINE_TABLE = "tblPurchaseOrdersMaterial"
 _WORKORDER_STATUS_FIELDS = ["chrStatus", "blnForceClosed", "blnLocked", "blnAllShipped"]
 _LINE_SHIP_FIELDS = ["intTotalShippedQuantity", "intShipQuantity", "intQuantityBO"]
 
-_VELOCITY_CURRENT_SCHEMA = "velocity_current"  # Diff B target, when an export is loaded
+_VELOCITY_CURRENT_SCHEMA = config.VELOCITY_CURRENT_SCHEMA  # Diff B target schema
+
+# Velocity quote status strings treated as "closed/terminal" when Diff B checks
+# which live quotes the G1 fix would re-open. Compared lower-cased.
+_CLOSEDISH = frozenset({"closed", "invoiced", "complete", "completed", "done"})
 
 
 # --------------------------------------------------------------------------- #
@@ -208,11 +214,11 @@ def run_reconciliation(url: str) -> dict[str, Any]:
         _report_profiles(cur, summary)
         _report_projects(cur, summary)
         _report_po_domain(cur, summary)
-        _report_diff_b_slot(cur, summary)
+        _report_diff_b(cur, summary)
 
         print("\n" + "=" * 72)
-        print("Diff A complete. (Diff B -- vs. live Velocity -- needs a read-only "
-              f"export in schema '{_VELOCITY_CURRENT_SCHEMA}'.)")
+        print("Reconciliation complete. (Diff B needs 'load-velocity' to have "
+              f"populated schema '{_VELOCITY_CURRENT_SCHEMA}'.)")
         print("=" * 72)
         return summary
     finally:
@@ -640,13 +646,140 @@ def _report_po_domain(cur: Any, summary: dict[str, Any]) -> None:
     }
 
 
-def _report_diff_b_slot(cur: Any, summary: dict[str, Any]) -> None:
+def _staged_wo_derived_status(cur: Any) -> tuple[dict[int, str], int]:
+    """Derive each staged Vision workorder's real close-state from its ship data.
+
+    The same close-state signal Diff A reports, but keyed by ``WorkorderID`` so Diff B
+    can line each *live* Velocity quote up against what its real fulfillment implies.
+
+    Args:
+        cur: Read-only cursor on the staging DB (reads the ``vision_legacy`` schema).
+
+    Returns:
+        ``(status_by_wo, staged_max_wo)`` where ``status_by_wo`` maps a Vision
+        WorkorderID to ``"open"`` (a line still has quantity pending), ``"closed"``
+        (all lines shipped), or ``"no_lines"``; and ``staged_max_wo`` is the highest
+        WorkorderID we staged -- it lets Diff B tell "newer than anything we have"
+        apart from "a real gap".
+    """
+    # Every WorkorderID present in staging -> the set a live WO# can match against.
+    wo_ids: set[int] = set()
+    if _table_exists(cur, SCHEMA, _WORKORDER_TABLE):
+        for row in _fetch_dicts(cur, SCHEMA, _WORKORDER_TABLE):
+            wo = opt_int(row.get("WorkorderID"))   # the workorder's own id
+            if wo is not None:
+                wo_ids.add(wo)
+
+    # Walk every workorder line (labour/part/misc); a workorder is "open" if ANY
+    # line still has quantity pending, else "closed".
+    pending: dict[int, bool] = {}            # wo# -> does it have an unshipped line?
+    for item_type, table in _LINE_TABLES.items():
+        if not _table_exists(cur, SCHEMA, table):
+            continue                         # this line table wasn't staged -> skip it
+        for row in _fetch_dicts(cur, SCHEMA, table):
+            line = transform_workorder_line(row, item_type)   # -> qty_pending etc.
+            wo = line["workorder_legacy_id"]
+            if wo is None or wo not in wo_ids:
+                continue                     # orphan line (no parent workorder) -> ignore
+            if line["qty_pending"] > 0:
+                pending[wo] = True           # at least one line still open
+            else:
+                pending.setdefault(wo, False)   # seen + fully shipped (unless flipped True elsewhere)
+
+    # Fold the two facts (has-lines? any-pending?) into one status per workorder.
+    status: dict[int, str] = {}
+    for wo in wo_ids:
+        status[wo] = "no_lines" if wo not in pending else ("open" if pending[wo] else "closed")
+    return status, (max(wo_ids) if wo_ids else 0)   # also hand back the highest staged WO#
+
+
+def _report_diff_b(cur: Any, summary: dict[str, Any]) -> None:
+    """Print Diff B: the migration's derived state vs. what live Velocity stores.
+
+    Headline = how many *live* quotes read ``closed`` in Velocity but the real
+    Vision ship data derives OPEN -- exactly the quotes a correct migration re-opens.
+    Read-only; only runs once ``load-velocity`` has populated ``velocity_current``.
+
+    Args:
+        cur: Read-only cursor on the staging DB (holds both ``vision_legacy`` and,
+            when loaded, ``velocity_current``).
+        summary: Machine-readable result dict; a ``"diff_b"`` block is added to it.
+    """
+    vc = _VELOCITY_CURRENT_SCHEMA
     print("\n-- Diff B (vs. live Velocity) " + "-" * 41)
-    present = _schema_exists(cur, _VELOCITY_CURRENT_SCHEMA)
-    summary["diff_b_available"] = present
-    if present:
-        print(f"  schema '{_VELOCITY_CURRENT_SCHEMA}' present -- live diff can be built "
-              "(not implemented in this increment).")
-    else:
-        print(f"  schema '{_VELOCITY_CURRENT_SCHEMA}' absent -- SKIPPED. Load a read-only "
-              "Velocity export there to enable it.")
+    # Diff B needs the live copy loaded first; skip cleanly (not error) if absent.
+    if not _schema_exists(cur, vc) or not _table_exists(cur, vc, "quotes"):
+        print(f"  schema '{vc}' (or its quotes table) absent -- SKIPPED. Run "
+              "'load-velocity' to pull a read-only copy of live Velocity there.")
+        summary["diff_b_available"] = False
+        return
+    summary["diff_b_available"] = True
+
+    derived, staged_max = _staged_wo_derived_status(cur)   # WO# -> real close-state
+    has_status = "status" in _columns(cur, vc, "quotes")   # tolerate a missing column
+
+    # We DEDUPE by WorkorderID rather than count per live quote-row: a user can
+    # Clone a migrated quote, and clone_quote copies work_description verbatim, so
+    # every clone carries the same [WO ####] tag -- counting per row would double-
+    # count clones. (We can't use the `legacy_imported` flag to exclude them: on
+    # the live data it is FALSE on every row, so it's no discriminator here.)
+    matched_wos: set[int] = set()            # distinct staged WO#s that appear in live
+    should_open_wos: set[int] = set()        # matched WO#s: derive open AND a live quote reads closed-ish
+    velo_status: dict[str, int] = {}         # live status distribution (per row, for visibility)
+    matched_rows = 0                         # live quote ROWS matched (rows > WO#s reveals clones)
+    unmatched_newer = unmatched_other = untagged = 0
+    for r in _fetch_dicts(cur, vc, "quotes"):
+        # The [WO ####] tag is the Vision WorkorderID the importer stamped in.
+        m = re.search(r"\[WO (\d+)\]", to_str(r.get("work_description")))
+        if not m:
+            untagged += 1                    # Velocity-native quote (no legacy tag)
+            continue
+        wo = int(m.group(1))
+        d = derived.get(wo)                  # this WO#'s staged close-state, or None
+        if d is None:
+            # A live WO# we don't have staged: newer than our source (expected --
+            # the staged .mdb is older/smaller) vs. an unexpected in-range gap.
+            if wo > staged_max:
+                unmatched_newer += 1
+            else:
+                unmatched_other += 1
+            continue
+        matched_rows += 1                    # count the row (clones included) for the clone tally
+        matched_wos.add(wo)                  # headline metrics dedupe on the WO# itself
+        vstatus = to_str(r.get("status")) if has_status else ""
+        velo_status[vstatus] = velo_status.get(vstatus, 0) + 1   # tally live status
+        # THE headline case: Velocity stores it closed, real ship data says open.
+        if d == "open" and vstatus.lower() in _CLOSEDISH:
+            should_open_wos.add(wo)
+
+    matched = len(matched_wos)               # distinct migrated workorders present in live
+    matched_closed_should_open = len(should_open_wos)
+    clones = matched_rows - matched          # extra live rows sharing a matched WO# (clones)
+    total = matched_rows + unmatched_newer + unmatched_other + untagged   # == all live quotes
+    print(f"  live Velocity quotes:                          {total:>7}")
+    print(f"    matched to a staged Vision WO#:              {matched:>7}  (distinct workorders)")
+    if clones:                               # surface clones instead of hiding them in the count
+        print(f"      (+{clones} cloned live quote(s) share a matched WO#)")
+    print(f"    unmatched -- newer than staged (WO# > {staged_max}):  {unmatched_newer:>7}"
+          "  (expected: staged source is older/smaller)")
+    print(f"    unmatched -- WO# <= staged max, not staged:  {unmatched_other:>7}")
+    print(f"    no [WO] tag (Velocity-native):               {untagged:>7}")
+    if has_status and velo_status:
+        dist = ", ".join(f"{k or '(blank)'}={v}" for k, v in sorted(velo_status.items()))
+        print(f"  matched-quote Velocity status: {dist}")
+    print(f"\n  >>> DIFF B HEADLINE: {matched_closed_should_open} matched workorders read "
+          "'closed' in Velocity but the real")
+    print("      Vision ship data derives OPEN -- the quotes a correct migration re-opens on live data.")
+
+    # Machine-readable mirror of the printed numbers, for callers/tests.
+    summary["diff_b"] = {
+        "velocity_quotes": total,
+        "matched": matched,                  # distinct workorders present in live
+        "matched_rows": matched_rows,        # live rows incl. clones (rows > matched => clones)
+        "clones": clones,
+        "unmatched_newer": unmatched_newer,
+        "unmatched_other": unmatched_other,
+        "untagged": untagged,
+        "matched_closed_should_open": matched_closed_should_open,
+        "velocity_status_matched": velo_status,
+    }

--- a/backend/scripts/vision_migration/sync/__init__.py
+++ b/backend/scripts/vision_migration/sync/__init__.py
@@ -1,0 +1,5 @@
+"""The Vision -> Velocity import engine and its per-domain callers.
+
+``engine.py`` holds the pure, database-free decision logic (update / adopt /
+insert, never delete). Per-domain modules wire it to real tables.
+"""

--- a/backend/scripts/vision_migration/sync/dry_run.py
+++ b/backend/scripts/vision_migration/sync/dry_run.py
@@ -1,0 +1,100 @@
+"""Read-only dry run of the import engine for the quote domain.
+
+Reads the staged Vision workorders and the read-only ``velocity_current`` copy of
+live Velocity, asks the engine what the importer WOULD do for each workorder
+(adopt / insert / update / skip), and prints the tally -- writing nothing. This
+proves the adoption strategy on real data before any write path exists: a first
+run should ADOPT the thousands of quotes an earlier un-keyed import already
+created, rather than inserting duplicates.
+
+The natural key for a quote is its Vision work-order number. The original importer
+stamped that number into each migrated quote's description as ``[WO ####]``, so we
+recover it from ``work_description`` to line a staged workorder up against the
+existing live quote.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from .. import config
+from ..transform import transform_workorder, to_str
+from .engine import DomainSpec, decide, summarize, ADOPT, INSERT, UPDATE, SKIP
+
+SCHEMA = config.STAGING_SCHEMA            # "vision_legacy" (the staged Vision copy)
+VC = config.VELOCITY_CURRENT_SCHEMA       # "velocity_current" (the live-Velocity copy)
+_WO_RE = re.compile(r"\[WO (\d+)\]")      # pulls the work-order number out of a description
+
+# How to route a staged workorder through the engine. Its Vision primary key and
+# its natural key are BOTH the work-order number: the id we would store, and the
+# value the original importer wrote into the live quote's description as [WO ####].
+QUOTE_SPEC = DomainSpec(
+    legacy_source="tblServiceRecords",
+    legacy_id_of=lambda r: r["workorder_legacy_id"] or None,   # 0 (missing) -> None -> skip
+    natural_key_of=lambda r: r["workorder_legacy_id"] or None,
+)
+
+
+def run_quote_dry_run(url: str) -> dict[str, int]:
+    """Print the quote-domain dry-run ledger and return the action counts.
+
+    Args:
+        url: The staging Postgres URL (holds both ``vision_legacy`` and, once
+            ``load-velocity`` has run, ``velocity_current``).
+
+    Returns:
+        ``{action: count}`` from :func:`engine.summarize`.
+    """
+    import psycopg2.extras
+    from psycopg2 import sql
+
+    conn = config.open_postgres(url)
+    try:
+        # Belt-and-suspenders: read-only session on top of SELECT-only queries.
+        conn.set_session(readonly=True, autocommit=True)
+        cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+
+        print("=" * 72)
+        print("Import dry-run: quotes (staged Vision vs. velocity_current)  [read-only]")
+        print("=" * 72)
+
+        # Source rows: every staged Vision workorder, transformed to a quote dict.
+        cur.execute(sql.SQL("SELECT * FROM {}.{}").format(
+            sql.Identifier(SCHEMA), sql.Identifier("tblServiceRecords")))
+        source_rows = [transform_workorder(dict(r)) for r in cur.fetchall()]
+
+        # existing_by_legacy: the live copy carries no legacy key yet (those columns
+        # only exist after this migration is applied to prod), so nothing UPDATEs on
+        # a first run -- the map is empty by construction.
+        existing_by_legacy: dict[tuple[str, int], int] = {}
+
+        # existing_by_natural: {work-order number -> live quote id}, parsed from the
+        # [WO ####] tag in each live quote's description. First-wins if a number
+        # repeats (a cloned quote), so one live row is offered for adoption per number.
+        existing_by_natural: dict[Any, int] = {}
+        cur.execute(sql.SQL("SELECT id, work_description FROM {}.{}").format(
+            sql.Identifier(VC), sql.Identifier("quotes")))
+        for r in cur.fetchall():
+            m = _WO_RE.search(to_str(r["work_description"]))
+            if m:
+                existing_by_natural.setdefault(int(m.group(1)), r["id"])
+
+        # Plan (no writes) and tally.
+        decisions = decide(source_rows, QUOTE_SPEC, existing_by_legacy, existing_by_natural)
+        counts = summarize(decisions)
+
+        print(f"\n  source workorders (staged Vision):        {len(source_rows):>7}")
+        print(f"  existing live quotes (by [WO ####]):      {len(existing_by_natural):>7}")
+        print("\n  the importer would:")
+        print(f"    adopt  (claim an existing live quote):  {counts[ADOPT]:>7}")
+        print(f"    insert (new, not present in live):      {counts[INSERT]:>7}")
+        print(f"    update (already keyed by a prior run):  {counts[UPDATE]:>7}")
+        print(f"    skip   (workorder has no id):           {counts[SKIP]:>7}")
+        print(f"\n  >>> ADOPTION PROOF: {counts[ADOPT]} existing live quotes are ADOPTED "
+              "(re-keyed in place),")
+        print(f"      not duplicated. Only {counts[INSERT]} workorder(s) -- ones live never "
+              "received -- would insert.")
+        print("=" * 72)
+        return counts
+    finally:
+        conn.close()

--- a/backend/scripts/vision_migration/sync/engine.py
+++ b/backend/scripts/vision_migration/sync/engine.py
@@ -1,0 +1,136 @@
+"""Idempotent Vision -> Velocity import engine (pure decision logic).
+
+The importer must be safe to re-run: a second run may NOT create duplicates of
+rows it already brought in, and it must never touch or delete rows a user created
+directly in Velocity. This module decides, for each source row, which ONE of these
+the importer would do:
+
+  * UPDATE -- a Velocity row already carries this source row's stored key
+    (legacy_source, legacy_id): refresh it in place.
+  * ADOPT  -- no stored key matches, but an existing Velocity row is clearly the
+    same real thing (its "natural key" matches -- e.g. a quote's work-order
+    number). Claim that row by stamping the key onto it, then update it. This is
+    what lets the FIRST run take ownership of rows an earlier, un-keyed import
+    (or the original CSV import) already created, instead of inserting duplicates.
+  * INSERT -- neither matches: it's genuinely new, so create it.
+  * SKIP   -- the source row has no usable id, so it can't be keyed or matched.
+
+It NEVER deletes. It is deliberately kept free of any database access so it is
+trivially unit-testable and cannot touch live data -- callers pass in plain
+lookups (built from a read-only copy for a dry run, or the ORM for a real run),
+and the engine just returns a plan. Performing the plan is the caller's job.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Hashable, Optional
+
+# The four actions the engine can choose. Strings (not an enum) so the ledger and
+# any printed report read plainly without extra imports.
+INSERT = "insert"
+UPDATE = "update"
+ADOPT = "adopt"
+SKIP = "skip"
+
+
+@dataclass(frozen=True)
+class Decision:
+    """One planned action for one source row (no write has happened yet).
+
+    Attributes:
+        action: One of INSERT / UPDATE / ADOPT / SKIP.
+        legacy_source: The Vision table the source row came from.
+        legacy_id: The source row's Vision primary key, or None when SKIPped.
+        target_id: The existing Velocity row id to update/adopt, or None on INSERT/SKIP.
+        reason: Short human-readable why, for the dry-run ledger.
+    """
+    action: str
+    legacy_source: str
+    legacy_id: Optional[int]
+    target_id: Optional[int]
+    reason: str
+
+
+@dataclass(frozen=True)
+class DomainSpec:
+    """Everything the engine needs to route ONE domain without knowing its shape.
+
+    Attributes:
+        legacy_source: The Vision table these rows come from (stored as legacy_source).
+        legacy_id_of: Given a source row, its Vision primary key (its legacy_id),
+            or None if the row can't be keyed.
+        natural_key_of: Given a source row, a value that identifies the same real
+            entity in an already-migrated-but-unkeyed Velocity row (e.g. the
+            work-order number for a quote), or None if it can't be adopted.
+    """
+    legacy_source: str
+    legacy_id_of: Callable[[dict[str, Any]], Optional[int]]
+    natural_key_of: Callable[[dict[str, Any]], Optional[Hashable]]
+
+
+def decide(
+    source_rows: list[dict[str, Any]],
+    spec: DomainSpec,
+    existing_by_legacy: dict[tuple[str, int], int],
+    existing_by_natural: dict[Hashable, int],
+) -> list[Decision]:
+    """Plan the importer's action for each source row -- reads nothing, writes nothing.
+
+    Args:
+        source_rows: Transformed source rows for one domain.
+        spec: How to read this domain's legacy id + natural key.
+        existing_by_legacy: ``{(legacy_source, legacy_id): velocity_id}`` for rows a
+            previous run already keyed -> these UPDATE.
+        existing_by_natural: ``{natural_key: velocity_id}`` for existing Velocity rows
+            that have NO legacy key yet but can be adopted by their natural key.
+
+    Returns:
+        One :class:`Decision` per source row, in the same order.
+    """
+    decisions: list[Decision] = []
+    # An existing un-keyed row may be adopted only ONCE: if two source rows share a
+    # natural key, the first adopts it and the rest fall through to INSERT rather
+    # than both claiming the same Velocity row.
+    already_adopted: set[Hashable] = set()
+
+    for row in source_rows:
+        legacy_id = spec.legacy_id_of(row)
+        if legacy_id is None:
+            # No Vision id -> can't be keyed or matched; leave it alone.
+            decisions.append(Decision(SKIP, spec.legacy_source, None, None, "source row has no legacy id"))
+            continue
+
+        key = (spec.legacy_source, legacy_id)
+        if key in existing_by_legacy:
+            # A prior run already stamped this exact source row -> refresh in place.
+            decisions.append(Decision(UPDATE, spec.legacy_source, legacy_id,
+                                      existing_by_legacy[key], "matched by stored legacy key"))
+            continue
+
+        natural = spec.natural_key_of(row)
+        if natural is not None and natural in existing_by_natural and natural not in already_adopted:
+            # Same real entity already exists un-keyed -> claim it instead of duplicating.
+            already_adopted.add(natural)
+            decisions.append(Decision(ADOPT, spec.legacy_source, legacy_id,
+                                      existing_by_natural[natural], "adopted existing row by natural key"))
+            continue
+
+        # Nothing matched -> it's genuinely new.
+        decisions.append(Decision(INSERT, spec.legacy_source, legacy_id, None, "no match -> insert"))
+
+    return decisions
+
+
+def summarize(decisions: list[Decision]) -> dict[str, int]:
+    """Tally decisions by action for the dry-run ledger.
+
+    Args:
+        decisions: The plan from :func:`decide`.
+
+    Returns:
+        ``{action: count}`` covering all four actions (zeros included).
+    """
+    counts = {INSERT: 0, UPDATE: 0, ADOPT: 0, SKIP: 0}
+    for d in decisions:
+        counts[d.action] += 1
+    return counts

--- a/backend/tests/test_sync_engine.py
+++ b/backend/tests/test_sync_engine.py
@@ -1,0 +1,84 @@
+"""Unit tests for the Vision -> Velocity import engine's decision logic.
+
+These exercise the pure ``decide`` function with plain dict fixtures -- no
+database -- proving each source row is routed to exactly one of update / adopt /
+insert / skip, and that an existing un-keyed row is never adopted twice.
+"""
+from scripts.vision_migration.sync import engine as e
+from scripts.vision_migration.sync.engine import DomainSpec, INSERT, UPDATE, ADOPT, SKIP
+
+
+# A fake domain: legacy id under "legacy_id", natural key under "nat".
+SPEC = DomainSpec(
+    legacy_source="tblServiceRecords",
+    legacy_id_of=lambda r: r.get("legacy_id"),
+    natural_key_of=lambda r: r.get("nat"),
+)
+
+
+def _one(row, existing_by_legacy=None, existing_by_natural=None):
+    """Run one source row through the engine and return its single Decision."""
+    return e.decide([row], SPEC, existing_by_legacy or {}, existing_by_natural or {})[0]
+
+
+def test_update_when_stored_legacy_key_matches():
+    """A row whose (source, id) already exists in Velocity is refreshed in place."""
+    d = _one({"legacy_id": 5, "nat": "WO5"}, existing_by_legacy={("tblServiceRecords", 5): 100})
+    assert d.action == UPDATE
+    assert d.target_id == 100
+
+
+def test_adopt_when_only_natural_key_matches():
+    """No stored key, but the natural key matches an existing un-keyed row -> adopt it."""
+    d = _one({"legacy_id": 5, "nat": "WO5"}, existing_by_natural={"WO5": 200})
+    assert d.action == ADOPT
+    assert d.target_id == 200
+
+
+def test_insert_when_nothing_matches():
+    """Neither key matches -> the row is genuinely new."""
+    d = _one({"legacy_id": 5, "nat": "WO5"})
+    assert d.action == INSERT
+    assert d.target_id is None
+
+
+def test_skip_when_no_legacy_id():
+    """A source row with no Vision id can't be keyed or matched, so it's left alone."""
+    d = _one({"legacy_id": None, "nat": "WO5"}, existing_by_natural={"WO5": 200})
+    assert d.action == SKIP
+
+
+def test_stored_key_wins_over_natural_key():
+    """When both could match, the stored legacy key (the reliable one) takes precedence."""
+    d = _one(
+        {"legacy_id": 5, "nat": "WO5"},
+        existing_by_legacy={("tblServiceRecords", 5): 100},
+        existing_by_natural={"WO5": 200},
+    )
+    assert d.action == UPDATE
+    assert d.target_id == 100
+
+
+def test_natural_key_adopted_only_once():
+    """Two source rows sharing a natural key: the first adopts the row, the rest insert."""
+    rows = [{"legacy_id": 5, "nat": "WO5"}, {"legacy_id": 6, "nat": "WO5"}]
+    decisions = e.decide(rows, SPEC, {}, existing_by_natural={"WO5": 200})
+    assert decisions[0].action == ADOPT and decisions[0].target_id == 200
+    assert decisions[1].action == INSERT  # can't claim the same existing row twice
+
+
+def test_summarize_tallies_all_actions():
+    """The dry-run ledger counts every action, including zeros for unused ones."""
+    rows = [
+        {"legacy_id": 5, "nat": "a"},   # update
+        {"legacy_id": 6, "nat": "b"},   # adopt
+        {"legacy_id": 7, "nat": "c"},   # insert
+        {"legacy_id": None, "nat": "d"},  # skip
+    ]
+    decisions = e.decide(
+        rows, SPEC,
+        existing_by_legacy={("tblServiceRecords", 5): 100},
+        existing_by_natural={"b": 200},
+    )
+    counts = e.summarize(decisions)
+    assert counts == {UPDATE: 1, ADOPT: 1, INSERT: 1, SKIP: 1}


### PR DESCRIPTION
A read-only verification report plus the groundwork for the Vision→Velocity import (schema key + engine + a dry-run), folded into one PR (per the file-scoped packaging rule). **Nothing here writes to live data.** Review commit-by-commit.

**Commits**
1. **live-Velocity verification report** — a read-only `load-velocity` command copies the live Velocity tables into an isolated `velocity_current` schema; the reconcile tool then compares the migration's *computed* close-state against what live Velocity stores, matched by the `[WO ####]` work-order tag. Result: **8,337** live quotes match a Vision workorder, all stored `Closed`, but **4,200 should be OPEN** per the real Vision ship data (the Vision-only pass derives the same figure, 4,201). Dedupes by work-order id so cloned quotes can't inflate. Read-only.
2. **Vision-import key columns** — nullable `legacy_source`/`legacy_id` on the 10 importable tables + a partial unique index (`WHERE legacy_id IS NOT NULL`), so re-running the import matches and UPDATEs an already-imported row instead of duplicating it (user-created rows, NULL keys, stay unconstrained). Additive + nullable; migration `028` verified up→down→up on a fresh DB.
3. **Import engine** — pure, database-free decision logic: per source row, **update** if a stored key matches → else **adopt** an existing un-keyed Velocity row by its natural key (a quote's work-order number) → else **insert**; **never delete**. 7 unit tests; no DB access.
4. **Quote-import dry-run (adoption proof)** — wires the engine to the read-only `velocity_current` copy and prints what the import *would* do, writing nothing. On real data: **8,337 adoptions** of existing live quotes (re-keyed in place, not duplicated), **5 inserts** (workorders live never received), **0 updates/skips** — proving adoption works before any write path exists. New `dryrun` command.

**Alembic note:** `028`'s `down_revision` is this branch's current head; **rebase it to the then-current head before merge** (other in-flight migrations fork from the same head) to keep a single migration head. `alembic check` reports only drift already on master (verified identical with/without this change); that CI step is non-blocking.

**Safety:** every commit is read-only or additive — the report reads live read-only, the engine can't reach a database, the dry-run writes nothing, and the columns are additive/nullable (clean downgrade). No live writes anywhere. Stacked on #190 — no CI until #190 merges + retargets.

**How to test:** `load-velocity` then `reconcile` (report); `alembic upgrade head`/`downgrade base` (migration); `pytest tests/test_sync_engine.py` (engine); `dryrun` (adoption ledger).
