### PR TITLE
fix(project): documents list gets its own bounded, scrollable height

### DIFF
--- a/frontend/src/pages/ProjectDetailsPage.tsx
+++ b/frontend/src/pages/ProjectDetailsPage.tsx
@@ -4,7 +4,6 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { StatusBadge } from "@/components/ui/status-badge"
 import { formatDate } from "@/lib/format"
-import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
 import {
   Dialog,
@@ -631,12 +630,12 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
                     />
                   </div>
                 </div>
-                {/* Document list scroll container. Radix ScrollArea with type="always" keeps
-                    the scrollbar permanently visible so long Quotes/POs/Invoices lists are
-                    obviously scrollable — a native/overlay scrollbar auto-hides when idle on
-                    Windows/macOS, which read as "no scrollbar". */}
-                <div className="flex-1 min-h-0 px-3 pb-3" onKeyDown={onSidebarKeyDown}>
-                  <ScrollArea className="h-full" type="always">
+                {/* Document list scroll container. Explicit viewport-relative height + native
+                    overflow — the same pattern the inventory VirtualizedTable uses (a fixed
+                    height + overflow:auto) — so the list is its OWN bounded scroll region with a
+                    visible scrollbar, independent of the page's scrollbar. Flexbox height
+                    (flex-1) did not constrain it here, so it never overflowed and showed no bar. */}
+                <div className="px-3 pb-3 overflow-y-auto h-[calc(100vh-270px)]" onKeyDown={onSidebarKeyDown}>
                     <div className="space-y-1 pr-2">
                       {activeTab === "quotes" && (
                         filteredQuotes.length === 0 ? (
@@ -695,7 +694,6 @@ export function ProjectDetailsPage({ projectId, onBack, initialDoc }: ProjectDet
                         )
                       )}
                     </div>
-                  </ScrollArea>
                 </div>
               </Tabs>
             </>


### PR DESCRIPTION
Gives the project-details **documents list** (Quotes/POs/Invoices) its own visible, independent scrollbar.

**Root cause (why #198 and #199 didn't work):** the app shell is `min-h-screen`, not `h-screen`, so it has no *definite* height. That means `ProjectDetailsPage`'s `h-full` never resolves, and the sidebar list's `flex-1 min-h-0` never gets a bounded height — the list just grows and is clipped by an ancestor `overflow-hidden`. Nothing actually overflowed, so no scrollbar could appear (native or Radix).

**Fix:** give the list an explicit viewport-relative height + native overflow — the exact pattern the inventory `VirtualizedTable` uses (`height` + `overflow:auto`), which is why the Parts Inventory table already shows a visible scrollbar. Now the list is its own bounded scroll region.

**What changed:** `ProjectDetailsPage.tsx` — one scroll container (removes the `ScrollArea` wrapper/import). Display-only; no data/logic/API.
**Note:** the `calc(100vh - 270px)` offset (the header stack above the list) is a tunable number, same idea as the Parts table's `calc(100vh - 360px)`.
**How to test:** open a project with many quotes; the left list scrolls on its own with a visible scrollbar, independent of the page scroll.
