### PR TITLE
fix(project): keep the documents-list scrollbar always visible

### DIFF
--- a/frontend/src/pages/ProjectDetailsPage.tsx
+++ b/frontend/src/pages/ProjectDetailsPage.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { StatusBadge } from "@/components/ui/status-badge"
 import { formatDate } from "@/lib/format"
+import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
 import {
   Dialog,
@@ -630,11 +631,13 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
                     />
                   </div>
                 </div>
-                {/* The document list owns its own always-visible native scrollbar (like the
-                    page's) so long Quotes/POs/Invoices lists are clearly scrollable; the prior
-                    Radix ScrollArea auto-hid its bar, which read as "no scrollbar". */}
-                <div className="flex-1 min-h-0 px-3 pb-3 overflow-y-auto" onKeyDown={onSidebarKeyDown}>
-                    <div className="space-y-1 pr-1">
+                {/* Document list scroll container. Radix ScrollArea with type="always" keeps
+                    the scrollbar permanently visible so long Quotes/POs/Invoices lists are
+                    obviously scrollable — a native/overlay scrollbar auto-hides when idle on
+                    Windows/macOS, which read as "no scrollbar". */}
+                <div className="flex-1 min-h-0 px-3 pb-3" onKeyDown={onSidebarKeyDown}>
+                  <ScrollArea className="h-full" type="always">
+                    <div className="space-y-1 pr-2">
                       {activeTab === "quotes" && (
                         filteredQuotes.length === 0 ? (
                           <EmptyListMessage
@@ -692,6 +695,7 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
                         )
                       )}
                     </div>
+                  </ScrollArea>
                 </div>
               </Tabs>
             </>


### PR DESCRIPTION
Follow-up to #198. That change used a native `overflow-y-auto` scrollbar, but native/overlay scrollbars **auto-hide when idle** on Windows 11 and macOS — so the documents list still looked like it had no scrollbar.

This uses the Radix `ScrollArea` with `type="always"`, which renders a **permanently-visible** scrollbar (a real DOM element) independent of the OS auto-hide behavior.

**What changed:** `ProjectDetailsPage.tsx` — the one document-list scroll container (re-adds the `ScrollArea` import).
**Scope:** display-only, that single list. No data/logic/API changes.
**How to test:** open a project with many quotes; the left list shows a visible scrollbar at all times and scrolls independently of the page.
