### PR TITLE
fix(po): banner reflects fully vs partially received (#196)

### DIFF
--- a/frontend/src/components/editors/POEditor.tsx
+++ b/frontend/src/components/editors/POEditor.tsx
@@ -1319,14 +1319,21 @@ export function POEditor({ poId, onUpdate, onSelectPO, onDirtyStateChange }: POE
         : "border-2 border-transparent"
     }`}>
 
-      {/* Received Banner */}
+      {/* Received banner — shown once receiving has started (edits are then restricted).
+          Label must reflect the REAL state (fully vs partially received), not a fixed string. */}
       {hasBeenReceived && (
         <Card className="border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950">
           <CardContent className="py-3">
             <div className="flex items-center gap-2 text-amber-700 dark:text-amber-300">
               <Check className="h-4 w-4" />
-              <span className="font-medium">Partially Received</span>
-              <span className="text-sm">— Some items on this PO have been received. Line item edits are restricted.</span>
+              {/* hasPendingItems = any line still has qty_pending > 0 -> a partial receive.
+                  When false, everything is received; the banner said "Partially" regardless — the bug. */}
+              <span className="font-medium">{hasPendingItems ? "Partially Received" : "Fully Received"}</span>
+              <span className="text-sm">
+                {hasPendingItems
+                  ? "— Some items on this PO have been received. Line item edits are restricted."
+                  : "— All items on this PO have been received. Line item edits are restricted."}
+              </span>
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
Fixes the PO banner that read **"Partially Received"** even when a PO is fully received (screenshot in #196).

**Cause:** the banner rendered whenever any item had `qty_received > 0`, and its label was hardcoded `"Partially Received"` — no check for fully vs partially received. The backend status (`Received`) and the line quantities were already correct; display-only bug.

**Fix:** use the existing `hasPendingItems` to choose the label — **"Fully Received"** when nothing is pending, **"Partially Received"** otherwise (with matching sub-text). One banner in `POEditor.tsx`.

**Scope / safety:** frontend-only. No backend, data, or schema change. `tsc -b` clean; a normalized lint-baseline diff (master vs branch) proves **zero** new lint problems.

Closes #196

_Note:_ this touches `POEditor.tsx`, which the in-flight lint-cleanup PR #191 also edits — different lines (banner label vs unused-vars), and #191 is set to merge last + rebase, so it absorbs any overlap.
