### PR TITLE
fix(project): documents list gets its own always-visible scrollbar

### DIFF
--- a/frontend/src/pages/ProjectDetailsPage.tsx
+++ b/frontend/src/pages/ProjectDetailsPage.tsx
@@ -4,7 +4,6 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { StatusBadge } from "@/components/ui/status-badge"
 import { formatDate } from "@/lib/format"
-import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
 import {
   Dialog,
@@ -631,9 +630,11 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
                     />
                   </div>
                 </div>
-                <div className="flex-1 min-h-0 px-3 pb-3" onKeyDown={onSidebarKeyDown}>
-                  <ScrollArea className="h-full">
-                    <div className="space-y-1 pr-2">
+                {/* The document list owns its own always-visible native scrollbar (like the
+                    page's) so long Quotes/POs/Invoices lists are clearly scrollable; the prior
+                    Radix ScrollArea auto-hid its bar, which read as "no scrollbar". */}
+                <div className="flex-1 min-h-0 px-3 pb-3 overflow-y-auto" onKeyDown={onSidebarKeyDown}>
+                    <div className="space-y-1 pr-1">
                       {activeTab === "quotes" && (
                         filteredQuotes.length === 0 ? (
                           <EmptyListMessage
@@ -691,7 +692,6 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
                         )
                       )}
                     </div>
-                  </ScrollArea>
                 </div>
               </Tabs>
             </>


### PR DESCRIPTION
The Quotes/POs/Invoices list on the project details page used a Radix `ScrollArea` whose scrollbar auto-hides, so a long list looked like it had no scroll control. This swaps it for a native `overflow-y-auto` container, giving the list an always-visible scrollbar that matches the page's own — a requested UX fix.

**What changed:** `ProjectDetailsPage.tsx` — the one document-list scroll container; removed the now-unused `ScrollArea` import.
**Scope:** display-only, that single list. No data, logic, or API changes.
**How to test:** open a project with many quotes; the left documents list shows a visible scrollbar and scrolls independently of the page.
